### PR TITLE
fix: 프레임 저장 frameType 매핑 수정

### DIFF
--- a/lib/frameApi.test.ts
+++ b/lib/frameApi.test.ts
@@ -1,8 +1,13 @@
-import { toCreateFrameRequest } from "@/lib/frameApi";
 import { FRAME_LAYOUTS } from "@/constants/frameLayouts";
+import type { RemoteFrame } from "@/lib/api-types";
+import {
+  frameIdFromFrameType,
+  frameTypeFromFrameId,
+  toCreateFrameRequest,
+  toThemeExportJson,
+} from "@/lib/frameApi";
 import type { ThemeExportJson } from "@/lib/types/themeEditor";
 
-// 테스트용 최소 Theme JSON 생성 헬퍼
 function makeJson(frameId: ThemeExportJson["frameId"]): ThemeExportJson {
   return {
     frameId,
@@ -24,8 +29,7 @@ function makeJson(frameId: ThemeExportJson["frameId"]): ThemeExportJson {
   };
 }
 
-describe("toCreateFrameRequest", () => {
-  // frame layout에서 캔버스 크기를 가져오고 meta 값이 그대로 전달되어야 합니다.
+describe("frame api mapping", () => {
   it("maps canvas size and metadata from frame layout", () => {
     const json = makeJson("classic-4");
     const req = toCreateFrameRequest(json, {
@@ -42,59 +46,60 @@ describe("toCreateFrameRequest", () => {
     expect(req.background).toEqual({ type: "COLOR", value: "000000" });
   });
 
-  // wide-* 프레임은 서버 enum 기준 WIDE로 변환되어야 합니다.
-  it("infers wide frame type from frame id", () => {
-    const req = toCreateFrameRequest(makeJson("wide-4"), {
-      title: "t",
-      description: "d",
-      previewKey: "p",
-    });
-
-    expect(req.frameType).toBe("WIDE");
+  it("maps each frame id to the swagger frame type", () => {
+    expect(frameTypeFromFrameId("classic-4")).toBe("CLASSIC");
+    expect(frameTypeFromFrameId("wide-4")).toBe("WIDE");
+    expect(frameTypeFromFrameId("grid-4")).toBe("GRID");
+    expect(frameTypeFromFrameId("polaroid-4")).toBe("POLAROID");
   });
 
-  // wide가 아닌 프레임은 현재 규칙상 CLASSIC으로 매핑됩니다.
-  it("keeps non-wide frame as CLASSIC", () => {
-    const req = toCreateFrameRequest(makeJson("grid-4"), {
-      title: "t",
-      description: "d",
-      previewKey: "p",
-    });
-
-    expect(req.frameType).toBe("CLASSIC");
+  it("maps swagger frame types back to local frame ids", () => {
+    expect(frameIdFromFrameType("CLASSIC")).toBe("classic-4");
+    expect(frameIdFromFrameType("WIDE")).toBe("wide-4");
+    expect(frameIdFromFrameType("GRID")).toBe("grid-4");
+    expect(frameIdFromFrameType("POLAROID")).toBe("polaroid-4");
   });
 
-  // scale/rotation/styleJson이 비어 있어도 안전한 기본값으로 보정되어야 합니다.
-  it("fills missing component defaults", () => {
-    const json = {
-      frameId: "classic-4",
+  it("converts a remote frame response into theme editor json", () => {
+    const remoteFrame: RemoteFrame = {
+      frameId: 12,
+      title: "saved",
+      description: "saved desc",
+      frameType: "GRID",
+      background: { type: "COLOR", value: "ffffff" },
       components: [
         {
-          id: "c-2",
-          type: "STICKER",
-          source: "/x.png",
-          x: 0,
-          y: 0,
-          width: 10,
-          height: 10,
-          // 의도적으로 undefined를 넣어 기본값(1, 0) 보정 동작 확인
-          scale: undefined,
-          rotation: undefined,
+          id: 3,
+          type: "TEXT",
+          source: "hello",
+          x: 1,
+          y: 2,
+          width: 3,
+          height: 4,
           zIndex: 1,
-          styleJson: undefined,
+          style: { color: "#fff" },
         },
       ],
-    } as unknown as ThemeExportJson;
+    };
 
-    const req = toCreateFrameRequest(json, {
-      title: "t",
-      description: "d",
-      previewKey: "p",
+    expect(toThemeExportJson(remoteFrame)).toEqual({
+      frameId: "grid-4",
+      background: { type: "COLOR", value: "ffffff" },
+      components: [
+        {
+          id: "3",
+          type: "TEXT",
+          source: "hello",
+          x: 1,
+          y: 2,
+          width: 3,
+          height: 4,
+          scale: 1,
+          rotation: 0,
+          zIndex: 1,
+          styleJson: { color: "#fff" },
+        },
+      ],
     });
-
-    expect(req.components[0].scale).toBe(1);
-    expect(req.components[0].rotation).toBe(0);
-    expect(req.components[0].styleJson).toEqual({});
   });
 });
-

--- a/lib/frameApi.ts
+++ b/lib/frameApi.ts
@@ -1,15 +1,21 @@
-import type { ThemeExportJson } from "@/lib/types/themeEditor";
+import type { FrameId } from "@/constants/frames";
 import { FRAME_LAYOUTS } from "@/constants/frameLayouts";
+import type {
+  RemoteFrame,
+  RemoteFrameType,
+} from "@/lib/api-types";
+import type { ThemeExportJson } from "@/lib/types/themeEditor";
 
-type CreateFrameRequest = {
+export type CreateFrameRequest = {
   title: string;
   description: string;
   previewKey: string;
-  frameType: "CLASSIC" | "WIDE" | "SQUARE"; // 서버 enum에 맞게
+  frameType: RemoteFrameType;
   canvasWidth: number;
   canvasHeight: number;
-  background: { type: "COLOR" | "IMAGE"; value: string };
+  background: { type: "COLOR"; value: string };
   components: Array<{
+    id?: string;
     type: "PHOTO" | "STICKER" | "TEXT";
     source: string;
     x: number;
@@ -20,21 +26,40 @@ type CreateFrameRequest = {
     rotation: number;
     zIndex: number;
     styleJson: Record<string, unknown>;
-    // 서버가 id를 받는지 여부에 따라 선택
-    id?: string;
   }>;
 };
 
-// FrameId에서 서버 enum으로 변환
-function inferFrameType(frameId: string): CreateFrameRequest["frameType"] {
-  // 너네 FrameId 규칙에 맞게 매핑
+export function frameTypeFromFrameId(frameId: FrameId): RemoteFrameType {
   if (frameId.startsWith("wide")) return "WIDE";
+  if (frameId.startsWith("grid")) return "GRID";
+  if (frameId.startsWith("polaroid")) return "POLAROID";
   return "CLASSIC";
 }
 
-/**
- * 에디터 JSON을 서버 요청 스키마로 변환
- */
+export function frameIdFromFrameType(frameType: RemoteFrameType): FrameId {
+  switch (frameType) {
+    case "WIDE":
+      return "wide-4";
+    case "GRID":
+      return "grid-4";
+    case "POLAROID":
+      return "polaroid-4";
+    case "CLASSIC":
+    default:
+      return "classic-4";
+  }
+}
+
+export function matchesFrameType(frameId: FrameId, frameType: RemoteFrameType) {
+  return frameTypeFromFrameId(frameId) === frameType;
+}
+
+function normalizeHexColor(input: string) {
+  const cleaned = input.trim().replace(/^#/, "");
+  if (!cleaned) return "000000";
+  return cleaned.toLowerCase();
+}
+
 export function toCreateFrameRequest(
   json: ThemeExportJson,
   meta: { title: string; description: string; previewKey: string },
@@ -43,21 +68,15 @@ export function toCreateFrameRequest(
   const canvasWidth = layout.totalWidth;
   const canvasHeight = layout.totalHeight;
   const bgRaw = json.background?.value ?? "000000";
-  const backgroundValue = bgRaw.startsWith("#") ? bgRaw.slice(1) : bgRaw;
 
   return {
     title: meta.title,
     description: meta.description,
     previewKey: meta.previewKey,
-
-    frameType: inferFrameType(json.frameId),
-
+    frameType: frameTypeFromFrameId(json.frameId),
     canvasWidth,
     canvasHeight,
-
-    // 배경을 지금 store에서 안 다루는 중이면 일단 기본값 박아두기
-    background: { type: "COLOR", value: backgroundValue },
-
+    background: { type: "COLOR", value: normalizeHexColor(bgRaw) },
     components: json.components.map((c) => ({
       type: c.type,
       source: c.source,
@@ -69,8 +88,34 @@ export function toCreateFrameRequest(
       rotation: c.rotation ?? 0,
       zIndex: c.zIndex,
       styleJson: (c.styleJson ?? {}) as Record<string, unknown>,
-      // 서버가 필요하면 여기서 넣기
       id: c.id,
+    })),
+  };
+}
+
+export function toThemeExportJson(frame: RemoteFrame): ThemeExportJson {
+  return {
+    frameId: frameIdFromFrameType(frame.frameType),
+    background:
+      frame.background?.type === "COLOR"
+        ? {
+            type: "COLOR",
+            value: normalizeHexColor(frame.background.value),
+          }
+        : undefined,
+    components: frame.components.map((component, index) => ({
+      id: String(component.id ?? `${component.type}-${index}`),
+      type: component.type,
+      source: component.source || component.key || "",
+      x: component.x,
+      y: component.y,
+      width: component.width,
+      height: component.height,
+      scale: component.scale ?? 1,
+      rotation: component.rotation ?? 0,
+      zIndex: component.zIndex,
+      styleJson:
+        (component.styleJson ?? component.style ?? {}) as Record<string, unknown>,
     })),
   };
 }


### PR DESCRIPTION
## 변경 사항
- 프레임 저장 요청의 `frameType` 매핑을 Swagger 계약에 맞게 수정
- 서버 frameType을 로컬 편집기 frame id로 되돌리는 유틸을 추가
- frame 변환 유닛 테스트를 보강

## 검증
- `pnpm exec jest --runInBand lib/frameApi.test.ts`

## 비고
- 이후 프레임 목록/상세 연동 PR의 선행 PR
