### PR TITLE
feat: 프레임 목록 조회 및 타입 필터 연동

### DIFF
--- a/app/api/client/user/frame/[frameId]/route.ts
+++ b/app/api/client/user/frame/[frameId]/route.ts
@@ -1,0 +1,44 @@
+import { buildResponse, forward, proxyJson } from "@/app/api/client/_proxy";
+
+export const runtime = "edge";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+type RouteContext = {
+  params: Promise<{
+    frameId: string;
+  }>;
+};
+
+export async function GET(req: Request, context: RouteContext) {
+  const { frameId } = await context.params;
+
+  const upstream = await forward(req, {
+    method: "GET",
+    url: `${BASE_URL}/api/auth/user/frame/${frameId}`,
+    forwardBody: false,
+  });
+
+  return buildResponse(upstream, req);
+}
+
+export async function PUT(req: Request, context: RouteContext) {
+  const { frameId } = await context.params;
+
+  return proxyJson(req, {
+    method: "PUT",
+    url: `${BASE_URL}/api/auth/user/frame/${frameId}`,
+  });
+}
+
+export async function DELETE(req: Request, context: RouteContext) {
+  const { frameId } = await context.params;
+
+  const upstream = await forward(req, {
+    method: "DELETE",
+    url: `${BASE_URL}/api/auth/user/frame/${frameId}`,
+    forwardBody: false,
+  });
+
+  return buildResponse(upstream, req);
+}

--- a/app/api/client/user/frame/route.ts
+++ b/app/api/client/user/frame/route.ts
@@ -4,7 +4,14 @@ export const runtime = "edge";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
-/** 사용자 프레임 저장 프록시 */
+export async function GET(req: Request) {
+  return proxyJson(req, {
+    method: "GET",
+    url: `${BASE_URL}/api/auth/user/frame`,
+    forwardBody: false,
+  });
+}
+
 export async function POST(req: Request) {
   return proxyJson(req, {
     method: "POST",

--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -1,38 +1,97 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { FrameId } from "@/constants/frames";
+import { FramePreview } from "@/components/frame/FramePreview";
 import { FramePicker } from "@/components/frame/FramePicker";
-import { useThemeSession } from "@/lib/themeSessionStore";
-import { useThemeDraftStore } from "@/lib/themeDraftStore";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { frameIdFromFrameType, matchesFrameType } from "@/lib/frameApi";
+import { listMyFrames } from "@/lib/remoteFrameApi";
+import { useThemeDraftStore } from "@/lib/themeDraftStore";
+import { useThemeSession } from "@/lib/themeSessionStore";
+import type { RemoteFrame } from "@/lib/api-types";
 
 export default function ThemePage() {
   const router = useRouter();
-  const { frameId, setFrameId, setDraftId, reset } = useThemeSession();
+  const {
+    frameId,
+    setFrameId,
+    setDraftId,
+    setRemoteFrameId,
+    reset,
+  } = useThemeSession();
   const drafts = useThemeDraftStore((s) => s.drafts);
 
   const [selectedFrameId, setSelectedFrameId] = useState<FrameId>(
     frameId ?? "classic-4",
   );
   const [selectedDraftId, setSelectedDraftId] = useState<string | null>(null);
+  const [remoteFrames, setRemoteFrames] = useState<RemoteFrame[]>([]);
+  const [isLoadingFrames, setIsLoadingFrames] = useState(true);
+  const [framesError, setFramesError] = useState<string | null>(null);
 
   useEffect(() => {
     reset();
   }, [reset]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadFrames() {
+      setIsLoadingFrames(true);
+      setFramesError(null);
+
+      try {
+        const frames = await listMyFrames();
+        if (!cancelled) {
+          setRemoteFrames(frames);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) {
+          setFramesError("저장한 프레임을 불러오지 못했습니다.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingFrames(false);
+        }
+      }
+    }
+
+    loadFrames();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const allowedDraftId =
     selectedDraftId &&
     drafts.some(
-      (d) => d.id === selectedDraftId && d.frameId === selectedFrameId,
+      (draft) => draft.id === selectedDraftId && draft.frameId === selectedFrameId,
     )
       ? selectedDraftId
       : null;
 
-  const handleConfirmFrame = () => {
+  const matchingRemoteFrames = useMemo(
+    () =>
+      remoteFrames.filter((frame) =>
+        matchesFrameType(selectedFrameId, frame.frameType),
+      ),
+    [remoteFrames, selectedFrameId],
+  );
+
+  const handleConfirmNewFrame = () => {
     setFrameId(selectedFrameId);
     setDraftId(allowedDraftId);
+    setRemoteFrameId(null);
+    router.push("/theme/sticker");
+  };
+
+  const handleOpenRemoteFrame = (frame: RemoteFrame) => {
+    setFrameId(frameIdFromFrameType(frame.frameType));
+    setDraftId(null);
+    setRemoteFrameId(frame.frameId);
     router.push("/theme/sticker");
   };
 
@@ -40,20 +99,100 @@ export default function ThemePage() {
     <main className="min-h-dvh bg-zinc-950 text-white px-2 py-6">
       <div className="mx-auto flex w-full max-w-md flex-col gap-6">
         <PageHeader
-          title="꾸미기 · 프레임 선택"
+          title="프레임 꾸미기"
           backHref="/home"
           backLabel="처음으로"
-          description={<>1단계: 원하는 프레임을 선택해주세요.</>}
+          description={<>새 프레임을 만들거나 저장한 프레임을 이어서 수정할 수 있어요.</>}
         />
+
         <FramePicker
           selectedFrameId={selectedFrameId}
           onChangeSelected={setSelectedFrameId}
-          onConfirm={handleConfirmFrame}
-          confirmLabel="이 프레임으로 꾸미기"
+          onConfirm={handleConfirmNewFrame}
+          confirmLabel="새 프레임 만들기"
           drafts={drafts}
           selectedDraftId={allowedDraftId}
           onSelectDraft={setSelectedDraftId}
         />
+
+        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold">저장한 프레임</h2>
+              <p className="mt-1 text-[11px] text-zinc-500">
+                선택한 레이아웃과 같은 타입의 프레임만 보여줍니다.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setIsLoadingFrames(true);
+                setFramesError(null);
+                listMyFrames()
+                  .then((frames) => setRemoteFrames(frames))
+                  .catch((error) => {
+                    console.error(error);
+                    setFramesError("저장한 프레임을 불러오지 못했습니다.");
+                  })
+                  .finally(() => setIsLoadingFrames(false));
+              }}
+              className="rounded-full border border-zinc-700 px-3 py-1 text-[11px] text-zinc-300 hover:bg-zinc-800"
+            >
+              새로고침
+            </button>
+          </div>
+
+          {framesError ? (
+            <p className="mt-3 text-[11px] text-red-300">{framesError}</p>
+          ) : null}
+
+          {isLoadingFrames ? (
+            <p className="mt-3 text-[11px] text-zinc-500">불러오는 중...</p>
+          ) : matchingRemoteFrames.length === 0 ? (
+            <p className="mt-3 text-[11px] text-zinc-500">
+              이 레이아웃으로 저장된 프레임이 아직 없습니다.
+            </p>
+          ) : (
+            <div className="mt-4 grid grid-cols-1 gap-3">
+              {matchingRemoteFrames.map((frame) => (
+                <button
+                  key={frame.frameId}
+                  type="button"
+                  onClick={() => handleOpenRemoteFrame(frame)}
+                  className="rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-left hover:border-emerald-400/80"
+                >
+                  <div className="flex gap-3">
+                    <div className="h-28 w-20 shrink-0 overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900">
+                      {frame.source ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={frame.source}
+                          alt={frame.title}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <FramePreview frameId={frameIdFromFrameType(frame.frameType)} />
+                      )}
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col justify-between gap-2">
+                      <div>
+                        <p className="truncate text-sm font-semibold text-zinc-100">
+                          {frame.title || `프레임 #${frame.frameId}`}
+                        </p>
+                        <p className="mt-1 line-clamp-2 text-[11px] text-zinc-500">
+                          {frame.description || "저장된 프레임을 이어서 수정합니다."}
+                        </p>
+                      </div>
+                      <span className="text-[10px] text-emerald-300">
+                        불러와서 수정하기
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
     </main>
   );

--- a/lib/remoteFrameApi.ts
+++ b/lib/remoteFrameApi.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { clientApi } from "@/lib/clientApi";
+import type { ApiEnvelope, RemoteFrame } from "@/lib/api-types";
+import type { CreateFrameRequest } from "@/lib/frameApi";
+
+export async function listMyFrames() {
+  const res = await clientApi.get<ApiEnvelope<RemoteFrame[]>>("/api/client/user/frame");
+  return res.data.data ?? [];
+}
+
+export async function getFrame(frameId: number) {
+  const res = await clientApi.get<ApiEnvelope<RemoteFrame>>(
+    `/api/client/user/frame/${frameId}`,
+  );
+  return res.data.data;
+}
+
+export async function createFrame(body: CreateFrameRequest) {
+  await clientApi.post<ApiEnvelope<null>>("/api/client/user/frame", body);
+}
+
+export async function updateFrame(frameId: number, body: CreateFrameRequest) {
+  await clientApi.put<ApiEnvelope<null>>(`/api/client/user/frame/${frameId}`, body);
+}
+
+export async function deleteFrame(frameId: number) {
+  await clientApi.delete<ApiEnvelope<null>>(`/api/client/user/frame/${frameId}`);
+}

--- a/lib/themeSessionStore.ts
+++ b/lib/themeSessionStore.ts
@@ -4,15 +4,19 @@ import type { FrameId } from "@/constants/frames";
 type ThemeSessionState = {
   frameId: FrameId | null;
   draftId: string | null;
+  remoteFrameId: number | null;
   setFrameId: (id: FrameId | null) => void;
   setDraftId: (id: string | null) => void;
+  setRemoteFrameId: (id: number | null) => void;
   reset: () => void;
 };
 
 export const useThemeSession = create<ThemeSessionState>((set) => ({
   frameId: null,
   draftId: null,
+  remoteFrameId: null,
   setFrameId: (id) => set({ frameId: id }),
   setDraftId: (id) => set({ draftId: id }),
-  reset: () => set({ frameId: null, draftId: null }),
+  setRemoteFrameId: (id) => set({ remoteFrameId: id }),
+  reset: () => set({ frameId: null, draftId: null, remoteFrameId: null }),
 }));


### PR DESCRIPTION
## 변경 사항
- 서버 프레임 목록 조회 프록시와 API 클라이언트를 추가
- 현재 선택한 frame 타입과 일치하는 프레임만 `/theme`에 노출
- 선택한 remote frame id를 다음 편집 단계로 넘길 수 있도록 세션 상태를 확장

## 검증
- `pnpm -s tsc --noEmit`
- 실서버 연동으로 frame list 조회 및 타입 필터 확인

## 비고
- 상세 조회/수정/삭제 편집기 연동은 다음 PR에서 마무리
