### PR TITLE
[codex] widen select pages on desktop

### DIFF
--- a/app/shoot/select/page.tsx
+++ b/app/shoot/select/page.tsx
@@ -70,7 +70,7 @@ export default function ShootSelectPage() {
 
   return (
     <main className="min-h-dvh bg-zinc-950 px-4 py-6 text-white">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-5">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
         <PageHeader
           title="사진 선택"
           backHref="/shoot/capture"

--- a/app/upload/select/page.tsx
+++ b/app/upload/select/page.tsx
@@ -104,7 +104,7 @@ export default function UploadSelectPage() {
 
   return (
     <main className="min-h-dvh bg-zinc-950 px-4 py-6 text-white">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-5">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
         <PageHeader
           title="업로드할 사진 선택"
           backHref="/upload"


### PR DESCRIPTION
## What changed
- expand `/upload/select` and `/shoot/select` to use a desktop-width container on large screens
- keep the mobile layout and selection flow unchanged on smaller screens

## Why
The select pages stayed inside a narrow phone-width wrapper even on desktop, which made the experience feel unnecessarily constrained.

## Issue
- closes #166

## Validation
- `pnpm test -- app/session-guards.test.tsx`
