### PR TITLE
[codex] send displayName for generated media registration

### DIFF
--- a/lib/fourcutOutput.ts
+++ b/lib/fourcutOutput.ts
@@ -19,10 +19,26 @@ export function sanitizeDisplayName(input: string, fallback: string) {
   return normalized || fallback;
 }
 
+function pad2(value: number) {
+  return String(value).padStart(2, "0");
+}
+
 export function buildDefaultDisplayName(frameName: string, kind: GeneratedFourcutAsset["kind"]) {
-  const safeFrameName = sanitizeDisplayName(frameName, "harucut").replace(/\s+/g, "_");
+  void frameName;
   void kind;
-  return `${safeFrameName}-${Date.now()}`;
+  const now = new Date();
+  const formatted = [
+    now.getFullYear(),
+    pad2(now.getMonth() + 1),
+    pad2(now.getDate()),
+  ].join("");
+  const time = [
+    pad2(now.getHours()),
+    pad2(now.getMinutes()),
+    pad2(now.getSeconds()),
+  ].join("");
+
+  return `harucut_${formatted}_${time}`;
 }
 
 export function buildDownloadFilename(

--- a/lib/fourcutProcessing.ts
+++ b/lib/fourcutProcessing.ts
@@ -27,6 +27,10 @@ function resolveInitialDisplayName(args: {
   objectUrl?: string;
   fallbackName: string;
 }) {
+  if (args.fallbackName.trim()) {
+    return sanitizeDisplayName(args.fallbackName, "harucut");
+  }
+
   const filename =
     extractFilenameFromUrlLike(args.downloadUrl) ??
     extractFilenameFromUrlLike(args.objectUrl);
@@ -45,7 +49,9 @@ export async function uploadGeneratedFourcutFile(args: {
   extension: GeneratedFourcutAsset["extension"];
 }) {
   const { file, kind, extension } = args;
-  const uploaded = await uploadFourcutMedia(file);
+  const uploaded = await uploadFourcutMedia(file, {
+    displayName: args.displayName,
+  });
   const displayName = resolveInitialDisplayName({
     downloadUrl: uploaded.downloadUrl,
     objectUrl: uploaded.objectUrl,

--- a/lib/presignedUploadApi.ts
+++ b/lib/presignedUploadApi.ts
@@ -7,7 +7,7 @@ import type {
   TranscodeTaskSubmitResponse,
 } from "@/lib/api-types";
 import { clientApi } from "@/lib/clientApi";
-import { registerUserMedia } from "@/lib/userMediaApi";
+import { registerUserMedia, updateMediaDisplayName } from "@/lib/userMediaApi";
 
 type PresignedUploadData = {
   key: string;
@@ -215,7 +215,10 @@ export function resolveFourcutUploadType(file: File): PresignedUploadType {
     : PRESIGNED_UPLOAD_TYPES.FOURCUT_PHOTO;
 }
 
-export async function uploadFourcutMedia(file: File) {
+export async function uploadFourcutMedia(
+  file: File,
+  opts: { displayName?: string } = {},
+) {
   const contentType = resolveUploadContentType(file);
   const uploaded = await uploadToS3WithPresigned({
     file,
@@ -227,6 +230,7 @@ export async function uploadFourcutMedia(file: File) {
     const media = await registerUserMedia({
       mediaType: "PHOTO",
       s3Key: uploaded.key,
+      ...(opts.displayName ? { displayName: opts.displayName } : {}),
     });
 
     return {
@@ -240,18 +244,23 @@ export async function uploadFourcutMedia(file: File) {
   if (contentType === "WEBM") {
     const task = await requestTranscode(uploaded.key);
     const media = await waitForTranscodeMedia(task.taskId);
+    const resolvedMedia =
+      opts.displayName && media.mediaId
+        ? await updateMediaDisplayName(media.mediaId, opts.displayName)
+        : media;
 
     return {
-      key: media.s3Key ?? uploaded.key,
-      mediaId: media.mediaId,
-      objectUrl: media.downloadUrl ?? uploaded.objectUrl,
-      downloadUrl: media.downloadUrl ?? uploaded.downloadUrl,
+      key: resolvedMedia.s3Key ?? uploaded.key,
+      mediaId: resolvedMedia.mediaId,
+      objectUrl: resolvedMedia.downloadUrl ?? uploaded.objectUrl,
+      downloadUrl: resolvedMedia.downloadUrl ?? uploaded.downloadUrl,
     };
   }
 
   const media = await registerUserMedia({
     mediaType: "VIDEO",
     s3Key: uploaded.key,
+    ...(opts.displayName ? { displayName: opts.displayName } : {}),
   });
 
   return {

--- a/lib/userMediaApi.ts
+++ b/lib/userMediaApi.ts
@@ -14,6 +14,7 @@ export async function listMyMedia(type?: UserMediaType) {
 export async function registerUserMedia(args: {
   mediaType: UserMediaType;
   s3Key: string;
+  displayName?: string;
 }) {
   const res = await clientApi.post<ApiEnvelope<UserMedia>>("/api/client/user/media", args);
   return res.data.data;


### PR DESCRIPTION
## What changed
- include `displayName` in generated media registration payloads to `/api/auth/user/media`
- use a unified generated result naming format: `harucut_YYYYMMDD_HHMMSS`
- preserve that display name in the returned generated asset state instead of falling back to URL-derived names
- apply the same display name after WEBM transcode completes

## Why
Generated image and video results should be registered with the intended display name at creation time so history and downloads stay consistent.

## Issue
- closes #172

## Validation
- not run
