### PR TITLE
fix: 쿠키 기반 인증/재발급 흐름 정합성 수정

### DIFF
--- a/app/api/client/_proxy.ts
+++ b/app/api/client/_proxy.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
+import {
+  adaptSetCookiesForRequest,
+  getSetCookieHeaders,
+} from "@/lib/server/setCookies";
 
 type ProxyOptions = {
   url: string;
-  method: "GET" | "POST" | "PATCH" | "DELETE";
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   forwardBody?: boolean;
   contentType?: string;
   extraHeaders?: Record<string, string>;
@@ -13,8 +17,10 @@ type ForwardResult = {
   status: number;
   body: string;
   contentType: string;
-  setCookie: string | null;
+  setCookies: string[];
 };
+
+type RequestLike = Pick<Request, "headers" | "url">;
 
 export async function forward(
   req: Request,
@@ -47,20 +53,26 @@ export async function forward(
     status: upstream.status,
     body: responseBody,
     contentType,
-    setCookie: upstream.headers.get("set-cookie"),
+    setCookies: getSetCookieHeaders(upstream.headers),
   };
 }
 
-export function buildResponse(result: ForwardResult) {
+export function buildResponse(result: ForwardResult, req?: RequestLike) {
   const res = new NextResponse(result.body, {
     status: result.status,
     headers: { "Content-Type": result.contentType },
   });
-  if (result.setCookie) res.headers.set("set-cookie", result.setCookie);
+  const setCookies = req
+    ? adaptSetCookiesForRequest(result.setCookies, req)
+    : result.setCookies;
+
+  for (const cookie of setCookies) {
+    res.headers.append("set-cookie", cookie);
+  }
   return res;
 }
 
 export async function proxyJson(req: Request, options: ProxyOptions) {
   const result = await forward(req, options);
-  return buildResponse(result);
+  return buildResponse(result, req);
 }

--- a/app/api/client/exit/route.ts
+++ b/app/api/client/exit/route.ts
@@ -1,5 +1,4 @@
-import { NextResponse } from "next/server";
-import { forward } from "@/app/api/client/_proxy";
+import { buildResponse, forward } from "@/app/api/client/_proxy";
 
 export const runtime = "edge";
 
@@ -14,11 +13,8 @@ export async function DELETE(req: Request) {
       forwardBody: false,
     });
 
-    return NextResponse.json(
-      { ok: upstream.ok },
-      { status: upstream.ok ? 200 : 400 },
-    );
+    return buildResponse(upstream, req);
   } catch {
-    return NextResponse.json({ ok: false }, { status: 500 });
+    return Response.json({ ok: false }, { status: 500 });
   }
 }

--- a/app/api/client/logout/route.ts
+++ b/app/api/client/logout/route.ts
@@ -1,5 +1,4 @@
-import { NextResponse } from "next/server";
-import { forward } from "@/app/api/client/_proxy";
+import { buildResponse, forward } from "@/app/api/client/_proxy";
 
 export const runtime = "edge";
 
@@ -14,11 +13,8 @@ export async function DELETE(req: Request) {
       forwardBody: false,
     });
 
-    return NextResponse.json(
-      { ok: upstream.ok },
-      { status: upstream.ok ? 200 : 400 },
-    );
+    return buildResponse(upstream, req);
   } catch {
-    return NextResponse.json({ ok: false }, { status: 500 });
+    return Response.json({ ok: false }, { status: 500 });
   }
 }

--- a/app/api/client/password/change/route.ts
+++ b/app/api/client/password/change/route.ts
@@ -1,36 +1,16 @@
-import { NextResponse } from "next/server";
+import { proxyJson } from "@/app/api/client/_proxy";
 
 export const runtime = "edge";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export async function PATCH(req: Request) {
-  const cookie = req.headers.get("cookie") ?? "";
-
   try {
-    const upstream = await fetch(`${BASE_URL}/api/harucut/change/password`, {
+    return await proxyJson(req, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        cookie,
-      },
-      body: await req.text(),
-      cache: "no-store",
+      url: `${BASE_URL}/api/harucut/change/password`,
     });
-
-    const body = await upstream.text();
-    const res = new NextResponse(body, { status: upstream.status });
-
-    upstream.headers.forEach((value, key) => {
-      if (key.toLowerCase() === "set-cookie") {
-        res.headers.append(key, value);
-      } else {
-        res.headers.set(key, value);
-      }
-    });
-
-    return res;
   } catch {
-    return NextResponse.json({ ok: false }, { status: 500 });
+    return Response.json({ ok: false }, { status: 500 });
   }
 }

--- a/app/api/client/user-info/route.ts
+++ b/app/api/client/user-info/route.ts
@@ -12,5 +12,5 @@ export async function GET(req: Request) {
     forwardBody: false,
   });
 
-  return buildResponse(upstream);
+  return buildResponse(upstream, req);
 }

--- a/app/api/client/user/files/presigned-img/route.ts
+++ b/app/api/client/user/files/presigned-img/route.ts
@@ -29,5 +29,5 @@ export async function GET(req: Request) {
     forwardBody: false,
   });
 
-  return buildResponse(upstream);
+  return buildResponse(upstream, req);
 }

--- a/app/api/client/user/username/route.ts
+++ b/app/api/client/user/username/route.ts
@@ -28,5 +28,5 @@ export async function PATCH(req: Request) {
     forwardBody: false,
   });
 
-  return buildResponse(upstream);
+  return buildResponse(upstream, req);
 }

--- a/lib/clientApi.ts
+++ b/lib/clientApi.ts
@@ -14,7 +14,7 @@ type ApiOptions = {
 };
 
 async function request<T>(
-  method: "GET" | "POST" | "PATCH" | "DELETE",
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
   path: string,
   body?: unknown,
   options: ApiOptions = {},
@@ -69,6 +69,9 @@ export const clientApi = {
   },
   patch<T>(path: string, body?: unknown, options?: ApiOptions) {
     return request<T>("PATCH", path, body, options);
+  },
+  put<T>(path: string, body?: unknown, options?: ApiOptions) {
+    return request<T>("PUT", path, body, options);
   },
   delete<T>(path: string, options?: ApiOptions) {
     return request<T>("DELETE", path, undefined, options);

--- a/lib/server/setCookies.ts
+++ b/lib/server/setCookies.ts
@@ -1,0 +1,99 @@
+type HeadersWithSetCookie = Headers & {
+  getSetCookie?: () => string[];
+};
+
+function splitCombinedSetCookie(value: string) {
+  const cookies: string[] = [];
+  let start = 0;
+  let inExpires = false;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const current = value[i];
+    const nextExpires = value.slice(i, i + 8).toLowerCase();
+
+    if (nextExpires === "expires=") {
+      inExpires = true;
+    }
+
+    if (inExpires && current === ";") {
+      inExpires = false;
+    }
+
+    if (current === "," && !inExpires) {
+      cookies.push(value.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  const last = value.slice(start).trim();
+  if (last) {
+    cookies.push(last);
+  }
+
+  return cookies;
+}
+
+export function getSetCookieHeaders(headers: Headers): string[] {
+  const setCookies = (headers as HeadersWithSetCookie).getSetCookie?.();
+  if (setCookies && setCookies.length > 0) {
+    return setCookies;
+  }
+
+  const single = headers.get("set-cookie");
+  return single ? splitCombinedSetCookie(single) : [];
+}
+
+type RequestLike = Pick<Request, "headers" | "url">;
+
+function getRequestUrl(req: RequestLike) {
+  const url = new URL(req.url);
+  const forwardedHost = req.headers.get("x-forwarded-host") ?? req.headers.get("host");
+  const forwardedProto = req.headers.get("x-forwarded-proto");
+
+  if (forwardedHost) {
+    url.host = forwardedHost;
+  }
+  if (forwardedProto) {
+    url.protocol = `${forwardedProto}:`;
+  }
+
+  return url;
+}
+
+function shouldStripCookieDomain(hostname: string, domain: string) {
+  const normalizedHost = hostname.trim().toLowerCase();
+  const normalizedDomain = domain.trim().replace(/^\./, "").toLowerCase();
+
+  if (!normalizedDomain) {
+    return false;
+  }
+
+  return (
+    normalizedHost !== normalizedDomain &&
+    !normalizedHost.endsWith(`.${normalizedDomain}`)
+  );
+}
+
+export function adaptSetCookieForRequest(setCookie: string, req: RequestLike) {
+  const url = getRequestUrl(req);
+  const hostname = url.hostname.toLowerCase();
+  let nextCookie = setCookie;
+
+  const domainMatch = nextCookie.match(/;\s*Domain=([^;]+)/i);
+  if (domainMatch && shouldStripCookieDomain(hostname, domainMatch[1])) {
+    nextCookie = nextCookie.replace(/;\s*Domain=[^;]+/i, "");
+  }
+
+  if (url.protocol !== "https:") {
+    nextCookie = nextCookie.replace(/;\s*Secure/gi, "");
+  }
+
+  return nextCookie;
+}
+
+export function adaptSetCookiesForRequest(
+  setCookies: string[],
+  req: RequestLike,
+) {
+  return setCookies.map((cookie) => adaptSetCookieForRequest(cookie, req));
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,20 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAccessToken } from "@/lib/server/auth";
+import {
+  adaptSetCookiesForRequest,
+  getSetCookieHeaders,
+} from "@/lib/server/setCookies";
 
 // 보호가 필요한 경로 목록
 const PROTECTED_PATHS = ["/home", "/shoot", "/upload", "/history", "/theme"];
 // const PROTECTED_PATHS = ["/history"];
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
-type ReissueResponse = {
-  code: string;
-  status: number;
-  message: string | null;
-  data: {
-    accessToken: string;
-    refreshToken: string;
-  };
-};
 /**
  * 보호 경로 접근 시 토큰 검증/리이슈 후 통과시키는 미들웨어 헬퍼
  */
@@ -54,39 +49,22 @@ export async function proxy(req: NextRequest) {
     const refreshRes = await fetch(`${BASE_URL}/api/harucut/reissue`, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
-        "Refresh-Token": refreshToken,
+        cookie: req.headers.get("cookie") ?? `refreshToken=${refreshToken}`,
       },
       cache: "no-store",
     });
 
     if (refreshRes.ok) {
-      const { data } = (await refreshRes.json()) as ReissueResponse;
-
-      const newAccessToken = data.accessToken;
-      const newRefreshToken = data.refreshToken;
-
-      if (newAccessToken || newRefreshToken) {
+      const setCookies = adaptSetCookiesForRequest(
+        getSetCookieHeaders(refreshRes.headers),
+        req,
+      );
+      if (setCookies.length > 0) {
+        await refreshRes.text();
         const res = NextResponse.next();
-
-        if (newAccessToken) {
-          res.cookies.set("accessToken", newAccessToken, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-            path: "/",
-          });
+        for (const cookie of setCookies) {
+          res.headers.append("set-cookie", cookie);
         }
-
-        if (newRefreshToken) {
-          res.cookies.set("refreshToken", newRefreshToken, {
-            httpOnly: true,
-            secure: process.env.NODE_ENV === "production",
-            sameSite: "lax",
-            path: "/",
-          });
-        }
-
         return res;
       }
     }


### PR DESCRIPTION
## 변경 사항
- 백엔드 `Set-Cookie`를 공통 프록시 응답에서 그대로 전달하도록 수정
- 로컬 환경에서도 쿠키가 저장되도록 요청 host 기준으로 `Domain`/`Secure`를 보정
- 로그아웃/탈퇴/비밀번호 변경/user-info 프록시가 같은 쿠키 전달 방식을 사용하도록 맞춤

## 검증
- `pnpm -s tsc --noEmit`
- 2026-03-15 실서버 연동 수동 검증
  - 로그인 성공
  - refresh 기반 재발급 성공
  - 로그아웃 후 `/home` 접근 시 `/login` 리다이렉트 확인

## 비고
- 이후 PR들의 인증 기반 공통 선행 PR
