### PR TITLE
[codex] stabilize fourcut video generation

### DIFF
--- a/app/shoot/result/page.test.tsx
+++ b/app/shoot/result/page.test.tsx
@@ -1,0 +1,179 @@
+import { render, waitFor } from "@testing-library/react";
+import { create } from "zustand";
+import ShootResultPage from "@/app/shoot/result/page";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+const mockConsumeVideoConversion = jest.fn();
+const mockComposeFramePng = jest.fn();
+const mockRecordFrameWebm = jest.fn();
+const mockUploadGeneratedFourcutFile = jest.fn();
+const mockCreateObjectURL = jest.fn();
+const mockRevokeObjectURL = jest.fn();
+
+const mockUseShootSession = create(() => ({
+  frameId: "classic-4" as string | null,
+  remoteFrameId: null as number | null,
+  shots: [
+    { photo: "/shot-1.png", video: "blob:shot-video-1" },
+    { photo: "/shot-2.png" },
+    { photo: "/shot-3.png" },
+    { photo: "/shot-4.png" },
+  ],
+  selectedIndexes: [0, 1, 2, 3] as Array<number | null>,
+  borderColor: "#111827",
+  outputFilter: "NONE",
+  includeVideo: true,
+  imageResult: null as null | object,
+  videoResult: null as null | object,
+  setImageResult: (imageResult: unknown) =>
+    mockUseShootSession.setState({ imageResult }),
+  setVideoResult: (videoResult: unknown) =>
+    mockUseShootSession.setState({ videoResult }),
+  clearResults: jest.fn(() =>
+    mockUseShootSession.setState({ imageResult: null, videoResult: null }),
+  ),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+jest.mock("@/components/layout/PageHeader", () => ({
+  PageHeader: () => <div data-testid="page-header" />,
+}));
+
+jest.mock("@/components/layout/StepProgress", () => ({
+  StepProgress: () => <div data-testid="step-progress" />,
+}));
+
+jest.mock("@/components/frame/FramePreview", () => ({
+  FramePreview: () => <div data-testid="frame-preview" />,
+}));
+
+jest.mock("@/components/frame/GeneratedAssetDownloadCard", () => ({
+  GeneratedAssetDownloadCard: () => <div data-testid="generated-asset-card" />,
+}));
+
+jest.mock("@/hooks/useRemoteFrameTheme", () => ({
+  useRemoteFrameTheme: () => null,
+}));
+
+jest.mock("@/lib/themeBackground", () => ({
+  resolveFrameBackgroundColor: (_theme: unknown, borderColor: string) =>
+    borderColor,
+}));
+
+jest.mock("@/lib/guards", () => ({
+  isNotNull: (value: unknown) => value != null,
+}));
+
+jest.mock("@/lib/shootSessionStore", () => ({
+  useShootSession: () => mockUseShootSession(),
+}));
+
+jest.mock("@/lib/videoConversionQuotaStore", () => ({
+  useVideoConversionQuotaStore: (
+    selector: (state: {
+      consume: () => void;
+      usedCount: number;
+      limit: number;
+    }) => unknown,
+  ) =>
+    selector({
+      consume: mockConsumeVideoConversion,
+      usedCount: 0,
+      limit: 3,
+    }),
+}));
+
+jest.mock("@/lib/canvas/composeFrame", () => ({
+  composeFramePng: (...args: unknown[]) => mockComposeFramePng(...args),
+  recordFrameWebm: (...args: unknown[]) => mockRecordFrameWebm(...args),
+  downloadFromUrl: jest.fn(),
+}));
+
+jest.mock("@/lib/fourcutProcessing", () => ({
+  uploadGeneratedFourcutFile: (...args: unknown[]) =>
+    mockUploadGeneratedFourcutFile(...args),
+}));
+
+jest.mock("@/lib/userMediaApi", () => ({
+  updateMediaDisplayName: jest.fn(),
+  getMediaDownloadUrl: jest.fn(),
+}));
+
+jest.mock("@/lib/share", () => ({
+  shareOrCopyLink: jest.fn(),
+}));
+
+jest.mock("@/lib/fourcutVideo", () => ({
+  MAX_FOURCUT_VIDEO_SECONDS: 8,
+  TRIMMED_VIDEO_NOTICE: "trimmed",
+  hasVideoSourceLongerThan: jest.fn().mockResolvedValue(false),
+}));
+
+describe("ShootResultPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue("blob:generated-video");
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    mockUseShootSession.setState({
+      frameId: "classic-4",
+      remoteFrameId: null,
+      shots: [
+        { photo: "/shot-1.png", video: "blob:shot-video-1" },
+        { photo: "/shot-2.png" },
+        { photo: "/shot-3.png" },
+        { photo: "/shot-4.png" },
+      ],
+      selectedIndexes: [0, 1, 2, 3],
+      borderColor: "#111827",
+      outputFilter: "NONE",
+      includeVideo: true,
+      imageResult: null,
+      videoResult: null,
+    });
+
+    mockComposeFramePng.mockResolvedValue(
+      new Blob(["image"], { type: "image/png" }),
+    );
+    mockRecordFrameWebm.mockResolvedValue(
+      new Blob(["video"], { type: "video/webm" }),
+    );
+    mockUploadGeneratedFourcutFile.mockImplementation(
+      async ({
+        kind,
+        displayName,
+        extension,
+      }: {
+        kind: "IMAGE" | "VIDEO";
+        displayName: string;
+        extension: "png" | "mp4";
+      }) => ({
+        mediaId: kind === "IMAGE" ? 1 : 2,
+        kind,
+        objectUrl: `https://example.com/${kind.toLowerCase()}`,
+        downloadUrl: `https://example.com/${kind.toLowerCase()}`,
+        extension,
+        displayName,
+      }),
+    );
+  });
+
+  it("starts the video generation flow only once after the image result updates the session", async () => {
+    render(<ShootResultPage />);
+
+    await waitFor(() => {
+      const videoCalls = mockUploadGeneratedFourcutFile.mock.calls.filter(
+        ([args]) => args.kind === "VIDEO",
+      );
+      expect(videoCalls).toHaveLength(1);
+    });
+
+    expect(mockRecordFrameWebm).toHaveBeenCalledTimes(1);
+    expect(mockConsumeVideoConversion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/shoot/result/page.tsx
+++ b/app/shoot/result/page.tsx
@@ -22,6 +22,15 @@ import {
   sanitizeDisplayName,
 } from "@/lib/fourcutOutput";
 import { uploadGeneratedFourcutFile } from "@/lib/fourcutProcessing";
+import {
+  MAX_FOURCUT_VIDEO_SECONDS,
+  TRIMMED_VIDEO_NOTICE,
+  hasVideoSourceLongerThan,
+} from "@/lib/fourcutVideo";
+import {
+  registerGeneratedWebmDebug,
+  unregisterGeneratedWebmDebug,
+} from "@/lib/generatedVideoDebug";
 import { isNotNull } from "@/lib/guards";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
 import { shareOrCopyLink } from "@/lib/share";
@@ -30,7 +39,7 @@ import { resolveFrameBackgroundColor } from "@/lib/themeBackground";
 import { updateMediaDisplayName, getMediaDownloadUrl } from "@/lib/userMediaApi";
 import { useVideoConversionQuotaStore } from "@/lib/videoConversionQuotaStore";
 
-const MAX_SECONDS = 8;
+const VIDEO_DEBUG_SCOPE = "shoot-result";
 
 type ProcessingState = "idle" | "processing" | "done" | "error";
 
@@ -71,7 +80,11 @@ export default function ShootResultPage() {
   const [isDownloadingVideo, setIsDownloadingVideo] = useState(false);
   const [isSharingImage, setIsSharingImage] = useState(false);
   const [isSharingVideo, setIsSharingVideo] = useState(false);
+  const [hasTrimmedVideoSource, setHasTrimmedVideoSource] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const imageGenerationKeyRef = useRef<string | null>(null);
+  const videoGenerationKeyRef = useRef<string | null>(null);
+  const debugVideoUrlRef = useRef<string | null>(null);
 
   const selectedCount = useMemo(
     () => selectedIndexes.filter((index) => index != null).length,
@@ -140,6 +153,27 @@ export default function ShootResultPage() {
     videoConversionLimit - usedVideoConversions,
     0,
   );
+  const generationKey = useMemo(
+    () =>
+      JSON.stringify({
+        frameId,
+        remoteFrameId,
+        borderColor: effectiveBorderColor,
+        outputFilter,
+        includeVideo,
+        imageSources: imageSources.map((source) => `${source.type}:${source.src}`),
+        videoSources: videoSources.map((source) => `${source.type}:${source.src}`),
+      }),
+    [
+      effectiveBorderColor,
+      frameId,
+      imageSources,
+      includeVideo,
+      outputFilter,
+      remoteFrameId,
+      videoSources,
+    ],
+  );
 
   useEffect(() => {
     setImageState(imageResult ? "done" : "idle");
@@ -152,13 +186,48 @@ export default function ShootResultPage() {
   }, [videoResult]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    async function inspectVideoSources() {
+      if (!shouldPrepareVideo) {
+        setHasTrimmedVideoSource(false);
+        return;
+      }
+
+      const nextHasTrimmedVideoSource = await hasVideoSourceLongerThan(
+        videoSources,
+        MAX_FOURCUT_VIDEO_SECONDS,
+      );
+
+      if (!cancelled) {
+        setHasTrimmedVideoSource(nextHasTrimmedVideoSource);
+      }
+    }
+
+    void inspectVideoSources();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldPrepareVideo, videoSources]);
+
+  useEffect(() => {
     if (!frameId || !layout || selectedCount !== 4 || imageSources.length !== 4) return;
 
     let cancelled = false;
     const currentLayout = layout;
+    const imageGenerationKey = `${generationKey}:image`;
+    const videoGenerationKey = `${generationKey}:video`;
 
     async function prepareOutputs() {
+      let generatedImageInThisPass = false;
+
       if (!imageResult) {
+        if (imageGenerationKeyRef.current === imageGenerationKey) {
+          return;
+        }
+
+        imageGenerationKeyRef.current = imageGenerationKey;
         setImageError(null);
         setImageState("processing");
 
@@ -189,6 +258,7 @@ export default function ShootResultPage() {
           if (!cancelled) {
             setImageResult(asset);
             setImageState("done");
+            generatedImageInThisPass = true;
           }
         } catch (error) {
           console.error(error);
@@ -197,6 +267,10 @@ export default function ShootResultPage() {
             setImageError("이미지를 준비하지 못했어요. 다시 시도해 주세요.");
           }
         }
+      }
+
+      if (generatedImageInThisPass) {
+        return;
       }
 
       if (!shouldPrepareVideo) {
@@ -222,6 +296,11 @@ export default function ShootResultPage() {
         return;
       }
 
+      if (videoGenerationKeyRef.current === videoGenerationKey) {
+        return;
+      }
+
+      videoGenerationKeyRef.current = videoGenerationKey;
       setVideoError(null);
       setVideoState("processing");
 
@@ -232,7 +311,7 @@ export default function ShootResultPage() {
           sources: videoSources,
           outputFilter,
           theme: themeData,
-          seconds: MAX_SECONDS,
+          seconds: MAX_FOURCUT_VIDEO_SECONDS,
           canvas: canvasRef.current ?? undefined,
         });
 
@@ -240,7 +319,18 @@ export default function ShootResultPage() {
           frameConfig?.name ?? "harucut",
           "VIDEO",
         );
-        const file = new File([blob], `${displayName}.webm`, {
+        const filename = `${displayName}.webm`;
+
+        if (!cancelled) {
+          debugVideoUrlRef.current = registerGeneratedWebmDebug({
+            scope: VIDEO_DEBUG_SCOPE,
+            blob,
+            filename,
+            previousUrl: debugVideoUrlRef.current,
+          });
+        }
+
+        const file = new File([blob], filename, {
           type: "video/webm",
         });
         const asset = await uploadGeneratedFourcutFile({
@@ -270,11 +360,11 @@ export default function ShootResultPage() {
       cancelled = true;
     };
   }, [
-    clearResults,
     consumeVideoConversion,
     effectiveBorderColor,
     frameConfig?.name,
     frameId,
+    generationKey,
     imageResult,
     imageSources,
     layout,
@@ -288,6 +378,13 @@ export default function ShootResultPage() {
     videoResult,
     videoSources,
   ]);
+
+  useEffect(() => {
+    return () => {
+      unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
+      debugVideoUrlRef.current = null;
+    };
+  }, []);
 
   if (!frameId || !layout) return null;
 
@@ -504,6 +601,15 @@ export default function ShootResultPage() {
           </section>
         ) : null}
 
+        {shouldPrepareVideo ? (
+          <section className="rounded-2xl border border-amber-300/20 bg-amber-400/10 px-4 py-3 text-[11px] text-amber-100">
+            <p>영상 결과는 최대 {MAX_FOURCUT_VIDEO_SECONDS}초로 만들어요.</p>
+            {hasTrimmedVideoSource ? (
+              <p className="mt-1 text-amber-50/90">{TRIMMED_VIDEO_NOTICE}</p>
+            ) : null}
+          </section>
+        ) : null}
+
         <section className="space-y-3">
           <FramePreview
             frameId={frameId}
@@ -531,6 +637,10 @@ export default function ShootResultPage() {
           <button
             type="button"
             onClick={() => {
+              imageGenerationKeyRef.current = null;
+              videoGenerationKeyRef.current = null;
+              unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
+              debugVideoUrlRef.current = null;
               clearResults();
               setImageState("idle");
               setVideoState("idle");

--- a/app/upload/result/page.test.tsx
+++ b/app/upload/result/page.test.tsx
@@ -1,0 +1,175 @@
+import { render, waitFor } from "@testing-library/react";
+import { create } from "zustand";
+import UploadResultPage from "@/app/upload/result/page";
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+const mockConsumeVideoConversion = jest.fn();
+const mockComposeFramePng = jest.fn();
+const mockRecordFrameWebm = jest.fn();
+const mockUploadGeneratedFourcutFile = jest.fn();
+const mockCreateObjectURL = jest.fn();
+const mockRevokeObjectURL = jest.fn();
+
+const mockUseUploadSession = create(() => ({
+  frameId: "classic-4" as string | null,
+  remoteFrameId: null as number | null,
+  media: [
+    { type: "video" as const, src: "blob:video-1" },
+    { type: "image" as const, src: "/image-2.png" },
+    { type: "image" as const, src: "/image-3.png" },
+    { type: "image" as const, src: "/image-4.png" },
+  ],
+  selectedIndexes: [0, 1, 2, 3] as Array<number | null>,
+  borderColor: "#111827",
+  outputFilter: "NONE",
+  includeVideo: true,
+  imageResult: null as null | object,
+  videoResult: null as null | object,
+  setImageResult: (imageResult: unknown) =>
+    mockUseUploadSession.setState({ imageResult }),
+  setVideoResult: (videoResult: unknown) =>
+    mockUseUploadSession.setState({ videoResult }),
+  clearResults: jest.fn(() =>
+    mockUseUploadSession.setState({ imageResult: null, videoResult: null }),
+  ),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+}));
+
+jest.mock("@/components/layout/PageHeader", () => ({
+  PageHeader: () => <div data-testid="page-header" />,
+}));
+
+jest.mock("@/components/layout/StepProgress", () => ({
+  StepProgress: () => <div data-testid="step-progress" />,
+}));
+
+jest.mock("@/components/frame/FramePreview", () => ({
+  FramePreview: () => <div data-testid="frame-preview" />,
+}));
+
+jest.mock("@/components/frame/GeneratedAssetDownloadCard", () => ({
+  GeneratedAssetDownloadCard: () => <div data-testid="generated-asset-card" />,
+}));
+
+jest.mock("@/hooks/useRemoteFrameTheme", () => ({
+  useRemoteFrameTheme: () => null,
+}));
+
+jest.mock("@/lib/themeBackground", () => ({
+  resolveFrameBackgroundColor: (_theme: unknown, borderColor: string) =>
+    borderColor,
+}));
+
+jest.mock("@/lib/uploadSessionStore", () => ({
+  useUploadSession: () => mockUseUploadSession(),
+}));
+
+jest.mock("@/lib/videoConversionQuotaStore", () => ({
+  useVideoConversionQuotaStore: (
+    selector: (state: {
+      consume: () => void;
+      usedCount: number;
+      limit: number;
+    }) => unknown,
+  ) =>
+    selector({
+      consume: mockConsumeVideoConversion,
+      usedCount: 0,
+      limit: 3,
+    }),
+}));
+
+jest.mock("@/lib/canvas/composeFrame", () => ({
+  composeFramePng: (...args: unknown[]) => mockComposeFramePng(...args),
+  recordFrameWebm: (...args: unknown[]) => mockRecordFrameWebm(...args),
+  downloadFromUrl: jest.fn(),
+}));
+
+jest.mock("@/lib/fourcutProcessing", () => ({
+  uploadGeneratedFourcutFile: (...args: unknown[]) =>
+    mockUploadGeneratedFourcutFile(...args),
+}));
+
+jest.mock("@/lib/userMediaApi", () => ({
+  updateMediaDisplayName: jest.fn(),
+  getMediaDownloadUrl: jest.fn(),
+}));
+
+jest.mock("@/lib/share", () => ({
+  shareOrCopyLink: jest.fn(),
+}));
+
+jest.mock("@/lib/fourcutVideo", () => ({
+  MAX_FOURCUT_VIDEO_SECONDS: 8,
+  TRIMMED_VIDEO_NOTICE: "trimmed",
+  hasVideoSourceLongerThan: jest.fn().mockResolvedValue(false),
+}));
+
+describe("UploadResultPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue("blob:generated-video");
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+
+    mockUseUploadSession.setState({
+      frameId: "classic-4",
+      remoteFrameId: null,
+      media: [
+        { type: "video", src: "blob:video-1" },
+        { type: "image", src: "/image-2.png" },
+        { type: "image", src: "/image-3.png" },
+        { type: "image", src: "/image-4.png" },
+      ],
+      selectedIndexes: [0, 1, 2, 3],
+      borderColor: "#111827",
+      outputFilter: "NONE",
+      includeVideo: true,
+      imageResult: null,
+      videoResult: null,
+    });
+
+    mockComposeFramePng.mockResolvedValue(
+      new Blob(["image"], { type: "image/png" }),
+    );
+    mockRecordFrameWebm.mockResolvedValue(
+      new Blob(["video"], { type: "video/webm" }),
+    );
+    mockUploadGeneratedFourcutFile.mockImplementation(
+      async ({
+        kind,
+        displayName,
+        extension,
+      }: {
+        kind: "IMAGE" | "VIDEO";
+        displayName: string;
+        extension: "png" | "mp4";
+      }) => ({
+        mediaId: kind === "IMAGE" ? 1 : 2,
+        kind,
+        objectUrl: `https://example.com/${kind.toLowerCase()}`,
+        downloadUrl: `https://example.com/${kind.toLowerCase()}`,
+        extension,
+        displayName,
+      }),
+    );
+  });
+
+  it("starts the video generation flow only once after the image result updates the session", async () => {
+    render(<UploadResultPage />);
+
+    await waitFor(() => {
+      const videoCalls = mockUploadGeneratedFourcutFile.mock.calls.filter(
+        ([args]) => args.kind === "VIDEO",
+      );
+      expect(videoCalls).toHaveLength(1);
+    });
+
+    expect(mockRecordFrameWebm).toHaveBeenCalledTimes(1);
+    expect(mockConsumeVideoConversion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/upload/result/page.tsx
+++ b/app/upload/result/page.tsx
@@ -22,6 +22,15 @@ import {
   sanitizeDisplayName,
 } from "@/lib/fourcutOutput";
 import { uploadGeneratedFourcutFile } from "@/lib/fourcutProcessing";
+import {
+  MAX_FOURCUT_VIDEO_SECONDS,
+  TRIMMED_VIDEO_NOTICE,
+  hasVideoSourceLongerThan,
+} from "@/lib/fourcutVideo";
+import {
+  registerGeneratedWebmDebug,
+  unregisterGeneratedWebmDebug,
+} from "@/lib/generatedVideoDebug";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
 import { shareOrCopyLink } from "@/lib/share";
 import { resolveFrameBackgroundColor } from "@/lib/themeBackground";
@@ -29,7 +38,7 @@ import { useUploadSession } from "@/lib/uploadSessionStore";
 import { updateMediaDisplayName, getMediaDownloadUrl } from "@/lib/userMediaApi";
 import { useVideoConversionQuotaStore } from "@/lib/videoConversionQuotaStore";
 
-const MAX_SECONDS = 8;
+const VIDEO_DEBUG_SCOPE = "upload-result";
 
 type ProcessingState = "idle" | "processing" | "done" | "error";
 
@@ -70,7 +79,11 @@ export default function UploadResultPage() {
   const [isDownloadingVideo, setIsDownloadingVideo] = useState(false);
   const [isSharingImage, setIsSharingImage] = useState(false);
   const [isSharingVideo, setIsSharingVideo] = useState(false);
+  const [hasTrimmedVideoSource, setHasTrimmedVideoSource] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const imageGenerationKeyRef = useRef<string | null>(null);
+  const videoGenerationKeyRef = useRef<string | null>(null);
+  const debugVideoUrlRef = useRef<string | null>(null);
 
   const selectedCount = useMemo(
     () => selectedIndexes.filter((index) => index != null).length,
@@ -138,6 +151,27 @@ export default function UploadResultPage() {
     videoConversionLimit - usedVideoConversions,
     0,
   );
+  const generationKey = useMemo(
+    () =>
+      JSON.stringify({
+        frameId,
+        remoteFrameId,
+        borderColor: effectiveBorderColor,
+        outputFilter,
+        includeVideo,
+        imageSources: imageSources.map((source) => `${source.type}:${source.src}`),
+        videoSources: videoSources.map((source) => `${source.type}:${source.src}`),
+      }),
+    [
+      effectiveBorderColor,
+      frameId,
+      imageSources,
+      includeVideo,
+      outputFilter,
+      remoteFrameId,
+      videoSources,
+    ],
+  );
 
   useEffect(() => {
     setImageState(imageResult ? "done" : "idle");
@@ -150,13 +184,48 @@ export default function UploadResultPage() {
   }, [videoResult]);
 
   useEffect(() => {
+    let cancelled = false;
+
+    async function inspectVideoSources() {
+      if (!shouldPrepareVideo) {
+        setHasTrimmedVideoSource(false);
+        return;
+      }
+
+      const nextHasTrimmedVideoSource = await hasVideoSourceLongerThan(
+        videoSources,
+        MAX_FOURCUT_VIDEO_SECONDS,
+      );
+
+      if (!cancelled) {
+        setHasTrimmedVideoSource(nextHasTrimmedVideoSource);
+      }
+    }
+
+    void inspectVideoSources();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldPrepareVideo, videoSources]);
+
+  useEffect(() => {
     if (!frameId || !layout || selectedCount !== 4 || imageSources.length !== 4) return;
 
     let cancelled = false;
     const currentLayout = layout;
+    const imageGenerationKey = `${generationKey}:image`;
+    const videoGenerationKey = `${generationKey}:video`;
 
     async function prepareOutputs() {
+      let generatedImageInThisPass = false;
+
       if (!imageResult) {
+        if (imageGenerationKeyRef.current === imageGenerationKey) {
+          return;
+        }
+
+        imageGenerationKeyRef.current = imageGenerationKey;
         setImageError(null);
         setImageState("processing");
 
@@ -187,6 +256,7 @@ export default function UploadResultPage() {
           if (!cancelled) {
             setImageResult(asset);
             setImageState("done");
+            generatedImageInThisPass = true;
           }
         } catch (error) {
           console.error(error);
@@ -195,6 +265,10 @@ export default function UploadResultPage() {
             setImageError("이미지를 준비하지 못했어요. 다시 시도해 주세요.");
           }
         }
+      }
+
+      if (generatedImageInThisPass) {
+        return;
       }
 
       if (!shouldPrepareVideo) {
@@ -220,6 +294,11 @@ export default function UploadResultPage() {
         return;
       }
 
+      if (videoGenerationKeyRef.current === videoGenerationKey) {
+        return;
+      }
+
+      videoGenerationKeyRef.current = videoGenerationKey;
       setVideoError(null);
       setVideoState("processing");
 
@@ -230,7 +309,7 @@ export default function UploadResultPage() {
           sources: videoSources,
           outputFilter,
           theme: themeData,
-          seconds: MAX_SECONDS,
+          seconds: MAX_FOURCUT_VIDEO_SECONDS,
           canvas: canvasRef.current ?? undefined,
         });
 
@@ -238,7 +317,18 @@ export default function UploadResultPage() {
           frameConfig?.name ?? "harucut",
           "VIDEO",
         );
-        const file = new File([blob], `${displayName}.webm`, {
+        const filename = `${displayName}.webm`;
+
+        if (!cancelled) {
+          debugVideoUrlRef.current = registerGeneratedWebmDebug({
+            scope: VIDEO_DEBUG_SCOPE,
+            blob,
+            filename,
+            previousUrl: debugVideoUrlRef.current,
+          });
+        }
+
+        const file = new File([blob], filename, {
           type: "video/webm",
         });
         const asset = await uploadGeneratedFourcutFile({
@@ -272,6 +362,7 @@ export default function UploadResultPage() {
     effectiveBorderColor,
     frameConfig?.name,
     frameId,
+    generationKey,
     imageResult,
     imageSources,
     layout,
@@ -285,6 +376,13 @@ export default function UploadResultPage() {
     videoResult,
     videoSources,
   ]);
+
+  useEffect(() => {
+    return () => {
+      unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
+      debugVideoUrlRef.current = null;
+    };
+  }, []);
 
   if (!frameId || !layout) return null;
 
@@ -501,6 +599,15 @@ export default function UploadResultPage() {
           </section>
         ) : null}
 
+        {shouldPrepareVideo ? (
+          <section className="rounded-2xl border border-amber-300/20 bg-amber-400/10 px-4 py-3 text-[11px] text-amber-100">
+            <p>영상 결과는 최대 {MAX_FOURCUT_VIDEO_SECONDS}초로 만들어요.</p>
+            {hasTrimmedVideoSource ? (
+              <p className="mt-1 text-amber-50/90">{TRIMMED_VIDEO_NOTICE}</p>
+            ) : null}
+          </section>
+        ) : null}
+
         <section className="space-y-3">
           <FramePreview
             frameId={frameId}
@@ -528,6 +635,10 @@ export default function UploadResultPage() {
           <button
             type="button"
             onClick={() => {
+              imageGenerationKeyRef.current = null;
+              videoGenerationKeyRef.current = null;
+              unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
+              debugVideoUrlRef.current = null;
               clearResults();
               setImageState("idle");
               setVideoState("idle");

--- a/lib/fourcutVideo.test.ts
+++ b/lib/fourcutVideo.test.ts
@@ -1,0 +1,42 @@
+const mockLoadVideo = jest.fn();
+
+jest.mock("@/lib/canvas/loaders", () => ({
+  loadVideo: (...args: unknown[]) => mockLoadVideo(...args),
+}));
+
+import {
+  MAX_FOURCUT_VIDEO_SECONDS,
+  hasVideoSourceLongerThan,
+} from "@/lib/fourcutVideo";
+
+describe("fourcut video helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns false when there are no video sources", async () => {
+    await expect(
+      hasVideoSourceLongerThan([{ type: "image", src: "/photo.png" }]),
+    ).resolves.toBe(false);
+    expect(mockLoadVideo).not.toHaveBeenCalled();
+  });
+
+  it("detects input videos that exceed the max result length", async () => {
+    mockLoadVideo
+      .mockResolvedValueOnce({
+        duration: MAX_FOURCUT_VIDEO_SECONDS + 1,
+        pause: jest.fn(),
+      })
+      .mockResolvedValueOnce({
+        duration: 3,
+        pause: jest.fn(),
+      });
+
+    await expect(
+      hasVideoSourceLongerThan([
+        { type: "video", src: "/long.webm" },
+        { type: "video", src: "/short.webm" },
+      ]),
+    ).resolves.toBe(true);
+  });
+});

--- a/lib/fourcutVideo.ts
+++ b/lib/fourcutVideo.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import type { FrameSource } from "@/lib/canvas/composeFrame";
+import { loadVideo } from "@/lib/canvas/loaders";
+
+export const MAX_FOURCUT_VIDEO_SECONDS = 8;
+export const TRIMMED_VIDEO_NOTICE =
+  "8초를 넘는 입력 영상은 앞 8초만 사용해 8초 결과로 만들어요.";
+
+export async function hasVideoSourceLongerThan(
+  sources: FrameSource[],
+  maxSeconds = MAX_FOURCUT_VIDEO_SECONDS,
+) {
+  const videoSources = sources.filter(
+    (source): source is Extract<FrameSource, { type: "video" }> =>
+      source.type === "video",
+  );
+
+  if (videoSources.length === 0) {
+    return false;
+  }
+
+  const durations = await Promise.all(
+    videoSources.map(async (source) => {
+      try {
+        const video = await loadVideo(source.src, { loop: false });
+        const duration = Number.isFinite(video.duration) ? video.duration : 0;
+
+        try {
+          video.pause();
+        } catch {}
+
+        return duration;
+      } catch {
+        return 0;
+      }
+    }),
+  );
+
+  return durations.some((duration) => duration > maxSeconds + 0.05);
+}

--- a/lib/generatedVideoDebug.test.ts
+++ b/lib/generatedVideoDebug.test.ts
@@ -1,0 +1,61 @@
+import {
+  registerGeneratedWebmDebug,
+  unregisterGeneratedWebmDebug,
+} from "@/lib/generatedVideoDebug";
+
+describe("generated video debug helpers", () => {
+  const mockCreateObjectURL = jest.fn();
+  const mockRevokeObjectURL = jest.fn();
+  const mockWindowOpen = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue("blob:debug-webm");
+    URL.createObjectURL = mockCreateObjectURL;
+    URL.revokeObjectURL = mockRevokeObjectURL;
+    window.open = mockWindowOpen;
+  });
+
+  it("registers global download and open commands for the latest generated webm", () => {
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    const url = registerGeneratedWebmDebug({
+      scope: "upload-result",
+      blob: new Blob(["video"], { type: "video/webm" }),
+      filename: "debug.webm",
+    });
+
+    expect(url).toBe("blob:debug-webm");
+    expect(typeof window.downloadHarucutGeneratedWebm).toBe("function");
+    expect(typeof window.openHarucutGeneratedWebm).toBe("function");
+
+    window.downloadHarucutGeneratedWebm?.();
+    expect(clickSpy).toHaveBeenCalled();
+
+    window.openHarucutGeneratedWebm?.();
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      "blob:debug-webm",
+      "_blank",
+      "noopener",
+    );
+
+    clickSpy.mockRestore();
+  });
+
+  it("cleans up global commands when the scoped debug entry is removed", () => {
+    registerGeneratedWebmDebug({
+      scope: "upload-result",
+      blob: new Blob(["video"], { type: "video/webm" }),
+      filename: "debug.webm",
+    });
+
+    unregisterGeneratedWebmDebug("upload-result", "blob:debug-webm");
+
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:debug-webm");
+    expect(window.downloadHarucutGeneratedWebm).toBeUndefined();
+    expect(window.openHarucutGeneratedWebm).toBeUndefined();
+    expect(window.__harucutGeneratedWebm).toBeUndefined();
+  });
+});

--- a/lib/generatedVideoDebug.ts
+++ b/lib/generatedVideoDebug.ts
@@ -1,0 +1,106 @@
+"use client";
+
+type GeneratedVideoDebugEntry = {
+  filename: string;
+  url: string;
+  download: () => void;
+  open: () => string | null;
+};
+
+declare global {
+  interface Window {
+    __harucutGeneratedWebm?: Record<string, GeneratedVideoDebugEntry>;
+    downloadHarucutGeneratedWebm?: (scope?: string) => void;
+    openHarucutGeneratedWebm?: (scope?: string) => string | null;
+  }
+}
+
+function triggerDownload(url: string, filename: string) {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+}
+
+function installGlobalCommands() {
+  window.downloadHarucutGeneratedWebm = (scope = "latest") => {
+    const entries = window.__harucutGeneratedWebm;
+    if (!entries) return;
+
+    const resolved = entries[scope] ?? entries.latest;
+    resolved?.download();
+  };
+
+  window.openHarucutGeneratedWebm = (scope = "latest") => {
+    const entries = window.__harucutGeneratedWebm;
+    if (!entries) return null;
+
+    const resolved = entries[scope] ?? entries.latest;
+    return resolved?.open() ?? null;
+  };
+}
+
+function cleanupGlobalCommandsIfEmpty() {
+  const entries = window.__harucutGeneratedWebm;
+  if (entries && Object.keys(entries).length > 0) {
+    return;
+  }
+
+  delete window.__harucutGeneratedWebm;
+  delete window.downloadHarucutGeneratedWebm;
+  delete window.openHarucutGeneratedWebm;
+}
+
+export function registerGeneratedWebmDebug(args: {
+  scope: string;
+  blob: Blob;
+  filename: string;
+  previousUrl?: string | null;
+}) {
+  if (args.previousUrl) {
+    URL.revokeObjectURL(args.previousUrl);
+  }
+
+  const url = URL.createObjectURL(args.blob);
+  const entry: GeneratedVideoDebugEntry = {
+    filename: args.filename,
+    url,
+    download: () => triggerDownload(url, args.filename),
+    open: () => {
+      window.open(url, "_blank", "noopener");
+      return url;
+    },
+  };
+
+  window.__harucutGeneratedWebm = window.__harucutGeneratedWebm ?? {};
+  window.__harucutGeneratedWebm[args.scope] = entry;
+  window.__harucutGeneratedWebm.latest = entry;
+  installGlobalCommands();
+
+  return url;
+}
+
+export function unregisterGeneratedWebmDebug(
+  scope: string,
+  currentUrl?: string | null,
+) {
+  if (currentUrl) {
+    URL.revokeObjectURL(currentUrl);
+  }
+
+  const entries = window.__harucutGeneratedWebm;
+  if (!entries) {
+    cleanupGlobalCommandsIfEmpty();
+    return;
+  }
+
+  delete entries[scope];
+
+  if (entries.latest?.url === currentUrl) {
+    delete entries.latest;
+  }
+
+  cleanupGlobalCommandsIfEmpty();
+}


### PR DESCRIPTION
## What changed
- capped result video generation messaging around an 8-second maximum and warned when an input video exceeds that limit
- kept long input videos to their first 8 seconds in the generated result flow and exposed the locally generated WEBM through console debug commands
- added generation locks on both upload and shoot result pages so image state updates cannot start the same video transcode flow twice
- added regression tests for upload/shoot result pages plus helper coverage for the video-length and debug utilities

## Why
The result pages could start the same video generation flow twice when the image result updated state before the video result existed. That created duplicate transcode requests and could double backend work.

## User impact
- Result videos stay capped at 8 seconds.
- When an uploaded source video is longer than 8 seconds, the UI now tells the user that only the first 8 seconds will be used.
- For local verification, the latest generated WEBM can be downloaded from the browser console with `downloadHarucutGeneratedWebm()` or opened with `openHarucutGeneratedWebm()`.

## Root cause
Upload and shoot result pages used one auto-generation effect for both image and video outputs. After `setImageResult()` reran the effect, the video path could be entered again before `videoResult` was set, which allowed duplicate `/transcode` starts.

## Validation
- `pnpm test -- lib/fourcutVideo.test.ts`
- `pnpm test -- lib/generatedVideoDebug.test.ts`
- `pnpm test -- app/upload/result/page.test.tsx`
- `pnpm test -- app/shoot/result/page.test.tsx`
- `pnpm test -- app/upload/select/page.test.tsx`
- `pnpm test -- lib/presignedUploadApi.test.ts`
- `pnpm exec eslint app/upload/result/page.tsx app/shoot/result/page.tsx app/upload/result/page.test.tsx app/shoot/result/page.test.tsx lib/fourcutVideo.ts lib/fourcutVideo.test.ts lib/generatedVideoDebug.ts lib/generatedVideoDebug.test.ts`
