### PR TITLE
feat: 탈퇴 요청 계정 reactivate 확인 흐름 추가

### DIFF
--- a/app/api/client/reactivate/route.ts
+++ b/app/api/client/reactivate/route.ts
@@ -1,0 +1,13 @@
+import { proxyJson } from "@/app/api/client/_proxy";
+
+export const runtime = "edge";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+export async function POST(req: Request) {
+  return proxyJson(req, {
+    method: "POST",
+    url: `${BASE_URL}/api/harucut/reactivate`,
+    forwardBody: false,
+  });
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,8 +7,9 @@ import { SocialLoginSection } from "@/components/auth/SocialLoginSection";
 import { AuthPageShell } from "@/components/auth/AuthPageShell";
 import { LOGIN_FIELDS } from "@/components/auth/authFields";
 import { validateEmail, validatePassword } from "@/lib/authValidation";
-import { loginWithEmail } from "@/lib/auth/authApi";
+import { loginWithEmail, reactivateAccount } from "@/lib/auth/authApi";
 import { useRedirectIfAuthenticated } from "@/hooks/useRedirectIfAuthenticated";
+import { clientApi } from "@/lib/clientApi";
 import type { AuthFieldName } from "@/components/auth/authFields";
 
 type LoginFieldName = Extract<AuthFieldName, "email" | "password">;
@@ -46,12 +47,38 @@ export default function LoginPage() {
     }
 
     try {
-      await loginWithEmail(email, password);
+      const loginData = await loginWithEmail(email, password);
+
+      if (loginData?.userStatus === "DELETED_REQUESTED") {
+        const shouldReactivate = window.confirm(
+          "회원 탈퇴 요청 상태입니다. 탈퇴를 취소하고 계속 로그인할까요?",
+        );
+
+        if (!shouldReactivate) {
+          await clientApi.delete("/api/client/logout").catch(() => undefined);
+          setErrors({
+            common: "회원 탈퇴 취소를 선택해야 다시 로그인할 수 있습니다.",
+          });
+          return;
+        }
+
+        try {
+          await reactivateAccount();
+        } catch (reactivateError) {
+          console.error(reactivateError);
+          await clientApi.delete("/api/client/logout").catch(() => undefined);
+          setErrors({
+            common: "회원 탈퇴 취소에 실패했습니다. 다시 시도해 주세요.",
+          });
+          return;
+        }
+      }
+
       window.location.href = "/home";
     } catch (error) {
       console.error(error);
       setErrors({
-        common: "로그인에 실패했습니다. 이메일/비밀번호를 확인해 주세요.",
+        common: "로그인에 실패했습니다. 이메일과 비밀번호를 확인해 주세요.",
       });
     } finally {
       setIsSubmitting(false);

--- a/constants/stickers.generated.ts
+++ b/constants/stickers.generated.ts
@@ -5,198 +5,198 @@ import type { Asset } from "@/lib/types/themeEditor";
 
 export const STICKERS: Asset[] = [
   {
-    id: "st-001",
-    src: "/stickers/sticker-001.png",
-    name: "sticker-001",
+    "id": "st-001",
+    "src": "/stickers/sticker-001.png",
+    "name": "sticker-001"
   },
   {
-    id: "st-002",
-    src: "/stickers/sticker-002.png",
-    name: "sticker-002",
+    "id": "st-002",
+    "src": "/stickers/sticker-002.png",
+    "name": "sticker-002"
   },
   {
-    id: "st-003",
-    src: "/stickers/sticker-003.png",
-    name: "sticker-003",
+    "id": "st-003",
+    "src": "/stickers/sticker-003.png",
+    "name": "sticker-003"
   },
   {
-    id: "st-004",
-    src: "/stickers/sticker-004.png",
-    name: "sticker-004",
+    "id": "st-004",
+    "src": "/stickers/sticker-004.png",
+    "name": "sticker-004"
   },
   {
-    id: "st-005",
-    src: "/stickers/sticker-005.png",
-    name: "sticker-005",
+    "id": "st-005",
+    "src": "/stickers/sticker-005.png",
+    "name": "sticker-005"
   },
   {
-    id: "st-006",
-    src: "/stickers/sticker-006.png",
-    name: "sticker-006",
+    "id": "st-006",
+    "src": "/stickers/sticker-006.png",
+    "name": "sticker-006"
   },
   {
-    id: "st-007",
-    src: "/stickers/sticker-007.png",
-    name: "sticker-007",
+    "id": "st-007",
+    "src": "/stickers/sticker-007.png",
+    "name": "sticker-007"
   },
   {
-    id: "st-008",
-    src: "/stickers/sticker-008.png",
-    name: "sticker-008",
+    "id": "st-008",
+    "src": "/stickers/sticker-008.png",
+    "name": "sticker-008"
   },
   {
-    id: "st-009",
-    src: "/stickers/sticker-009.png",
-    name: "sticker-009",
+    "id": "st-009",
+    "src": "/stickers/sticker-009.png",
+    "name": "sticker-009"
   },
   {
-    id: "st-010",
-    src: "/stickers/sticker-010.png",
-    name: "sticker-010",
+    "id": "st-010",
+    "src": "/stickers/sticker-010.png",
+    "name": "sticker-010"
   },
   {
-    id: "st-011",
-    src: "/stickers/sticker-011.png",
-    name: "sticker-011",
+    "id": "st-011",
+    "src": "/stickers/sticker-011.png",
+    "name": "sticker-011"
   },
   {
-    id: "st-012",
-    src: "/stickers/sticker-012.png",
-    name: "sticker-012",
+    "id": "st-012",
+    "src": "/stickers/sticker-012.png",
+    "name": "sticker-012"
   },
   {
-    id: "st-013",
-    src: "/stickers/sticker-013.png",
-    name: "sticker-013",
+    "id": "st-013",
+    "src": "/stickers/sticker-013.png",
+    "name": "sticker-013"
   },
   {
-    id: "st-014",
-    src: "/stickers/sticker-014.png",
-    name: "sticker-014",
+    "id": "st-014",
+    "src": "/stickers/sticker-014.png",
+    "name": "sticker-014"
   },
   {
-    id: "st-015",
-    src: "/stickers/sticker-015.png",
-    name: "sticker-015",
+    "id": "st-015",
+    "src": "/stickers/sticker-015.png",
+    "name": "sticker-015"
   },
   {
-    id: "st-016",
-    src: "/stickers/sticker-016.png",
-    name: "sticker-016",
+    "id": "st-016",
+    "src": "/stickers/sticker-016.png",
+    "name": "sticker-016"
   },
   {
-    id: "st-017",
-    src: "/stickers/sticker-017.png",
-    name: "sticker-017",
+    "id": "st-017",
+    "src": "/stickers/sticker-017.png",
+    "name": "sticker-017"
   },
   {
-    id: "st-018",
-    src: "/stickers/sticker-018.png",
-    name: "sticker-018",
+    "id": "st-018",
+    "src": "/stickers/sticker-018.png",
+    "name": "sticker-018"
   },
   {
-    id: "st-019",
-    src: "/stickers/sticker-019.png",
-    name: "sticker-019",
+    "id": "st-019",
+    "src": "/stickers/sticker-019.png",
+    "name": "sticker-019"
   },
   {
-    id: "st-020",
-    src: "/stickers/sticker-020.png",
-    name: "sticker-020",
+    "id": "st-020",
+    "src": "/stickers/sticker-020.png",
+    "name": "sticker-020"
   },
   {
-    id: "st-021",
-    src: "/stickers/sticker-021.png",
-    name: "sticker-021",
+    "id": "st-021",
+    "src": "/stickers/sticker-021.png",
+    "name": "sticker-021"
   },
   {
-    id: "st-022",
-    src: "/stickers/sticker-022.png",
-    name: "sticker-022",
+    "id": "st-022",
+    "src": "/stickers/sticker-022.png",
+    "name": "sticker-022"
   },
   {
-    id: "st-023",
-    src: "/stickers/sticker-023.png",
-    name: "sticker-023",
+    "id": "st-023",
+    "src": "/stickers/sticker-023.png",
+    "name": "sticker-023"
   },
   {
-    id: "st-024",
-    src: "/stickers/sticker-024.png",
-    name: "sticker-024",
+    "id": "st-024",
+    "src": "/stickers/sticker-024.png",
+    "name": "sticker-024"
   },
   {
-    id: "st-025",
-    src: "/stickers/sticker-025.png",
-    name: "sticker-025",
+    "id": "st-025",
+    "src": "/stickers/sticker-025.png",
+    "name": "sticker-025"
   },
   {
-    id: "st-026",
-    src: "/stickers/sticker-026.png",
-    name: "sticker-026",
+    "id": "st-026",
+    "src": "/stickers/sticker-026.png",
+    "name": "sticker-026"
   },
   {
-    id: "st-027",
-    src: "/stickers/sticker-027.png",
-    name: "sticker-027",
+    "id": "st-027",
+    "src": "/stickers/sticker-027.png",
+    "name": "sticker-027"
   },
   {
-    id: "st-028",
-    src: "/stickers/sticker-028.png",
-    name: "sticker-028",
+    "id": "st-028",
+    "src": "/stickers/sticker-028.png",
+    "name": "sticker-028"
   },
   {
-    id: "st-029",
-    src: "/stickers/sticker-029.png",
-    name: "sticker-029",
+    "id": "st-029",
+    "src": "/stickers/sticker-029.png",
+    "name": "sticker-029"
   },
   {
-    id: "st-030",
-    src: "/stickers/sticker-030.png",
-    name: "sticker-030",
+    "id": "st-030",
+    "src": "/stickers/sticker-030.png",
+    "name": "sticker-030"
   },
   {
-    id: "st-031",
-    src: "/stickers/sticker-031.png",
-    name: "sticker-031",
+    "id": "st-031",
+    "src": "/stickers/sticker-031.png",
+    "name": "sticker-031"
   },
   {
-    id: "st-032",
-    src: "/stickers/sticker-032.png",
-    name: "sticker-032",
+    "id": "st-032",
+    "src": "/stickers/sticker-032.png",
+    "name": "sticker-032"
   },
   {
-    id: "st-033",
-    src: "/stickers/sticker-033.png",
-    name: "sticker-033",
+    "id": "st-033",
+    "src": "/stickers/sticker-033.png",
+    "name": "sticker-033"
   },
   {
-    id: "st-034",
-    src: "/stickers/sticker-034.png",
-    name: "sticker-034",
+    "id": "st-034",
+    "src": "/stickers/sticker-034.png",
+    "name": "sticker-034"
   },
   {
-    id: "st-035",
-    src: "/stickers/sticker-035.png",
-    name: "sticker-035",
+    "id": "st-035",
+    "src": "/stickers/sticker-035.png",
+    "name": "sticker-035"
   },
   {
-    id: "st-036",
-    src: "/stickers/sticker-036.png",
-    name: "sticker-036",
+    "id": "st-036",
+    "src": "/stickers/sticker-036.png",
+    "name": "sticker-036"
   },
   {
-    id: "st-037",
-    src: "/stickers/sticker-037.png",
-    name: "sticker-037",
+    "id": "st-037",
+    "src": "/stickers/sticker-037.png",
+    "name": "sticker-037"
   },
   {
-    id: "st-038",
-    src: "/stickers/sticker-038.png",
-    name: "sticker-038",
+    "id": "st-038",
+    "src": "/stickers/sticker-038.png",
+    "name": "sticker-038"
   },
   {
-    id: "st-039",
-    src: "/stickers/sticker-039.png",
-    name: "sticker-039",
-  },
+    "id": "st-039",
+    "src": "/stickers/sticker-039.png",
+    "name": "sticker-039"
+  }
 ];

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -20,7 +20,7 @@ if (!baseURL) {
 }
 
 async function request<T>(
-  method: "GET" | "POST" | "PATCH" | "DELETE",
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
   path: string,
   body?: unknown,
   options: ApiOptions = {},
@@ -75,6 +75,9 @@ export const api = {
   },
   patch<T>(path: string, body?: unknown, options?: ApiOptions) {
     return request<T>("PATCH", path, body, options);
+  },
+  put<T>(path: string, body?: unknown, options?: ApiOptions) {
+    return request<T>("PUT", path, body, options);
   },
   delete<T>(path: string, options?: ApiOptions) {
     return request<T>("DELETE", path, undefined, options);

--- a/lib/auth/authApi.ts
+++ b/lib/auth/authApi.ts
@@ -1,21 +1,23 @@
 import { clientApi } from "@/lib/clientApi";
+import type { ApiEnvelope, LoginResponseData } from "@/lib/api-types";
 
-/** 이메일 로그인 */
 export async function loginWithEmail(email: string, password: string) {
-  await clientApi.post("/api/client/auth/login", { email, password });
+  const res = await clientApi.post<ApiEnvelope<LoginResponseData>>(
+    "/api/client/auth/login",
+    { email, password },
+  );
+
+  return res.data.data;
 }
 
-/** 이메일 인증 코드 전송 */
 export async function sendEmailAuthCode(email: string) {
   await clientApi.post("/api/client/auth/email/code", { email });
 }
 
-/** 이메일 인증 코드 검증 */
 export async function verifyEmailAuthCode(email: string, code: string) {
   await clientApi.post("/api/client/auth/email/verification", { email, code });
 }
 
-/** 이메일 회원가입 */
 export async function signupWithEmail(args: {
   email: string;
   password: string;
@@ -23,4 +25,8 @@ export async function signupWithEmail(args: {
 }) {
   const res = await clientApi.post("/api/client/auth/register", args);
   return res.data;
+}
+
+export async function reactivateAccount() {
+  await clientApi.post<ApiEnvelope<null>>("/api/client/reactivate");
 }


### PR DESCRIPTION
## 변경 사항
- 로그인 응답의 `userStatus`를 확인해 `DELETED_REQUESTED` 계정 분기를 추가
- 사용자가 확인하면 reactivate API를 호출하고, 취소/실패 시 로그아웃 및 에러 문구를 표시하도록 처리
- reactivate 프록시 라우트를 추가

## 검증
- `pnpm -s tsc --noEmit`
- 2026-03-15 실서버 연동 수동 검증
  - 확인창 노출 성공
  - 프런트 분기 동작 확인
  - 백엔드 `POST /api/harucut/reactivate` 응답은 `400 AUTH-005 DELETED_REQUEST_USER`

## 비고
- 프런트 구현은 완료됐고, 최종 완료는 백엔드 계약 수정이 필요
