### PR TITLE
feat: 꾸미기 편집기 frame CRUD 연동

### DIFF
--- a/components/theme/editor/ThemeEditorPage.test.tsx
+++ b/components/theme/editor/ThemeEditorPage.test.tsx
@@ -9,11 +9,15 @@ const mockResetPhotos = jest.fn();
 const mockSetBackgroundColor = jest.fn();
 const mockAddDraft = jest.fn();
 const mockUpdateDraft = jest.fn();
-const mockClientPost = jest.fn();
+const mockCreateFrame = jest.fn();
+const mockUpdateFrame = jest.fn();
+const mockDeleteFrame = jest.fn();
+const mockGetFrame = jest.fn();
 const mockUploadPresigned = jest.fn();
 const mockRenderPreview = jest.fn();
 
 let mockDraftId: string | null = null;
+let mockRemoteFrameId: number | null = null;
 let mockDrafts: Array<{
   id: string;
   data: { frameId: string; components: unknown[] };
@@ -34,6 +38,7 @@ function themeEditorStoreMock(
 ) {
   return selector(editorStoreState);
 }
+
 (
   themeEditorStoreMock as unknown as { getState: () => typeof editorStoreState }
 ).getState = () => editorStoreState;
@@ -69,11 +74,17 @@ jest.mock("@/lib/themeDraftStore", () => ({
 }));
 
 jest.mock("@/lib/themeSessionStore", () => ({
-  useThemeSession: () => ({ draftId: mockDraftId }),
+  useThemeSession: () => ({
+    draftId: mockDraftId,
+    remoteFrameId: mockRemoteFrameId,
+  }),
 }));
 
-jest.mock("@/lib/clientApi", () => ({
-  clientApi: { post: (...args: unknown[]) => mockClientPost(...args) },
+jest.mock("@/lib/remoteFrameApi", () => ({
+  createFrame: (...args: unknown[]) => mockCreateFrame(...args),
+  updateFrame: (...args: unknown[]) => mockUpdateFrame(...args),
+  deleteFrame: (...args: unknown[]) => mockDeleteFrame(...args),
+  getFrame: (...args: unknown[]) => mockGetFrame(...args),
 }));
 
 jest.mock("@/lib/presignedUploadApi", () => ({
@@ -95,6 +106,7 @@ describe("ThemeEditorPage save flow", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDraftId = null;
+    mockRemoteFrameId = null;
     mockDrafts = [];
     editorStoreState.components = [];
     mockExportJson.mockReturnValue({
@@ -104,10 +116,18 @@ describe("ThemeEditorPage save flow", () => {
     });
     mockRenderPreview.mockResolvedValue(new Blob(["x"], { type: "image/png" }));
     mockUploadPresigned.mockResolvedValue({ key: "preview-key" });
-    mockClientPost.mockResolvedValue({ ok: true });
+    mockCreateFrame.mockResolvedValue(undefined);
+    mockUpdateFrame.mockResolvedValue(undefined);
+    mockGetFrame.mockResolvedValue({
+      frameId: 7,
+      title: "saved",
+      frameType: "CLASSIC",
+      background: { type: "COLOR", value: "111827" },
+      components: [],
+    });
   });
 
-  it("updates existing draft when draft is selected", async () => {
+  it("creates a new frame and updates the local draft when a draft is selected", async () => {
     mockDraftId = "draft-1";
     mockDrafts = [
       {
@@ -120,28 +140,44 @@ describe("ThemeEditorPage save flow", () => {
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
 
     await waitFor(() => {
-      expect(mockClientPost).toHaveBeenCalledTimes(1);
+      expect(mockCreateFrame).toHaveBeenCalledTimes(1);
       expect(mockUploadPresigned).toHaveBeenCalledWith(
         expect.objectContaining({ type: "FRAME", isTemp: false }),
       );
       expect(mockUpdateDraft).toHaveBeenCalledTimes(1);
       expect(mockAddDraft).not.toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith("/home");
+      expect(mockPush).toHaveBeenCalledWith("/theme");
     });
   });
 
-  it("adds draft when no selected draft exists", async () => {
+  it("adds a local draft when creating without a selected draft", async () => {
     render(<ThemeEditorPage frameId="classic-4" />);
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
 
     await waitFor(() => {
-      expect(mockClientPost).toHaveBeenCalledTimes(1);
-      expect(mockUploadPresigned).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "FRAME", isTemp: false }),
-      );
+      expect(mockCreateFrame).toHaveBeenCalledTimes(1);
       expect(mockAddDraft).toHaveBeenCalledTimes(1);
       expect(mockUpdateDraft).not.toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith("/home");
+      expect(mockPush).toHaveBeenCalledWith("/theme");
+    });
+  });
+
+  it("updates a remote frame without touching local drafts", async () => {
+    mockRemoteFrameId = 7;
+
+    render(<ThemeEditorPage frameId="classic-4" />);
+
+    await waitFor(() => {
+      expect(mockGetFrame).toHaveBeenCalledWith(7);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정 저장" }));
+
+    await waitFor(() => {
+      expect(mockUpdateFrame).toHaveBeenCalledWith(7, expect.any(Object));
+      expect(mockAddDraft).not.toHaveBeenCalled();
+      expect(mockUpdateDraft).not.toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/theme");
     });
   });
 });

--- a/components/theme/editor/ThemeEditorPage.tsx
+++ b/components/theme/editor/ThemeEditorPage.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -9,8 +9,13 @@ import { CanvasStage } from "@/components/theme/editor/canvas/CanvasStage";
 import { AssetPanel } from "@/components/theme/editor/AssetPanel";
 import { LayersPanel } from "@/components/theme/editor/LayersPanel";
 import { InspectorPanel } from "@/components/theme/editor/InspectorPanel";
-import { clientApi } from "@/lib/clientApi";
-import { toCreateFrameRequest } from "@/lib/frameApi";
+import { toCreateFrameRequest, toThemeExportJson } from "@/lib/frameApi";
+import {
+  createFrame,
+  deleteFrame,
+  getFrame,
+  updateFrame,
+} from "@/lib/remoteFrameApi";
 import {
   PRESIGNED_UPLOAD_TYPES,
   uploadToS3WithPresigned,
@@ -30,35 +35,67 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
   const setBackgroundColor = useThemeEditorStore((s) => s.setBackgroundColor);
   const addDraft = useThemeDraftStore((s) => s.addDraft);
   const updateDraft = useThemeDraftStore((s) => s.updateDraft);
-  const { draftId } = useThemeSession();
+  const { draftId, remoteFrameId } = useThemeSession();
   const [isSaving, setIsSaving] = useState(false);
+  const [isLoadingFrame, setIsLoadingFrame] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   const draft = useThemeDraftStore((s) =>
     draftId ? s.drafts.find((d) => d.id === draftId) : undefined,
   );
 
-  // 프레임 변경 시 에디터 상태 초기화
   useEffect(() => {
     setFrameId(frameId);
   }, [frameId, setFrameId]);
 
-  // 선택된 저장본이 있으면 불러오기
   useEffect(() => {
-    if (draft && draft.data.frameId === frameId) {
-      importJson(draft.data);
-    }
-  }, [draft, frameId, importJson]);
+    let cancelled = false;
 
-  // 언마운트 시 업로드 이미지 메모리 정리
+    async function loadRemoteFrame() {
+      if (!remoteFrameId) {
+        setLoadError(null);
+        if (draft && draft.data.frameId === frameId) {
+          importJson(draft.data);
+        }
+        return;
+      }
+
+      setIsLoadingFrame(true);
+      setLoadError(null);
+
+      try {
+        const remoteFrame = await getFrame(remoteFrameId);
+        if (!cancelled) {
+          importJson(toThemeExportJson(remoteFrame));
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) {
+          setLoadError("저장한 프레임을 불러오지 못했습니다.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingFrame(false);
+        }
+      }
+    }
+
+    loadRemoteFrame();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [draft, frameId, importJson, remoteFrameId]);
+
   useEffect(() => {
     return () => {
       resetPhotos();
     };
   }, [resetPhotos]);
 
-  // 저장: JSON 내보내기 → Draft 저장
   const onDone = async () => {
-    if (isSaving) return;
-    // 숨김 레이어가 있으면 경고 (서버에는 제외됨)
+    if (isSaving || isLoadingFrame) return;
+
     const state = useThemeEditorStore.getState();
     const hiddenCount = state.components.filter((c) => c.hidden).length;
     if (hiddenCount > 0) {
@@ -71,15 +108,6 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
     setIsSaving(true);
     try {
       const previewBlob = await renderThemePreviewPng(themeJson);
-
-      // const localUrl = URL.createObjectURL(previewBlob);
-      // const a = document.createElement("a");
-      // a.href = localUrl;
-      // a.download = "theme-preview-local.png";
-      // a.click();
-      // URL.revokeObjectURL(localUrl);
-      // return; // 여기서 종료하면 통신 없이 이미지 확인 가능
-
       const previewFile = new File(
         [previewBlob],
         `theme-preview-${Date.now()}.png`,
@@ -93,40 +121,78 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
 
       const body = toCreateFrameRequest(themeJson, {
         title: "테마 프레임",
-        description: "프레임 꾸미기 저장",
+        description: remoteFrameId
+          ? "프레임 꾸미기 수정"
+          : "프레임 꾸미기 저장",
         previewKey,
       });
-      await clientApi.post("/api/client/user/frame", body);
-    } catch (e) {
-      console.error(e);
-      alert("저장에 실패했습니다.");
-      setIsSaving(false);
-      return;
-    }
 
-    if (draft?.id) {
-      updateDraft(draft.id, themeJson);
-    } else {
-      addDraft(themeJson);
+      if (remoteFrameId) {
+        await updateFrame(remoteFrameId, body);
+      } else {
+        await createFrame(body);
+
+        if (draft?.id) {
+          updateDraft(draft.id, themeJson);
+        } else {
+          addDraft(themeJson);
+        }
+      }
+
+      router.push("/theme");
+    } catch (error) {
+      console.error(error);
+      alert("저장에 실패했습니다.");
+    } finally {
+      setIsSaving(false);
     }
-    setIsSaving(false);
-    router.push("/home");
+  };
+
+  const onDelete = async () => {
+    if (!remoteFrameId || isDeleting) return;
+
+    const ok = confirm("이 프레임을 삭제할까요?");
+    if (!ok) return;
+
+    setIsDeleting(true);
+    try {
+      await deleteFrame(remoteFrameId);
+      router.push("/theme");
+    } catch (error) {
+      console.error(error);
+      alert("삭제에 실패했습니다.");
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   return (
     <main className="min-h-dvh bg-zinc-950 text-white px-4 py-6">
       <div className="mx-auto w-full max-w-6xl flex flex-col gap-4 lg:gap-6">
-        <header className="flex items-center justify-between">
+        <header className="flex items-center justify-between gap-4">
           <div className="flex flex-col">
             <span className="text-[11px] tracking-[0.16em] text-zinc-500">
               harucut
             </span>
             <h1 className="text-lg font-semibold tracking-tight">
-              프레임 꾸미기
+              {remoteFrameId ? "저장한 프레임 수정" : "프레임 꾸미기"}
             </h1>
+            {loadError ? (
+              <p className="mt-1 text-[11px] text-red-300">{loadError}</p>
+            ) : null}
           </div>
 
           <div className="flex items-center gap-3">
+            {remoteFrameId ? (
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={isDeleting || isSaving}
+                className="rounded-full border border-red-500/40 px-4 py-2 text-xs font-semibold text-red-200 hover:bg-red-500/10 disabled:opacity-50"
+              >
+                {isDeleting ? "삭제 중..." : "삭제"}
+              </button>
+            ) : null}
             <Link
               href="/theme"
               className="text-xs text-zinc-400 underline underline-offset-4"
@@ -135,18 +201,24 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
                 router.push("/theme");
               }}
             >
-              프레임 선택으로 돌아가기
+              프레임 목록으로 돌아가기
             </Link>
             <button
               type="button"
               onClick={onDone}
-              disabled={isSaving}
+              disabled={isSaving || isLoadingFrame}
               className="rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold text-zinc-950 hover:bg-emerald-400 disabled:opacity-50"
             >
-              {isSaving ? "저장 중..." : "저장"}
+              {isSaving ? "저장 중..." : remoteFrameId ? "수정 저장" : "저장"}
             </button>
           </div>
         </header>
+
+        {isLoadingFrame ? (
+          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4 text-sm text-zinc-400">
+            저장한 프레임을 불러오는 중입니다.
+          </section>
+        ) : null}
 
         <div className="grid grid-cols-1 gap-4 lg:gap-6 lg:grid-cols-[380px_minmax(0,1fr)] lg:auto-rows-min">
           <div className="lg:col-start-2 lg:row-start-1 min-w-0">
@@ -198,7 +270,7 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
               <div className="flex items-center justify-between">
                 <p className="text-sm font-semibold">미리보기</p>
                 <p className="text-[11px] text-zinc-500">
-                  스티커 & 사진 혹은 글/투명 배경을 조합해보세요.
+                  스티커, 사진, 글을 조합해 나만의 프레임을 만들어요.
                 </p>
               </div>
 


### PR DESCRIPTION
## 변경 사항
- 편집기에서 remote frame을 로드해 수정할 수 있도록 연결
- 신규 저장과 기존 프레임 수정 저장을 분기 처리
- 편집기에서 프레임 삭제 기능을 추가
- 편집기 저장/수정 흐름 테스트를 보강

## 검증
- `pnpm exec jest --runInBand components/theme/editor/ThemeEditorPage.test.tsx`
- 실서버 연동으로 frame 수정/삭제 확인
