### PR TITLE
[codex] fix upload source media before frame generation

### DIFF
--- a/app/upload/select/page.test.tsx
+++ b/app/upload/select/page.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import UploadSelectPage from "@/app/upload/select/page";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+const mockAddMedia = jest.fn();
+const mockUploadFourcutMedia = jest.fn();
+
+const uploadSessionState = {
+  frameId: "classic-4",
+  remoteFrameId: null as number | null,
+  media: [] as Array<{ type: "image" | "video"; src: string }>,
+  selectedIndexes: [null, null, null, null] as Array<number | null>,
+  borderColor: "#111827",
+  outputFilter: "NONE",
+  includeVideo: false,
+  toggleSelect: jest.fn(),
+  resetAll: jest.fn(),
+  addMedia: mockAddMedia,
+  setBorderColor: jest.fn(),
+  setOutputFilter: jest.fn(),
+  setIncludeVideo: jest.fn(),
+};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+jest.mock("@/components/layout/PageHeader", () => ({
+  PageHeader: () => <div data-testid="page-header" />,
+}));
+
+jest.mock("@/components/frame/FrameOutputOptionsPanel", () => ({
+  FrameOutputOptionsPanel: () => <div data-testid="frame-output-options" />,
+}));
+
+jest.mock("@/components/frame/FrameSelectPanel", () => ({
+  FrameSelectPanel: ({
+    renderExtraControls,
+  }: {
+    renderExtraControls?: () => React.ReactNode;
+  }) => <div>{renderExtraControls?.()}</div>,
+}));
+
+jest.mock("@/hooks/useRemoteFrameTheme", () => ({
+  useRemoteFrameTheme: () => null,
+}));
+
+jest.mock("@/lib/themeBackground", () => ({
+  resolveFrameBackgroundColor: (_theme: unknown, borderColor: string) => borderColor,
+}));
+
+jest.mock("@/lib/videoConversionQuotaStore", () => ({
+  useVideoConversionQuotaStore: (selector: (state: { usedCount: number; limit: number }) => unknown) =>
+    selector({ usedCount: 0, limit: 3 }),
+}));
+
+jest.mock("@/lib/uploadSessionStore", () => ({
+  useUploadSession: () => uploadSessionState,
+}));
+
+jest.mock("@/lib/presignedUploadApi", () => ({
+  SUPPORTED_FOURCUT_ACCEPT: "image/png,video/mp4,video/webm",
+  uploadFourcutMedia: (...args: unknown[]) => mockUploadFourcutMedia(...args),
+}));
+
+describe("UploadSelectPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uploadSessionState.media = [];
+    uploadSessionState.selectedIndexes = [null, null, null, null];
+    uploadSessionState.frameId = "classic-4";
+  });
+
+  it("uploads selected files before adding them to the session", async () => {
+    mockUploadFourcutMedia.mockResolvedValueOnce({
+      mediaId: 11,
+      objectUrl: "https://example.com/source.png",
+      downloadUrl: "https://example.com/source.png?sig=1",
+    });
+
+    const { container } = render(<UploadSelectPage />);
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+
+    expect(input).not.toBeNull();
+
+    const file = new File(["image"], "source.png", { type: "image/png" });
+    fireEvent.change(input as HTMLInputElement, {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(mockUploadFourcutMedia).toHaveBeenCalledWith(file);
+    });
+
+    await waitFor(() => {
+      expect(mockAddMedia).toHaveBeenCalledWith([
+        { type: "image", src: "https://example.com/source.png?sig=1" },
+      ]);
+    });
+  });
+});

--- a/app/upload/select/page.tsx
+++ b/app/upload/select/page.tsx
@@ -1,13 +1,16 @@
 ﻿"use client";
 
-import { useEffect, useMemo, useRef, type ChangeEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
 import { FrameOutputOptionsPanel } from "@/components/frame/FrameOutputOptionsPanel";
 import { FrameSelectPanel } from "@/components/frame/FrameSelectPanel";
 import type { FrameMedia } from "@/components/frame/FramePreview";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
-import { SUPPORTED_FOURCUT_ACCEPT } from "@/lib/presignedUploadApi";
+import {
+  SUPPORTED_FOURCUT_ACCEPT,
+  uploadFourcutMedia,
+} from "@/lib/presignedUploadApi";
 import { resolveFrameBackgroundColor } from "@/lib/themeBackground";
 import { useUploadSession } from "@/lib/uploadSessionStore";
 import { useVideoConversionQuotaStore } from "@/lib/videoConversionQuotaStore";
@@ -33,6 +36,8 @@ export default function UploadSelectPage() {
   const usedVideoConversions = useVideoConversionQuotaStore((state) => state.usedCount);
   const videoConversionLimit = useVideoConversionQuotaStore((state) => state.limit);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isUploadingFiles, setIsUploadingFiles] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!frameId) {
@@ -71,30 +76,47 @@ export default function UploadSelectPage() {
     fileInputRef.current?.click();
   };
 
-  const handleChangeFiles = (event: ChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files;
-    if (!files || files.length === 0) return;
-
-    const items: FrameMedia[] = Array.from(files)
-      .map((file) => {
-        const url = URL.createObjectURL(file);
-
-        if (file.type.startsWith("image/")) {
-          return { type: "image" as const, src: url };
-        }
-
-        if (file.type.startsWith("video/")) {
-          return { type: "video" as const, src: url };
-        }
-
-        return null;
-      })
-      .filter((value): value is FrameMedia => value !== null);
-
-    if (items.length === 0) return;
-
-    addMedia(items);
+  const handleChangeFiles = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
     event.target.value = "";
+
+    if (files.length === 0) return;
+
+    setUploadError(null);
+    setIsUploadingFiles(true);
+
+    const uploadResults = await Promise.allSettled(
+      files.map(async (file) => {
+        if (!file.type.startsWith("image/") && !file.type.startsWith("video/")) {
+          throw new Error(`Unsupported upload file type: ${file.type || file.name}`);
+        }
+
+        const uploaded = await uploadFourcutMedia(file);
+
+        return {
+          type: file.type.startsWith("video/") ? "video" : "image",
+          src: uploaded.downloadUrl ?? uploaded.objectUrl,
+        } satisfies FrameMedia;
+      }),
+    );
+
+    const items = uploadResults.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value] : [],
+    );
+
+    const failedCount = uploadResults.length - items.length;
+
+    if (items.length > 0) {
+      addMedia(items);
+    }
+
+    if (failedCount === files.length) {
+      setUploadError("사진이나 영상을 업로드하지 못했어요. 다시 시도해 주세요.");
+    } else if (failedCount > 0) {
+      setUploadError(`${failedCount}개 파일은 업로드하지 못했어요. 다시 시도해 주세요.`);
+    }
+
+    setIsUploadingFiles(false);
   };
 
   const handleNext = () => {
@@ -135,9 +157,10 @@ export default function UploadSelectPage() {
               <button
                 type="button"
                 onClick={handleClickUpload}
-                className="h-9 rounded-full bg-zinc-800 text-[11px] font-medium text-zinc-100 hover:bg-zinc-700"
+                disabled={isUploadingFiles}
+                className="h-9 rounded-full bg-zinc-800 text-[11px] font-medium text-zinc-100 hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                사진 또는 영상 추가하기
+                {isUploadingFiles ? "업로드 중..." : "사진 또는 영상 추가하기"}
               </button>
 
               <input
@@ -152,6 +175,10 @@ export default function UploadSelectPage() {
               <p className="text-[10px] text-zinc-500">
                 여러 파일을 한 번에 넣고 프레임에 어울릴 4개를 선택할 수 있어요.
               </p>
+
+              {uploadError ? (
+                <p className="text-[10px] text-rose-300">{uploadError}</p>
+              ) : null}
 
               <FrameOutputOptionsPanel
                 borderColor={borderColor}

--- a/lib/presignedUploadApi.test.ts
+++ b/lib/presignedUploadApi.test.ts
@@ -199,19 +199,41 @@ describe("presigned upload flow", () => {
         headers: new Headers(),
       });
 
-    mockGet.mockResolvedValueOnce({
-      data: {
-        code: "GEN-000",
-        status: 200,
-        message: null,
+    mockGet
+      .mockResolvedValueOnce({
         data: {
-          downloadUrl: "https://example.com/video.webm?sig=3",
+          code: "GEN-000",
+          status: 200,
+          message: null,
+          data: {
+            downloadUrl: "https://example.com/video.webm?sig=3",
+          },
         },
-      },
-      ok: true,
-      status: 200,
-      headers: new Headers(),
-    });
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+      })
+      .mockResolvedValueOnce({
+        data: {
+          code: "GEN-000",
+          status: 200,
+          message: null,
+          data: {
+            taskId: "task-1",
+            jobId: "job-1",
+            status: "COMPLETE",
+            media: {
+              mediaId: 8,
+              mediaType: "VIDEO",
+              s3Key: "uploads/users/u/video.mp4",
+              downloadUrl,
+            },
+          },
+        },
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+      });
 
     (global.fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
@@ -226,7 +248,7 @@ describe("presigned upload flow", () => {
       filename: "video.webm",
     });
     expect(result).toEqual({
-      key,
+      key: "uploads/users/u/video.mp4",
       mediaId: 8,
       objectUrl: downloadUrl,
       downloadUrl,


### PR DESCRIPTION
## What changed
- upload selected source files immediately on `/upload/select` instead of storing only local `blob:` URLs in session state
- store the uploaded remote media URLs back into the upload session so selected photos and videos are registered in user media history
- add coverage for the upload-select flow and align the WEBM transcode test with the current polling/result behavior

## Why
The upload flow only registered the generated four-cut result. Selected source photos were kept as local object URLs, so they never reached backend media registration and only the frame output appeared in history.

## Impact
Users now get their uploaded source photos or videos persisted as media records before generating the final frame, so history is no longer missing the original uploads.

## Validation
- `pnpm test -- app/upload/select/page.test.tsx lib/presignedUploadApi.test.ts`
