### PR TITLE
feat: 사용자 미디어 기반 사진기록 화면 추가

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,6 +1,74 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { downloadFromUrl } from "@/lib/canvas/composeFrame";
+import { getMediaDownloadUrl, listMyMedia } from "@/lib/userMediaApi";
+import type { UserMedia, UserMediaType } from "@/lib/api-types";
+
+type FilterValue = "ALL" | UserMediaType;
 
 export default function HistoryPage() {
+  const [filter, setFilter] = useState<FilterValue>("ALL");
+  const [items, setItems] = useState<UserMedia[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [downloadingId, setDownloadingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadItems() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const media = await listMyMedia(filter === "ALL" ? undefined : filter);
+        if (!cancelled) {
+          const sorted = [...media].sort((a, b) => {
+            const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+            const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+            return bTime - aTime;
+          });
+          setItems(sorted);
+        }
+      } catch (loadError) {
+        console.error(loadError);
+        if (!cancelled) {
+          setError("기록을 불러오지 못했습니다.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadItems();
+    return () => {
+      cancelled = true;
+    };
+  }, [filter]);
+
+  const emptyText = useMemo(() => {
+    if (filter === "PHOTO") return "저장된 사진 기록이 없습니다.";
+    if (filter === "VIDEO") return "저장된 영상 기록이 없습니다.";
+    return "저장된 기록이 없습니다.";
+  }, [filter]);
+
+  const handleDownload = async (item: UserMedia) => {
+    setDownloadingId(item.mediaId);
+    try {
+      const url = await getMediaDownloadUrl(item.mediaId);
+      await downloadFromUrl(url);
+    } catch (downloadError) {
+      console.error(downloadError);
+      alert("다운로드에 실패했습니다.");
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
   return (
     <main className="min-h-dvh bg-zinc-950 text-white px-4 py-6">
       <div className="mx-auto w-full max-w-md flex flex-col gap-4">
@@ -8,9 +76,98 @@ export default function HistoryPage() {
           title="사진 기록"
           backHref="/home"
           backLabel="홈으로"
-          description={<>인생네컷 사진 기록 페이지(추후 개발 예정)</>}
+          description={<>내가 만든 사진과 영상을 다시 내려받을 수 있어요.</>}
         />
-        <p className="text-xs text-zinc-500"></p>
+
+        <section className="flex gap-2">
+          {(["ALL", "PHOTO", "VIDEO"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setFilter(value)}
+              className={`rounded-full px-3 py-1.5 text-[11px] font-medium ${
+                filter === value
+                  ? "bg-emerald-500 text-zinc-950"
+                  : "bg-zinc-900 text-zinc-300 border border-zinc-800"
+              }`}
+            >
+              {value === "ALL" ? "전체" : value === "PHOTO" ? "사진" : "영상"}
+            </button>
+          ))}
+        </section>
+
+        {error ? <p className="text-[11px] text-red-300">{error}</p> : null}
+
+        {loading ? (
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
+            <p className="text-[11px] text-zinc-400">불러오는 중...</p>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
+            <p className="text-[11px] text-zinc-500">{emptyText}</p>
+          </div>
+        ) : (
+          <section className="grid grid-cols-1 gap-3">
+            {items.map((item) => (
+              <article
+                key={item.mediaId}
+                className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-3"
+              >
+                <div className="flex gap-3">
+                  <div className="h-28 w-24 shrink-0 overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950">
+                    {item.downloadUrl ? (
+                      item.mediaType === "VIDEO" ? (
+                        <video
+                          src={item.downloadUrl}
+                          className="h-full w-full object-cover"
+                          muted
+                          playsInline
+                          controls={false}
+                        />
+                      ) : (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={item.downloadUrl}
+                          alt={`media-${item.mediaId}`}
+                          className="h-full w-full object-cover"
+                        />
+                      )
+                    ) : (
+                      <div className="grid h-full w-full place-items-center text-[10px] text-zinc-500">
+                        미리보기 없음
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
+                    <div className="flex flex-col gap-1">
+                      <span className="text-[10px] uppercase tracking-[0.2em] text-emerald-300">
+                        {item.mediaType}
+                      </span>
+                      <p className="truncate text-sm font-semibold text-zinc-100">
+                        {item.originalFileName || item.s3Key.split("/").pop() || "기록"}
+                      </p>
+                      <p className="text-[11px] text-zinc-500">
+                        {item.createdAt
+                          ? new Date(item.createdAt).toLocaleString("ko-KR")
+                          : "생성 시각 없음"}
+                      </p>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => handleDownload(item)}
+                      disabled={downloadingId === item.mediaId}
+                      className="rounded-full bg-emerald-500 px-3 py-2 text-[11px] font-semibold text-zinc-950 hover:bg-emerald-400 disabled:opacity-50"
+                    >
+                      {downloadingId === item.mediaId ? "다운로드 중..." : "다시 다운로드"}
+                    </button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </section>
+        )}
       </div>
     </main>
   );

--- a/app/home/_config/features.ts
+++ b/app/home/_config/features.ts
@@ -1,36 +1,34 @@
 import type { Feature } from "../_components/FeatureCard";
-
-import { Camera, Upload, Palette, History } from "lucide-react";
+import { Camera, History, Palette, Upload } from "lucide-react";
 
 export const features: Feature[] = [
   {
     id: "shoot",
     title: "사진 촬영",
     description:
-      "웹캠으로 8장을 자동 촬영하고, 4장을 골라 인생네컷으로 만들어요.",
+      "카메라로 8장을 자동 촬영하고, 4장을 골라 인생네컷으로 만들어요.",
     href: "/shoot",
     icon: Camera,
   },
   {
     id: "upload",
     title: "사진 업로드",
-    description: "이미 찍어둔 사진 4장을 업로드해서 네컷 프레임을 만들어요.",
+    description: "가지고 있는 사진 4장을 업로드해 네컷 프레임을 만들어요.",
     href: "/upload",
     icon: Upload,
   },
   {
     id: "theme",
-    title: "테마 꾸미기",
-    description: "프레임, 스티커, 텍스트로 나만의 테마를 꾸밀 수 있어요.",
+    title: "프레임 꾸미기",
+    description: "프레임에 스티커와 텍스트를 올려 나만의 테마를 만들 수 있어요.",
     href: "/theme",
     icon: Palette,
   },
   {
     id: "history",
     title: "사진 기록",
-    description: "이 기기에서 만든 인생네컷을 1주일 동안 다시 볼 수 있어요.",
+    description: "저장된 사진과 영상을 다시 보고 내려받을 수 있어요.",
     href: "/history",
-    comingSoon: true,
     icon: History,
   },
 ];


### PR DESCRIPTION
## 변경 사항
- `/api/auth/user/media`를 사용하는 사진기록 화면을 추가
- 사진/영상 필터와 재다운로드 버튼을 연결
- 홈에서 사진기록 기능을 바로 진입할 수 있도록 노출

## 검증
- `pnpm -s tsc --noEmit`
- 실서버 연동으로 media 목록 조회 및 download-url 확인
