### PR TITLE
[codex] show plan limit guidance for 403 responses

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   Share2,
 } from "lucide-react";
+import { getUserFacingApiErrorMessage } from "@/lib/apiError";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { downloadFromUrl } from "@/lib/canvas/composeFrame";
 import { buildDownloadFilename } from "@/lib/fourcutOutput";
@@ -84,7 +85,9 @@ export default function HistoryPage() {
       } catch (loadError) {
         console.error(loadError);
         if (!cancelled) {
-          setError("기록을 불러오지 못했어요.");
+          setError(
+            getUserFacingApiErrorMessage(loadError, "기록을 불러오지 못했어요."),
+          );
         }
       } finally {
         if (!cancelled) {
@@ -149,7 +152,12 @@ export default function HistoryPage() {
       );
     } catch (downloadError) {
       console.error(downloadError);
-      alert("다운로드에 실패했어요.");
+      alert(
+        getUserFacingApiErrorMessage(
+          downloadError,
+          "다운로드를 준비하지 못했어요.",
+        ),
+      );
     } finally {
       setDownloadingId(null);
     }
@@ -173,7 +181,12 @@ export default function HistoryPage() {
       }
     } catch (shareError) {
       console.error(shareError);
-      alert("공유 링크를 준비하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(
+          shareError,
+          "공유 링크를 준비하지 못했어요.",
+        ),
+      );
     } finally {
       setSharingId(null);
     }

--- a/app/shoot/result/page.tsx
+++ b/app/shoot/result/page.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { StepProgress } from "@/components/layout/StepProgress";
 import { FRAME_CONFIGS, type FrameId } from "@/constants/frames";
 import { FRAME_LAYOUTS } from "@/constants/frameLayouts";
+import { getUserFacingApiErrorMessage } from "@/lib/apiError";
 import {
   composeFramePng,
   downloadFromUrl,
@@ -367,7 +368,9 @@ export default function ShootResultPage() {
       );
     } catch (error) {
       console.error(error);
-      alert("이미지를 다운로드하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "이미지를 다운로드하지 못했어요."),
+      );
     } finally {
       setIsDownloadingImage(false);
     }
@@ -385,7 +388,9 @@ export default function ShootResultPage() {
       );
     } catch (error) {
       console.error(error);
-      alert("영상을 다운로드하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "영상을 다운로드하지 못했어요."),
+      );
     } finally {
       setIsDownloadingVideo(false);
     }
@@ -408,7 +413,9 @@ export default function ShootResultPage() {
       }
     } catch (error) {
       console.error(error);
-      alert("이미지 링크를 준비하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "이미지 링크를 준비하지 못했어요."),
+      );
     } finally {
       setIsSharingImage(false);
     }
@@ -431,7 +438,9 @@ export default function ShootResultPage() {
       }
     } catch (error) {
       console.error(error);
-      alert("영상 링크를 준비하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "영상 링크를 준비하지 못했어요."),
+      );
     } finally {
       setIsSharingVideo(false);
     }

--- a/app/upload/result/page.tsx
+++ b/app/upload/result/page.tsx
@@ -9,6 +9,7 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { StepProgress } from "@/components/layout/StepProgress";
 import { FRAME_CONFIGS, type FrameId } from "@/constants/frames";
 import { FRAME_LAYOUTS } from "@/constants/frameLayouts";
+import { getUserFacingApiErrorMessage } from "@/lib/apiError";
 import {
   composeFramePng,
   downloadFromUrl,
@@ -364,7 +365,9 @@ export default function UploadResultPage() {
       );
     } catch (error) {
       console.error(error);
-      alert("이미지를 다운로드하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "이미지를 다운로드하지 못했어요."),
+      );
     } finally {
       setIsDownloadingImage(false);
     }
@@ -382,7 +385,9 @@ export default function UploadResultPage() {
       );
     } catch (error) {
       console.error(error);
-      alert("영상을 다운로드하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "영상을 다운로드하지 못했어요."),
+      );
     } finally {
       setIsDownloadingVideo(false);
     }
@@ -405,7 +410,9 @@ export default function UploadResultPage() {
       }
     } catch (error) {
       console.error(error);
-      alert("이미지 링크를 준비하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "이미지 링크를 준비하지 못했어요."),
+      );
     } finally {
       setIsSharingImage(false);
     }
@@ -428,7 +435,9 @@ export default function UploadResultPage() {
       }
     } catch (error) {
       console.error(error);
-      alert("영상 링크를 준비하지 못했어요.");
+      alert(
+        getUserFacingApiErrorMessage(error, "영상 링크를 준비하지 못했어요."),
+      );
     } finally {
       setIsSharingVideo(false);
     }

--- a/components/theme/editor/ThemeEditorPage.test.tsx
+++ b/components/theme/editor/ThemeEditorPage.test.tsx
@@ -14,6 +14,7 @@ const mockDeleteFrame = jest.fn();
 const mockGetFrame = jest.fn();
 const mockUploadPresigned = jest.fn();
 const mockRenderPreview = jest.fn();
+const mockAlert = jest.fn();
 
 let mockRemoteFrameId: number | null = null;
 
@@ -112,6 +113,7 @@ jest.mock("@/lib/canvas/renderThemePreview", () => ({
 describe("ThemeEditorPage save flow", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.alert = mockAlert;
     mockRemoteFrameId = null;
     editorStoreState.components = [];
     editorStoreState.background = { type: "COLOR", value: "111827" };
@@ -184,5 +186,26 @@ describe("ThemeEditorPage save flow", () => {
 
     expect(mockUpdateFrame).not.toHaveBeenCalled();
     expect(mockCreateFrame).not.toHaveBeenCalled();
+  });
+
+  it("shows the plan limit message when frame creation is rejected with USR-102", async () => {
+    mockCreateFrame.mockRejectedValueOnce({
+      status: 403,
+      data: {
+        code: "USR-102",
+        status: 403,
+        message: "요금제의 월간 프레임 생성 횟수를 초과했습니다.",
+      },
+    });
+
+    const { container } = render(<ThemeEditorPage frameId="classic-4" />);
+
+    fireEvent.click(getPrimarySaveButton(container));
+
+    await waitFor(() => {
+      expect(mockAlert).toHaveBeenCalledWith(
+        "요금제의 월간 프레임 생성 횟수를 초과했습니다.",
+      );
+    });
   });
 });

--- a/components/theme/editor/ThemeEditorPage.tsx
+++ b/components/theme/editor/ThemeEditorPage.tsx
@@ -21,6 +21,7 @@ import {
   uploadToS3WithPresigned,
 } from "@/lib/presignedUploadApi";
 import { renderThemePreviewPng } from "@/lib/canvas/renderThemePreview";
+import { getUserFacingApiErrorMessage } from "@/lib/apiError";
 import { useThemeEditorStore } from "@/lib/themeEditorStore";
 import { useThemeSession } from "@/lib/themeSessionStore";
 import { useThemeDraftStore } from "@/lib/themeDraftStore";
@@ -148,7 +149,7 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
       router.push("/theme");
     } catch (error) {
       console.error(error);
-      alert("저장에 실패했습니다.");
+      alert(getUserFacingApiErrorMessage(error, "저장에 실패했습니다."));
     } finally {
       setIsSaving(false);
     }

--- a/lib/apiError.test.ts
+++ b/lib/apiError.test.ts
@@ -1,0 +1,36 @@
+import { getApiErrorDetails, getUserFacingApiErrorMessage } from "@/lib/apiError";
+
+describe("apiError helpers", () => {
+  it("extracts code and message from nested API envelope data", () => {
+    const details = getApiErrorDetails({
+      status: 403,
+      data: {
+        code: "USR-101",
+        status: 403,
+        message: "요금제의 월간 영상 다운로드 횟수를 초과했습니다.",
+      },
+    });
+
+    expect(details).toEqual({
+      status: 403,
+      code: "USR-101",
+      message: "요금제의 월간 영상 다운로드 횟수를 초과했습니다.",
+    });
+  });
+
+  it("prioritizes known plan-limit guidance over generic fallback text", () => {
+    const message = getUserFacingApiErrorMessage(
+      {
+        status: 403,
+        data: {
+          code: "USR-102",
+          status: 403,
+          message: "backend raw message",
+        },
+      },
+      "저장에 실패했습니다.",
+    );
+
+    expect(message).toBe("요금제의 월간 프레임 생성 횟수를 초과했습니다.");
+  });
+});

--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -1,0 +1,70 @@
+"use client";
+
+const PLAN_ERROR_MESSAGES = {
+  "USR-101": "요금제의 월간 영상 다운로드 횟수를 초과했습니다.",
+  "USR-102": "요금제의 월간 프레임 생성 횟수를 초과했습니다.",
+  "USR-103": "요금제에서 허용한 기록 조회 기간을 초과했습니다.",
+} as const;
+
+type ApiErrorDetails = {
+  status?: number;
+  code?: string;
+  message?: string | null;
+};
+
+function asRecord(value: unknown) {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function getApiErrorDetails(error: unknown): ApiErrorDetails {
+  const record = asRecord(error);
+  if (!record) {
+    return {};
+  }
+
+  const data = asRecord(record.data);
+
+  const status =
+    typeof record.status === "number"
+      ? record.status
+      : typeof data?.status === "number"
+        ? data.status
+        : undefined;
+
+  const code =
+    typeof record.code === "string"
+      ? record.code
+      : typeof data?.code === "string"
+        ? data.code
+        : undefined;
+
+  const message =
+    typeof record.apiMessage === "string" || record.apiMessage === null
+      ? (record.apiMessage as string | null)
+      : typeof record.message === "string" || record.message === null
+        ? (record.message as string | null)
+        : typeof data?.message === "string" || data?.message === null
+          ? (data.message as string | null)
+          : undefined;
+
+  return { status, code, message };
+}
+
+export function getUserFacingApiErrorMessage(
+  error: unknown,
+  fallback: string,
+) {
+  const { code, message } = getApiErrorDetails(error);
+
+  if (code && code in PLAN_ERROR_MESSAGES) {
+    return PLAN_ERROR_MESSAGES[code as keyof typeof PLAN_ERROR_MESSAGES];
+  }
+
+  if (message?.trim()) {
+    return message;
+  }
+
+  return fallback;
+}

--- a/lib/clientApi.ts
+++ b/lib/clientApi.ts
@@ -1,5 +1,11 @@
 "use client";
 
+type ApiEnvelopeLike = {
+  code?: string;
+  status?: number;
+  message?: string | null;
+};
+
 type ApiResult<T> = {
   data: T;
   ok: boolean;
@@ -12,6 +18,41 @@ type ApiOptions = {
   cache?: RequestCache;
   signal?: AbortSignal;
 };
+
+function extractEnvelopeLike(value: unknown): ApiEnvelopeLike | null {
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  return {
+    code: typeof record.code === "string" ? record.code : undefined,
+    status: typeof record.status === "number" ? record.status : undefined,
+    message:
+      typeof record.message === "string" || record.message === null
+        ? (record.message as string | null)
+        : undefined,
+  };
+}
+
+export class ApiRequestError<T = unknown> extends Error {
+  status?: number;
+  data?: T;
+  code?: string;
+  apiMessage?: string | null;
+
+  constructor(args: {
+    status?: number;
+    data?: T;
+    code?: string;
+    apiMessage?: string | null;
+  }) {
+    super(args.apiMessage || "API request failed");
+    this.name = "ApiRequestError";
+    this.status = args.status;
+    this.data = args.data;
+    this.code = args.code;
+    this.apiMessage = args.apiMessage;
+  }
+}
 
 async function request<T>(
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
@@ -46,10 +87,13 @@ async function request<T>(
   }
 
   if (!res.ok) {
-    const error = new Error("API request failed");
-    (error as { status?: number }).status = res.status;
-    (error as { data?: T }).data = data;
-    throw error;
+    const envelope = extractEnvelopeLike(data);
+    throw new ApiRequestError<T>({
+      status: res.status,
+      data,
+      code: envelope?.code,
+      apiMessage: envelope?.message,
+    });
   }
 
   return {


### PR DESCRIPTION
## What changed
- add a shared API error helper that extracts backend error code/message from non-2xx responses
- map `USR-101`, `USR-102`, and `USR-103` to user-facing plan-limit guidance
- surface those messages in frame save, history load, and media download/share flows instead of generic failure alerts
- add tests for the error helper and the frame-save `USR-102` path

## Why
The backend returns 403 for plan-limit rejections, but the frontend treated those responses as generic failures, so users could not tell whether they hit a plan rule or a real error.

## Issue
- closes #169

## Validation
- `pnpm test -- lib/apiError.test.ts components/theme/editor/ThemeEditorPage.test.tsx`
- `pnpm test -- app/session-guards.test.tsx`
