### PR TITLE
fix: presigned upload 요청 스펙 정합화

### DIFF
--- a/app/api/client/user/media/[mediaId]/download-url/route.ts
+++ b/app/api/client/user/media/[mediaId]/download-url/route.ts
@@ -1,0 +1,23 @@
+import { buildResponse, forward } from "@/app/api/client/_proxy";
+
+export const runtime = "edge";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+type RouteContext = {
+  params: Promise<{
+    mediaId: string;
+  }>;
+};
+
+export async function GET(req: Request, context: RouteContext) {
+  const { mediaId } = await context.params;
+
+  const upstream = await forward(req, {
+    method: "GET",
+    url: `${BASE_URL}/api/auth/user/media/${mediaId}/download-url`,
+    forwardBody: false,
+  });
+
+  return buildResponse(upstream, req);
+}

--- a/app/api/client/user/media/route.ts
+++ b/app/api/client/user/media/route.ts
@@ -1,0 +1,30 @@
+import { buildResponse, forward, proxyJson } from "@/app/api/client/_proxy";
+
+export const runtime = "edge";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get("type")?.trim();
+
+  const url = new URL(`${BASE_URL}/api/auth/user/media`);
+  if (type) {
+    url.searchParams.set("type", type);
+  }
+
+  const upstream = await forward(req, {
+    method: "GET",
+    url: url.toString(),
+    forwardBody: false,
+  });
+
+  return buildResponse(upstream, req);
+}
+
+export async function POST(req: Request) {
+  return proxyJson(req, {
+    method: "POST",
+    url: `${BASE_URL}/api/auth/user/media`,
+  });
+}

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -1,0 +1,83 @@
+export type ApiEnvelope<T> = {
+  code: string;
+  status: number;
+  message: string | null;
+  data: T;
+};
+
+export type UserStatus =
+  | "ACTIVE"
+  | "DELETED"
+  | "DELETED_REQUESTED"
+  | "SUSPENDED";
+
+export type LoginResponseData = {
+  userStatus: UserStatus;
+};
+
+export type PresignedUploadContentType =
+  | "JPEG"
+  | "PNG"
+  | "WEBP"
+  | "GIF"
+  | "MP4"
+  | "WEBM"
+  | "MOV";
+
+export type UserMediaType = "PHOTO" | "VIDEO";
+
+export type UserMedia = {
+  mediaId: number;
+  mediaType: UserMediaType;
+  s3Key: string;
+  downloadUrl?: string;
+  originalS3Key?: string;
+  originalFileName?: string;
+  transcodeJobId?: string;
+  createdAt?: string;
+};
+
+export type RemoteFrameType = "CLASSIC" | "WIDE" | "GRID" | "POLAROID";
+
+export type RemoteFrameBackground =
+  | {
+      type: "COLOR";
+      value: string;
+    }
+  | {
+      type: "IMAGE";
+      key?: string;
+      opacity?: number;
+    }
+  | {
+      type: "VIDEO";
+      key?: string;
+      autoPlay?: boolean;
+      loop?: boolean;
+    };
+
+export type RemoteFrameComponent = {
+  id?: number | string;
+  type: "PHOTO" | "STICKER" | "TEXT";
+  source: string;
+  key?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale?: number;
+  rotation?: number;
+  zIndex: number;
+  style?: Record<string, unknown>;
+  styleJson?: Record<string, unknown>;
+};
+
+export type RemoteFrame = {
+  frameId: number;
+  title: string;
+  description?: string;
+  source?: string;
+  frameType: RemoteFrameType;
+  background?: RemoteFrameBackground;
+  components: RemoteFrameComponent[];
+};

--- a/lib/presignedUploadApi.test.ts
+++ b/lib/presignedUploadApi.test.ts
@@ -1,5 +1,6 @@
 const mockGet = jest.fn();
 const mockPost = jest.fn();
+const mockRegisterUserMedia = jest.fn();
 
 jest.mock("@/lib/clientApi", () => ({
   clientApi: {
@@ -8,9 +9,15 @@ jest.mock("@/lib/clientApi", () => ({
   },
 }));
 
+jest.mock("@/lib/userMediaApi", () => ({
+  registerUserMedia: (...args: unknown[]) => mockRegisterUserMedia(...args),
+}));
+
 import {
   PRESIGNED_UPLOAD_TYPES,
   resolveFourcutUploadType,
+  resolveUploadContentType,
+  uploadFourcutMedia,
   uploadToS3WithPresigned,
 } from "@/lib/presignedUploadApi";
 
@@ -20,34 +27,23 @@ describe("presigned upload flow", () => {
     global.fetch = jest.fn();
   });
 
-  it("maps shot and uploaded videos to FOURCUT_VIDEO", () => {
+  it("maps jpg files to the swagger JPEG enum", () => {
+    const jpg = new File(["x"], "photo.jpg", { type: "image/jpeg" });
+    expect(resolveUploadContentType(jpg)).toBe("JPEG");
+  });
+
+  it("maps shot videos to FOURCUT_VIDEO and photos to FOURCUT_PHOTO", () => {
     const capturedVideo = new File(["x"], "captured.webm", {
       type: "video/webm",
     });
-    const uploadedVideo = new File(["x"], "uploaded.webm", {
-      type: "video/webm",
+    const capturedPhoto = new File(["x"], "captured.png", {
+      type: "image/png",
     });
 
     expect(resolveFourcutUploadType(capturedVideo)).toBe(
       PRESIGNED_UPLOAD_TYPES.FOURCUT_VIDEO,
     );
-    expect(resolveFourcutUploadType(uploadedVideo)).toBe(
-      PRESIGNED_UPLOAD_TYPES.FOURCUT_VIDEO,
-    );
-  });
-
-  it("maps shot and uploaded photos to FOURCUT_PHOTO", () => {
-    const capturedPhoto = new File(["x"], "captured.png", {
-      type: "image/png",
-    });
-    const uploadedPhoto = new File(["x"], "uploaded.jpeg", {
-      type: "image/jpeg",
-    });
-
     expect(resolveFourcutUploadType(capturedPhoto)).toBe(
-      PRESIGNED_UPLOAD_TYPES.FOURCUT_PHOTO,
-    );
-    expect(resolveFourcutUploadType(uploadedPhoto)).toBe(
       PRESIGNED_UPLOAD_TYPES.FOURCUT_PHOTO,
     );
   });
@@ -109,11 +105,65 @@ describe("presigned upload flow", () => {
     });
   });
 
-  it("transcodes webm and returns mp4 downloadUrl", async () => {
-    const key =
-      "uploads/users/VZ_LtszNul/webm/d62ce849-47f7-4983-bbbf-0f4f2fcb6029.webm";
+  it("registers photo media after upload", async () => {
+    mockPost.mockResolvedValueOnce({
+      data: {
+        code: "GEN-000",
+        status: 200,
+        message: null,
+        data: {
+          key: "uploads/users/u/photo.png",
+          uploadUrl: "https://example.com/upload/photo.png?sig=1",
+          contentType: "image/png",
+          expiresIn: "PT24H",
+        },
+      },
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+    });
+
+    mockGet.mockResolvedValueOnce({
+      data: {
+        code: "GEN-000",
+        status: 200,
+        message: null,
+        data: {
+          downloadUrl: "https://example.com/photo.png?sig=2",
+        },
+      },
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+    });
+
+    mockRegisterUserMedia.mockResolvedValueOnce({
+      mediaId: 1,
+      mediaType: "PHOTO",
+      s3Key: "uploads/users/u/photo.png",
+      downloadUrl: "https://example.com/photo.png?sig=3",
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+    });
+
+    const result = await uploadFourcutMedia(
+      new File(["x"], "photo.png", { type: "image/png" }),
+    );
+
+    expect(mockRegisterUserMedia).toHaveBeenCalledWith({
+      mediaType: "PHOTO",
+      s3Key: "uploads/users/u/photo.png",
+    });
+    expect(result.downloadUrl).toBe("https://example.com/photo.png?sig=3");
+  });
+
+  it("transcodes webm output and returns the converted downloadUrl", async () => {
+    const key = "uploads/users/u/video.webm";
     const downloadUrl =
-      "[https://harucuts3.s3.ap-northeast-2.amazonaws.com/uploads/users/VZ_LtszNul/mp4/d62ce849-47f7-4983-bbbf-0f4f2fcb6029_converted.mp4](https://harucuts3.s3.ap-northeast-2.amazonaws.com/uploads/users/VZ_LtszNul/mp4/d62ce849-47f7-4983-bbbf-0f4f2fcb6029_converted.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256)";
+      "https://harucuts3.s3.ap-northeast-2.amazonaws.com/uploads/users/u/video.mp4?sig=2";
 
     mockPost
       .mockResolvedValueOnce({
@@ -123,8 +173,7 @@ describe("presigned upload flow", () => {
           message: null,
           data: {
             key,
-            uploadUrl:
-              "https://example.com/upload/d62ce849-47f7-4983-bbbf-0f4f2fcb6029.webm?sig=1",
+            uploadUrl: "https://example.com/upload/video.webm?sig=1",
             contentType: "video/webm",
             expiresIn: "PT24H",
           },
@@ -138,7 +187,12 @@ describe("presigned upload flow", () => {
           code: "GEN-000",
           status: 200,
           message: null,
-          data: {},
+          data: {
+            mediaId: 8,
+            mediaType: "VIDEO",
+            s3Key: "uploads/users/u/video.mp4",
+            downloadUrl,
+          },
         },
         ok: true,
         status: 200,
@@ -151,8 +205,7 @@ describe("presigned upload flow", () => {
         status: 200,
         message: null,
         data: {
-          mediaType: "VIDEO",
-          downloadUrl,
+          downloadUrl: "https://example.com/video.webm?sig=3",
         },
       },
       ok: true,
@@ -165,30 +218,18 @@ describe("presigned upload flow", () => {
       status: 200,
     });
 
-    const result = await uploadToS3WithPresigned({
-      file: new File(["x"], "d62ce849-47f7-4983-bbbf-0f4f2fcb6029.webm", {
-        type: "video/webm",
-      }),
-      type: PRESIGNED_UPLOAD_TYPES.FOURCUT_VIDEO,
-      isTemp: false,
-    });
+    const result = await uploadFourcutMedia(
+      new File(["x"], "video.webm", { type: "video/webm" }),
+    );
 
-    expect(mockPost).toHaveBeenNthCalledWith(
-      2,
-      "/api/client/user/files/transcode",
-      {
-        filename: "d62ce849-47f7-4983-bbbf-0f4f2fcb6029.webm",
-      },
-    );
-    expect(mockGet).toHaveBeenCalledWith(
-      `/api/client/user/files/presigned-img?key=${encodeURIComponent(key)}`,
-    );
+    expect(mockPost).toHaveBeenNthCalledWith(2, "/api/client/user/files/transcode", {
+      filename: "video.webm",
+    });
     expect(result).toEqual({
       key,
-      objectUrl:
-        "https://harucuts3.s3.ap-northeast-2.amazonaws.com/uploads/users/VZ_LtszNul/mp4/d62ce849-47f7-4983-bbbf-0f4f2fcb6029_converted.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256",
-      downloadUrl:
-        "https://harucuts3.s3.ap-northeast-2.amazonaws.com/uploads/users/VZ_LtszNul/mp4/d62ce849-47f7-4983-bbbf-0f4f2fcb6029_converted.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256",
+      mediaId: 8,
+      objectUrl: downloadUrl,
+      downloadUrl,
     });
   });
 });

--- a/lib/presignedUploadApi.ts
+++ b/lib/presignedUploadApi.ts
@@ -1,13 +1,12 @@
 "use client";
 
+import type {
+  ApiEnvelope,
+  PresignedUploadContentType,
+  UserMedia,
+} from "@/lib/api-types";
 import { clientApi } from "@/lib/clientApi";
-
-type ApiEnvelope<T> = {
-  code: string;
-  status: number;
-  message: string | null;
-  data: T;
-};
+import { registerUserMedia } from "@/lib/userMediaApi";
 
 type PresignedUploadData = {
   key: string;
@@ -20,6 +19,12 @@ type UploadedMediaInfo = {
   objectUrl: string;
   downloadUrl?: string;
 };
+
+export const SUPPORTED_IMAGE_ACCEPT =
+  "image/png,image/jpeg,image/webp,image/gif";
+export const SUPPORTED_VIDEO_ACCEPT =
+  "video/mp4,video/webm,video/quicktime";
+export const SUPPORTED_FOURCUT_ACCEPT = `${SUPPORTED_IMAGE_ACCEPT},${SUPPORTED_VIDEO_ACCEPT}`;
 
 export const PRESIGNED_UPLOAD_TYPES = {
   FRAME: "FRAME",
@@ -35,9 +40,17 @@ export type PresignedUploadType =
 type PresignedUploadRequest = {
   type: PresignedUploadType;
   filename: string;
-  contentType: string;
+  contentType: PresignedUploadContentType;
   isTemp: boolean;
 };
+
+function isImageContentType(contentType: PresignedUploadContentType) {
+  return ["PNG", "JPEG", "WEBP", "GIF"].includes(contentType);
+}
+
+function isVideoContentType(contentType: PresignedUploadContentType) {
+  return ["MP4", "WEBM", "MOV"].includes(contentType);
+}
 
 function normalizeRemoteUrl(value: string | null | undefined): string | null {
   if (!value) return null;
@@ -123,58 +136,88 @@ function extractFilenameFromKey(key: string) {
 }
 
 async function requestTranscode(key: string) {
-  await clientApi.post<ApiEnvelope<Record<string, never>>>(
+  const res = await clientApi.post<ApiEnvelope<UserMedia>>(
     "/api/client/user/files/transcode",
     {
       filename: extractFilenameFromKey(key),
     },
   );
+
+  return res.data.data;
 }
 
-function isImageContentType(contentType: string) {
-  return ["PNG", "JPG", "JPEG", "WEBP"].includes(contentType);
+function createUnsupportedTypeError(file: File) {
+  return new Error(`Unsupported upload file type: ${file.type || file.name}`);
 }
 
-function isWebmContentType(contentType: string) {
-  return contentType === "WEBM";
-}
-
-export function resolveUploadContentType(file: File) {
+export function resolveUploadContentType(file: File): PresignedUploadContentType {
   const mime = file.type.toLowerCase();
+  const ext = file.name.split(".").pop()?.trim().toLowerCase();
 
-  if (mime === "image/png") return "PNG";
-  if (mime === "image/jpeg") {
-    return file.name.toLowerCase().endsWith(".jpg") ? "JPG" : "JPEG";
+  if (mime === "image/png" || ext === "png") return "PNG";
+  if (mime === "image/jpeg" || mime === "image/jpg" || ext === "jpg" || ext === "jpeg") {
+    return "JPEG";
   }
-  if (mime === "image/jpg") return "JPG";
-  if (mime === "image/webp") return "WEBP";
-  if (mime === "video/webm") return "WEBM";
+  if (mime === "image/webp" || ext === "webp") return "WEBP";
+  if (mime === "image/gif" || ext === "gif") return "GIF";
+  if (mime === "video/mp4" || ext === "mp4") return "MP4";
+  if (mime === "video/webm" || ext === "webm") return "WEBM";
+  if (mime === "video/quicktime" || ext === "mov") return "MOV";
 
-  const ext = file.name.split(".").pop()?.trim().toUpperCase();
-  if (ext) return ext;
-  return "BIN";
+  throw createUnsupportedTypeError(file);
 }
 
 export function resolveFourcutUploadType(file: File): PresignedUploadType {
-  const mime = file.type.toLowerCase();
   const contentType = resolveUploadContentType(file);
-
-  if (
-    mime.startsWith("video/") ||
-    ["WEBM", "MP4", "MOV", "AVI", "MKV", "M4V"].includes(contentType)
-  ) {
-    return PRESIGNED_UPLOAD_TYPES.FOURCUT_VIDEO;
-  }
-
-  return PRESIGNED_UPLOAD_TYPES.FOURCUT_PHOTO;
+  return isVideoContentType(contentType)
+    ? PRESIGNED_UPLOAD_TYPES.FOURCUT_VIDEO
+    : PRESIGNED_UPLOAD_TYPES.FOURCUT_PHOTO;
 }
 
 export async function uploadFourcutMedia(file: File) {
-  return uploadToS3WithPresigned({
+  const contentType = resolveUploadContentType(file);
+  const uploaded = await uploadToS3WithPresigned({
     file,
     type: resolveFourcutUploadType(file),
     isTemp: false,
   });
+
+  if (isImageContentType(contentType)) {
+    const media = await registerUserMedia({
+      mediaType: "PHOTO",
+      s3Key: uploaded.key,
+    });
+
+    return {
+      key: uploaded.key,
+      mediaId: media.mediaId,
+      objectUrl: media.downloadUrl ?? uploaded.objectUrl,
+      downloadUrl: media.downloadUrl ?? uploaded.downloadUrl,
+    };
+  }
+
+  if (contentType === "WEBM") {
+    const media = await requestTranscode(uploaded.key);
+
+    return {
+      key: uploaded.key,
+      mediaId: media.mediaId,
+      objectUrl: media.downloadUrl ?? uploaded.objectUrl,
+      downloadUrl: media.downloadUrl ?? uploaded.downloadUrl,
+    };
+  }
+
+  const media = await registerUserMedia({
+    mediaType: "VIDEO",
+    s3Key: uploaded.key,
+  });
+
+  return {
+    key: uploaded.key,
+    mediaId: media.mediaId,
+    objectUrl: media.downloadUrl ?? uploaded.objectUrl,
+    downloadUrl: media.downloadUrl ?? uploaded.downloadUrl,
+  };
 }
 
 export async function uploadToS3WithPresigned(opts: {
@@ -212,11 +255,7 @@ export async function uploadToS3WithPresigned(opts: {
 
   const fallbackObjectUrl = uploadUrl.split("?")[0] ?? uploadUrl;
 
-  if (isWebmContentType(resolvedContentType)) {
-    await requestTranscode(key);
-  }
-
-  if (isImageContentType(resolvedContentType) || isWebmContentType(resolvedContentType)) {
+  if (isImageContentType(resolvedContentType) || resolvedContentType === "WEBM") {
     const uploadedMediaInfo = await requestUploadedMediaInfo(key, fallbackObjectUrl);
     return {
       key,

--- a/lib/userMediaApi.ts
+++ b/lib/userMediaApi.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { clientApi } from "@/lib/clientApi";
+import type { ApiEnvelope, UserMedia, UserMediaType } from "@/lib/api-types";
+
+export async function listMyMedia(type?: UserMediaType) {
+  const query = type ? `?type=${encodeURIComponent(type)}` : "";
+  const res = await clientApi.get<ApiEnvelope<UserMedia[]>>(
+    `/api/client/user/media${query}`,
+  );
+  return res.data.data ?? [];
+}
+
+export async function registerUserMedia(args: {
+  mediaType: UserMediaType;
+  s3Key: string;
+}) {
+  const res = await clientApi.post<ApiEnvelope<UserMedia>>("/api/client/user/media", args);
+  return res.data.data;
+}
+
+export async function getMediaDownloadUrl(mediaId: number) {
+  const res = await clientApi.get<ApiEnvelope<string>>(
+    `/api/client/user/media/${mediaId}/download-url`,
+  );
+  return res.data.data;
+}


### PR DESCRIPTION
## 변경 사항
- presigned upload 요청의 `contentType` 매핑을 Swagger 계약에 맞게 정리
- `.jpg` 입력을 `JPEG` enum으로 정규화
- 업로드 이후 재사용할 공통 API 타입과 user media API 클라이언트를 추가

## 검증
- `pnpm exec jest --runInBand lib/presignedUploadApi.test.ts`
- 실서버 연동으로 presigned upload + S3 업로드 확인

## 비고
- 사진기록 UI PR의 선행 계약 정리 PR
