### PR TITLE
fix: 프로필/포토부스 업로드 입력 제한 정리

### DIFF
--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -6,6 +6,7 @@ import { clientApi } from "@/lib/clientApi";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { RefreshCw } from "lucide-react";
 import { uploadProfileImage } from "@/lib/profileImageApi";
+import { SUPPORTED_IMAGE_ACCEPT } from "@/lib/presignedUploadApi";
 
 type UserInfoResponse = {
   code: string;
@@ -260,7 +261,7 @@ export default function MyPage() {
               <div className="mt-3 flex items-center gap-2">
                 <input
                   type="file"
-                  accept="image/png,image/jpeg,image/jpg,image/webp,video/webm"
+                  accept={SUPPORTED_IMAGE_ACCEPT}
                   onChange={handleProfileFileChange}
                   disabled={isUploadingProfile}
                   className="block w-full text-[11px] text-zinc-300 file:mr-3 file:rounded-full file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-[11px] file:font-semibold file:text-zinc-100 hover:file:bg-zinc-700"

--- a/app/upload/select/page.tsx
+++ b/app/upload/select/page.tsx
@@ -7,6 +7,7 @@ import { useUploadSession } from "@/lib/uploadSessionStore";
 import type { FrameMedia } from "@/components/frame/FramePreview";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useThemeDraftStore } from "@/lib/themeDraftStore";
+import { SUPPORTED_FOURCUT_ACCEPT } from "@/lib/presignedUploadApi";
 
 export default function UploadSelectPage() {
   const router = useRouter();
@@ -110,7 +111,7 @@ export default function UploadSelectPage() {
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*,video/*"
+                accept={SUPPORTED_FOURCUT_ACCEPT}
                 multiple
                 onChange={handleChangeFiles}
                 className="hidden"

--- a/components/theme/editor/AssetPanel.tsx
+++ b/components/theme/editor/AssetPanel.tsx
@@ -3,6 +3,7 @@
 import { useThemeEditorStore } from "@/lib/themeEditorStore";
 import React, { useRef, useState } from "react";
 import { ImagePlus, X } from "lucide-react";
+import { SUPPORTED_IMAGE_ACCEPT } from "@/lib/presignedUploadApi";
 
 export function AssetPanel() {
   const tab = useThemeEditorStore((s) => s.tab);
@@ -81,7 +82,7 @@ function PhotoTab() {
       <input
         ref={fileRef}
         type="file"
-        accept="image/*"
+        accept={SUPPORTED_IMAGE_ACCEPT}
         multiple
         className="hidden"
         onChange={async (e) => {

--- a/lib/profileImageApi.ts
+++ b/lib/profileImageApi.ts
@@ -1,17 +1,11 @@
 "use client";
 
+import type { ApiEnvelope } from "@/lib/api-types";
 import { clientApi } from "@/lib/clientApi";
 import {
   PRESIGNED_UPLOAD_TYPES,
   uploadToS3WithPresigned,
 } from "@/lib/presignedUploadApi";
-
-type ApiEnvelope<T> = {
-  code: string;
-  status: number;
-  message: string | null;
-  data: T;
-};
 
 type ApiError = Error & {
   status?: number;
@@ -39,6 +33,10 @@ async function requestProfileImageChange(s3Key: string) {
 export async function uploadProfileImage(file: File) {
   if (!file) {
     throw new Error("No file selected");
+  }
+
+  if (!file.type.toLowerCase().startsWith("image/")) {
+    throw new Error("Profile image must be an image file");
   }
 
   const { key } = await uploadToS3WithPresigned({


### PR DESCRIPTION
## 변경 사항
- 프로필 업로드 input을 이미지 전용으로 제한
- 포토부스 업로드 input을 Swagger 허용 포맷 기준으로 제한
- 꾸미기 사진 asset 업로드도 이미지 전용으로 맞춤
- 프로필 업로드 API에서 비이미지 파일을 런타임 검증으로 차단

## 검증
- `pnpm -s tsc --noEmit`
- 브라우저에서 input `accept` 값 수동 확인
