### PR TITLE
[codex] fix desktop select page width

### DIFF
--- a/app/shoot/select/page.tsx
+++ b/app/shoot/select/page.tsx
@@ -70,7 +70,7 @@ export default function ShootSelectPage() {
 
   return (
     <main className="min-h-dvh bg-zinc-950 px-4 py-6 text-white">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-5">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
         <PageHeader
           title="사진 선택"
           backHref="/shoot/capture"

--- a/app/upload/select/page.tsx
+++ b/app/upload/select/page.tsx
@@ -104,7 +104,7 @@ export default function UploadSelectPage() {
 
   return (
     <main className="min-h-dvh bg-zinc-950 px-4 py-6 text-white">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-5">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
         <PageHeader
           title="업로드할 사진 선택"
           backHref="/upload"


### PR DESCRIPTION
## What changed
- widen the top-level content wrapper on `/upload/select` and `/shoot/select` from a mobile-width container to a desktop-width container
- keep the existing selection panel behavior and session guards unchanged

## Why
The select pages were still constrained to a phone-sized layout on desktop, so the panel never used the available screen width.

## Issue
- closes #166

## Validation
- `pnpm test -- app/session-guards.test.tsx`
