### PR TITLE
feat: middleware에서 proxy로 변경

### DIFF
--- a/app/proxy.ts
+++ b/app/proxy.ts
@@ -13,7 +13,7 @@ type ReissueResponse = {
     refreshToken: string;
   };
 };
-export async function middleware(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
   // 보호 안 하는 경로면 패스


### PR DESCRIPTION
`The "middleware" file convention is deprecated. Please use "proxy" instead.` 경고로 인해  app/proxy.ts로 변경