### PR TITLE
[codex] keep upload source media local until result generation

### DIFF
--- a/app/upload/select/page.test.tsx
+++ b/app/upload/select/page.test.tsx
@@ -1,10 +1,10 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import UploadSelectPage from "@/app/upload/select/page";
 
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
 const mockAddMedia = jest.fn();
-const mockUploadFourcutMedia = jest.fn();
+const mockCreateObjectURL = jest.fn();
 
 const uploadSessionState = {
   frameId: "classic-4",
@@ -61,24 +61,19 @@ jest.mock("@/lib/uploadSessionStore", () => ({
 
 jest.mock("@/lib/presignedUploadApi", () => ({
   SUPPORTED_FOURCUT_ACCEPT: "image/png,video/mp4,video/webm",
-  uploadFourcutMedia: (...args: unknown[]) => mockUploadFourcutMedia(...args),
 }));
 
 describe("UploadSelectPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue("blob:preview-image");
+    URL.createObjectURL = mockCreateObjectURL;
     uploadSessionState.media = [];
     uploadSessionState.selectedIndexes = [null, null, null, null];
     uploadSessionState.frameId = "classic-4";
   });
 
-  it("uploads selected files before adding them to the session", async () => {
-    mockUploadFourcutMedia.mockResolvedValueOnce({
-      mediaId: 11,
-      objectUrl: "https://example.com/source.png",
-      downloadUrl: "https://example.com/source.png?sig=1",
-    });
-
+  it("adds selected files as local preview media without uploading them", () => {
     const { container } = render(<UploadSelectPage />);
     const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
 
@@ -89,14 +84,9 @@ describe("UploadSelectPage", () => {
       target: { files: [file] },
     });
 
-    await waitFor(() => {
-      expect(mockUploadFourcutMedia).toHaveBeenCalledWith(file);
-    });
-
-    await waitFor(() => {
-      expect(mockAddMedia).toHaveBeenCalledWith([
-        { type: "image", src: "https://example.com/source.png?sig=1" },
-      ]);
-    });
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(file);
+    expect(mockAddMedia).toHaveBeenCalledWith([
+      { type: "image", src: "blob:preview-image" },
+    ]);
   });
 });

--- a/app/upload/select/page.tsx
+++ b/app/upload/select/page.tsx
@@ -1,16 +1,13 @@
 ﻿"use client";
 
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { useEffect, useMemo, useRef, type ChangeEvent } from "react";
 import { useRouter } from "next/navigation";
 import { FrameOutputOptionsPanel } from "@/components/frame/FrameOutputOptionsPanel";
 import { FrameSelectPanel } from "@/components/frame/FrameSelectPanel";
 import type { FrameMedia } from "@/components/frame/FramePreview";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
-import {
-  SUPPORTED_FOURCUT_ACCEPT,
-  uploadFourcutMedia,
-} from "@/lib/presignedUploadApi";
+import { SUPPORTED_FOURCUT_ACCEPT } from "@/lib/presignedUploadApi";
 import { resolveFrameBackgroundColor } from "@/lib/themeBackground";
 import { useUploadSession } from "@/lib/uploadSessionStore";
 import { useVideoConversionQuotaStore } from "@/lib/videoConversionQuotaStore";
@@ -36,8 +33,6 @@ export default function UploadSelectPage() {
   const usedVideoConversions = useVideoConversionQuotaStore((state) => state.usedCount);
   const videoConversionLimit = useVideoConversionQuotaStore((state) => state.limit);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [isUploadingFiles, setIsUploadingFiles] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!frameId) {
@@ -76,47 +71,30 @@ export default function UploadSelectPage() {
     fileInputRef.current?.click();
   };
 
-  const handleChangeFiles = async (event: ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(event.target.files ?? []);
-    event.target.value = "";
+  const handleChangeFiles = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
 
-    if (files.length === 0) return;
+    const items: FrameMedia[] = Array.from(files)
+      .map((file) => {
+        const url = URL.createObjectURL(file);
 
-    setUploadError(null);
-    setIsUploadingFiles(true);
-
-    const uploadResults = await Promise.allSettled(
-      files.map(async (file) => {
-        if (!file.type.startsWith("image/") && !file.type.startsWith("video/")) {
-          throw new Error(`Unsupported upload file type: ${file.type || file.name}`);
+        if (file.type.startsWith("image/")) {
+          return { type: "image" as const, src: url };
         }
 
-        const uploaded = await uploadFourcutMedia(file);
+        if (file.type.startsWith("video/")) {
+          return { type: "video" as const, src: url };
+        }
 
-        return {
-          type: file.type.startsWith("video/") ? "video" : "image",
-          src: uploaded.downloadUrl ?? uploaded.objectUrl,
-        } satisfies FrameMedia;
-      }),
-    );
+        return null;
+      })
+      .filter((value): value is FrameMedia => value !== null);
 
-    const items = uploadResults.flatMap((result) =>
-      result.status === "fulfilled" ? [result.value] : [],
-    );
+    if (items.length === 0) return;
 
-    const failedCount = uploadResults.length - items.length;
-
-    if (items.length > 0) {
-      addMedia(items);
-    }
-
-    if (failedCount === files.length) {
-      setUploadError("사진이나 영상을 업로드하지 못했어요. 다시 시도해 주세요.");
-    } else if (failedCount > 0) {
-      setUploadError(`${failedCount}개 파일은 업로드하지 못했어요. 다시 시도해 주세요.`);
-    }
-
-    setIsUploadingFiles(false);
+    addMedia(items);
+    event.target.value = "";
   };
 
   const handleNext = () => {
@@ -157,10 +135,9 @@ export default function UploadSelectPage() {
               <button
                 type="button"
                 onClick={handleClickUpload}
-                disabled={isUploadingFiles}
-                className="h-9 rounded-full bg-zinc-800 text-[11px] font-medium text-zinc-100 hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
+                className="h-9 rounded-full bg-zinc-800 text-[11px] font-medium text-zinc-100 hover:bg-zinc-700"
               >
-                {isUploadingFiles ? "업로드 중..." : "사진 또는 영상 추가하기"}
+                사진 또는 영상 추가하기
               </button>
 
               <input
@@ -175,10 +152,6 @@ export default function UploadSelectPage() {
               <p className="text-[10px] text-zinc-500">
                 여러 파일을 한 번에 넣고 프레임에 어울릴 4개를 선택할 수 있어요.
               </p>
-
-              {uploadError ? (
-                <p className="text-[10px] text-rose-300">{uploadError}</p>
-              ) : null}
 
               <FrameOutputOptionsPanel
                 borderColor={borderColor}


### PR DESCRIPTION
## What changed
- reverted upload select flow to keep chosen source media local with `URL.createObjectURL()` until the result step
- removed immediate `uploadFourcutMedia()` calls from source selection
- updated the upload select test to assert local preview media is added without an upload request

## Why
Selecting a source image was immediately requesting a presigned upload and sending the original file to storage before the user finished generating a final result.

## User impact
Users now only upload the final generated result. Source images chosen on `/upload/select` stay local until result generation runs.

## Root cause
The upload select flow was changed to upload each selected file immediately and replace the local preview source with the remote download URL.

## Validation
- `pnpm test -- app/upload/select/page.test.tsx`
- `pnpm test -- lib/presignedUploadApi.test.ts`
- `pnpm exec eslint app/upload/select/page.tsx app/upload/select/page.test.tsx`
