### PR TITLE
[codex] Fix upload/shoot placeholder copy and guest auth check

### DIFF
--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET(req: Request) {
+  const cookieHeader = req.headers.get("cookie") ?? "";
+  const authenticated =
+    cookieHeader.includes("accessToken=") || cookieHeader.includes("refreshToken=");
+
+  return NextResponse.json({ authenticated });
+}

--- a/app/shoot/page.tsx
+++ b/app/shoot/page.tsx
@@ -54,8 +54,13 @@ function ShootPageContent() {
   return (
     <main className="min-h-dvh bg-zinc-950 px-2 py-6 text-white">
       <div className="mx-auto flex w-full max-w-md flex-col gap-4">
-        <PageHeader title="??" backHref="/home" backLabel="????" />
-        <StepProgress current={1} total={4} label="??? ??" />
+        <PageHeader
+          title="촬영"
+          backHref="/home"
+          backLabel="홈으로"
+          description="촬영할 프레임을 먼저 골라 주세요."
+        />
+        <StepProgress current={1} total={4} label="프레임 선택" />
 
         <FramePicker
           selectedFrameId={selectedFrameId}
@@ -64,13 +69,13 @@ function ShootPageContent() {
             setSelectedRemoteFrameId(null);
           }}
           onConfirm={handleConfirmFrame}
-          confirmLabel="? ????? ????"
+          confirmLabel="촬영 시작하기"
         />
 
         <SavedFramesSection
-          title="??? ???"
-          description="?? ??? ???? ??? ???? ?? ??? ??? ? ???."
-          emptyText="? ??? ???? ??? ???? ?? ???."
+          title="저장한 프레임"
+          description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 촬영할 수 있어요."
+          emptyText="이 타입으로 저장한 프레임이 아직 없어요."
           selectedFrameId={selectedFrameId}
           frames={frames}
           isLoading={isLoading}
@@ -81,8 +86,8 @@ function ShootPageContent() {
             setSelectedRemoteFrameId(frame.frameId);
           }}
           onRefresh={refresh}
-          selectedStatusText="?? ??"
-          idleStatusText="???? ??"
+          selectedStatusText="선택됨"
+          idleStatusText="클릭해서 선택"
         />
       </div>
     </main>

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -54,8 +54,13 @@ function UploadFramePageContent() {
   return (
     <main className="min-h-dvh bg-zinc-950 px-2 py-6 text-white">
       <div className="mx-auto flex w-full max-w-md flex-col gap-4">
-        <PageHeader title="???" backHref="/home" backLabel="????" />
-        <StepProgress current={1} total={3} label="??? ??" />
+        <PageHeader
+          title="업로드"
+          backHref="/home"
+          backLabel="홈으로"
+          description="업로드로 만들 프레임을 먼저 골라 주세요."
+        />
+        <StepProgress current={1} total={3} label="프레임 선택" />
 
         <FramePicker
           selectedFrameId={selectedFrameId}
@@ -64,13 +69,13 @@ function UploadFramePageContent() {
             setSelectedRemoteFrameId(null);
           }}
           onConfirm={handleConfirmFrame}
-          confirmLabel="? ????? ?????"
+          confirmLabel="업로드 시작하기"
         />
 
         <SavedFramesSection
-          title="??? ???"
-          description="?? ??? ???? ??? ???? ?? ??? ??? ? ???."
-          emptyText="? ??? ???? ??? ???? ?? ???."
+          title="저장한 프레임"
+          description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 만들 수 있어요."
+          emptyText="이 타입으로 저장한 프레임이 아직 없어요."
           selectedFrameId={selectedFrameId}
           frames={frames}
           isLoading={isLoading}
@@ -81,8 +86,8 @@ function UploadFramePageContent() {
             setSelectedRemoteFrameId(frame.frameId);
           }}
           onRefresh={refresh}
-          selectedStatusText="?? ??"
-          idleStatusText="???? ??"
+          selectedStatusText="선택됨"
+          idleStatusText="클릭해서 선택"
         />
       </div>
     </main>

--- a/components/frame/FrameSelectPanel.tsx
+++ b/components/frame/FrameSelectPanel.tsx
@@ -33,7 +33,7 @@ export function FrameSelectPanel({
   selectedIndexes,
   maxSelect,
   guideText,
-  emptyStateText = "??? ???",
+  emptyStateText = "선택 가능한 사진이나 영상이 아직 없어요.",
   nextButtonLabel,
   onToggleSelect,
   onReset,
@@ -65,8 +65,8 @@ export function FrameSelectPanel({
   const nextSlotIndex = selectedIndexes.findIndex((index) => index == null);
   const selectionHint =
     nextSlotIndex === -1
-      ? "??? ?? ????. ?? ????? ???? ?? ??? ?????."
-      : `${nextSlotIndex + 1}?? ?? ??? ??? ??? ????. ?? ??? ??? ????.`;
+      ? "선택이 모두 끝났어요. 다음 단계에서 결과를 확인해 보세요."
+      : `${nextSlotIndex + 1}번 칸에 넣을 미디어를 골라 주세요. 아래 목록에서 눌러 바로 채울 수 있어요.`;
 
   return (
     <div className="flex flex-col gap-4 xl:grid xl:grid-cols-[minmax(0,1fr)_320px] xl:items-start">
@@ -74,7 +74,7 @@ export function FrameSelectPanel({
         <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-sm font-semibold text-zinc-100">?? ??</p>
+              <p className="text-sm font-semibold text-zinc-100">선택 현황</p>
               <p className="mt-1 text-[11px] text-zinc-500">{guideText}</p>
             </div>
             <span className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-[10px] text-zinc-300">
@@ -89,15 +89,15 @@ export function FrameSelectPanel({
         <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-sm font-semibold text-zinc-100">?? ??</p>
+              <p className="text-sm font-semibold text-zinc-100">선택 슬롯</p>
               <p className="mt-1 text-[11px] text-zinc-500">
-                ???? ??? ???? ????? 1?, 2?, 3?, 4? ????.
+                선택한 순서대로 프레임의 1번, 2번, 3번, 4번 칸에 들어가요.
               </p>
             </div>
             {canProceed ? (
               <span className="inline-flex items-center gap-1 rounded-full border border-emerald-300/30 bg-emerald-400/10 px-2.5 py-1 text-[10px] text-emerald-100">
                 <CheckCircle2 className="h-3.5 w-3.5" />
-                ?? ??
+                선택 완료
               </span>
             ) : null}
           </div>
@@ -117,7 +117,7 @@ export function FrameSelectPanel({
                   ].join(" ")}
                 >
                   <div className="absolute left-2 top-2 z-10 rounded-full bg-black/70 px-2 py-1 text-[10px] text-zinc-100">
-                    {slotIndex + 1}?
+                    {slotIndex + 1}번
                   </div>
 
                   {item ? (
@@ -147,13 +147,13 @@ export function FrameSelectPanel({
                           className="absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/70 px-2 py-1 text-[10px] text-zinc-100 hover:bg-black/80"
                         >
                           <X className="h-3.5 w-3.5" />
-                          ??
+                          해제
                         </button>
                       ) : null}
                     </>
                   ) : (
                     <div className="grid aspect-[3/4] place-items-center px-3 text-center text-[11px] text-zinc-500">
-                      {isActive ? "?? ?? ????" : "?? ?? ???"}
+                      {isActive ? "다음 선택 칸" : "선택 대기"}
                     </div>
                   )}
                 </div>
@@ -205,7 +205,7 @@ export function FrameSelectPanel({
                     )}
 
                     <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent px-2 py-2 text-[10px] text-zinc-100">
-                      {isSelected ? `${order}?? ?? ???` : "??? ??"}
+                      {isSelected ? `${order}번 칸에 배치` : "선택 가능"}
                     </div>
 
                     <span className="pointer-events-none absolute left-1 top-1 rounded-full bg-black/70 px-1.5 py-0.5 text-[9px] text-zinc-200">
@@ -231,7 +231,7 @@ export function FrameSelectPanel({
             className="inline-flex w-fit items-center gap-1 rounded-full border border-zinc-700 px-2.5 py-1.5 text-[10px] text-zinc-400 hover:bg-zinc-900"
           >
             <RotateCcw className="h-3.5 w-3.5" />
-            ???? ??
+            선택 초기화
           </button>
 
           <button
@@ -248,7 +248,7 @@ export function FrameSelectPanel({
       <aside className="flex flex-col gap-3 xl:sticky xl:top-6">
         {frameId ? (
           <section className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3">
-            <p className="text-[11px] font-medium text-zinc-200">??? ????</p>
+            <p className="text-[11px] font-medium text-zinc-200">프레임 미리보기</p>
             <div className="flex justify-center">
               <FramePreview
                 frameId={frameId}

--- a/hooks/useRedirectIfAuthenticated.ts
+++ b/hooks/useRedirectIfAuthenticated.ts
@@ -12,9 +12,9 @@ export function useRedirectIfAuthenticated(targetPath: string = "/home") {
   useEffect(() => {
     let cancelled = false;
 
-    const checkAuth = async () => {
+    const checkSession = async () => {
       try {
-        const res = await fetch("/api/client/user-info", {
+        const res = await fetch("/api/auth/session", {
           method: "GET",
           credentials: "include",
           cache: "no-store",
@@ -22,13 +22,16 @@ export function useRedirectIfAuthenticated(targetPath: string = "/home") {
 
         if (!res.ok || cancelled) return;
 
+        const data = (await res.json()) as { authenticated?: boolean };
+        if (!data.authenticated) return;
+
         router.replace(targetPath);
       } catch (error) {
-        console.error("Failed to verify auth status", error);
+        console.error("Failed to verify auth session", error);
       }
     };
 
-    checkAuth();
+    void checkSession();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
﻿## Summary
- replace leftover `???` placeholder copy on upload and shoot entry pages
- replace placeholder state text in the frame selection panel with production Korean labels
- add a lightweight auth session endpoint so guest redirects do not trigger avoidable `AUTH-001` 400 responses on login and signup screens

## Why
The upload and shoot entry flow still exposed placeholder text in user-facing UI. Separately, unauthenticated users redirected from protected routes were landing on login/signup while the frontend probed `/api/client/user-info`, which created noisy 400 responses in the browser console even though the page rendered correctly.

## Impact
- upload/shoot/frame selection entry UX is readable and release-safe
- login and signup pages no longer emit guest auth noise during redirect checks
- auth redirect behavior stays the same for signed-in users

## Root cause
- placeholder copy from an unfinished UI pass remained in entry and selection surfaces
- redirect guard logic used a backend user-info request for a simple guest/session presence check

## Validation
- `pnpm lint`
- `pnpm test -- FrameSelectPanel --runInBand`
- `pnpm build`

Closes #160
