### PR TITLE
[codex] share fourcut image and video filenames

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -2,17 +2,13 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import {
-  Download,
-  PencilLine,
-  Search,
-  Share2,
-} from "lucide-react";
+import { Download, PencilLine, Search, Share2 } from "lucide-react";
 import { getUserFacingApiErrorMessage } from "@/lib/apiError";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { downloadFromUrl } from "@/lib/canvas/composeFrame";
 import { buildDownloadFilename } from "@/lib/fourcutOutput";
 import { shareOrCopyLink } from "@/lib/share";
+import { getUserMediaPreview, getUserMediaTitle } from "@/lib/userMediaPreview";
 import {
   getMediaDownloadUrl,
   listMyMedia,
@@ -21,16 +17,6 @@ import {
 import type { UserMedia, UserMediaType } from "@/lib/api-types";
 
 type FilterValue = "ALL" | UserMediaType;
-
-function getMediaTitle(item: UserMedia) {
-  const preferredName = item.displayName?.trim() || item.displayname?.trim();
-  if (preferredName) return preferredName;
-
-  const originalName = item.originalFileName?.trim();
-  if (originalName) return originalName;
-
-  return item.s3Key.split("/").pop() || "기록";
-}
 
 function getMediaTypeLabel(type: UserMediaType) {
   return type === "PHOTO" ? "사진" : "영상";
@@ -52,9 +38,18 @@ function getMediaExtension(item: UserMedia) {
   return item.mediaType === "VIDEO" ? "mp4" : "png";
 }
 
+function sortMedia(items: UserMedia[]) {
+  return [...items].sort((a, b) => {
+    const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+}
+
 export default function HistoryPage() {
   const [filter, setFilter] = useState<FilterValue>("ALL");
   const [items, setItems] = useState<UserMedia[]>([]);
+  const [previewItems, setPreviewItems] = useState<UserMedia[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -74,13 +69,14 @@ export default function HistoryPage() {
 
       try {
         const media = await listMyMedia(filter === "ALL" ? undefined : filter);
+        const nextPreviewItems =
+          filter === "ALL"
+            ? media
+            : await listMyMedia().catch(() => media);
+
         if (!cancelled) {
-          const sorted = [...media].sort((a, b) => {
-            const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-            const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-            return bTime - aTime;
-          });
-          setItems(sorted);
+          setItems(sortMedia(media));
+          setPreviewItems(sortMedia(nextPreviewItems));
         }
       } catch (loadError) {
         console.error(loadError);
@@ -120,7 +116,7 @@ export default function HistoryPage() {
     if (!keyword) return items;
 
     return items.filter((item) =>
-      getMediaTitle(item).toLowerCase().includes(keyword),
+      getUserMediaTitle(item).toLowerCase().includes(keyword),
     );
   }, [items, search]);
 
@@ -148,7 +144,7 @@ export default function HistoryPage() {
       const url = await getMediaDownloadUrl(item.mediaId);
       await downloadFromUrl(
         url,
-        buildDownloadFilename(getMediaTitle(item), getMediaExtension(item)),
+        buildDownloadFilename(getUserMediaTitle(item), getMediaExtension(item)),
       );
     } catch (downloadError) {
       console.error(downloadError);
@@ -169,7 +165,7 @@ export default function HistoryPage() {
     try {
       const url = await getMediaDownloadUrl(item.mediaId);
       const result = await shareOrCopyLink({
-        title: `${getMediaTitle(item)} | 하루컷`,
+        title: `${getUserMediaTitle(item)} | 하루컷`,
         text: `${getMediaTypeLabel(item.mediaType)} 공유 링크`,
         url,
       });
@@ -194,7 +190,7 @@ export default function HistoryPage() {
 
   const handleStartRename = (item: UserMedia) => {
     setEditingId(item.mediaId);
-    setDraftName(getMediaTitle(item));
+    setDraftName(getUserMediaTitle(item));
   };
 
   const handleSaveName = async (item: UserMedia) => {
@@ -212,6 +208,13 @@ export default function HistoryPage() {
         updated.displayName?.trim() || updated.displayname?.trim() || nextName;
 
       setItems((current) =>
+        current.map((currentItem) =>
+          currentItem.mediaId === item.mediaId
+            ? { ...currentItem, displayName: resolvedName }
+            : currentItem,
+        ),
+      );
+      setPreviewItems((current) =>
         current.map((currentItem) =>
           currentItem.mediaId === item.mediaId
             ? { ...currentItem, displayName: resolvedName }
@@ -258,7 +261,7 @@ export default function HistoryPage() {
             <div className="flex flex-wrap gap-2">
               {[
                 { label: "전체", value: `${stats.total}개` },
-                { label: "사진", value: `${stats.photos}장` },
+                { label: "사진", value: `${stats.photos}개` },
                 { label: "영상", value: `${stats.videos}개` },
               ].map((stat) => (
                 <span
@@ -334,125 +337,129 @@ export default function HistoryPage() {
           </div>
         ) : (
           <section className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-            {filteredItems.map((item) => (
-              <article
-                key={item.mediaId}
-                className="rounded-[28px] border border-white/10 bg-white/[0.04] p-4"
-              >
-                <div className="flex gap-3">
-                  <div className="h-32 w-24 shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950">
-                    {item.downloadUrl ? (
-                      item.mediaType === "VIDEO" ? (
-                        <video
-                          src={item.downloadUrl}
-                          className="h-full w-full object-cover"
-                          muted
-                          playsInline
-                          controls={false}
-                        />
-                      ) : (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={item.downloadUrl}
-                          alt={getMediaTitle(item)}
-                          className="h-full w-full object-cover"
-                        />
-                      )
-                    ) : (
-                      <div className="grid h-full w-full place-items-center px-2 text-center text-[10px] text-zinc-500">
-                        미리보기를 준비하는 중이에요.
-                      </div>
-                    )}
-                  </div>
+            {filteredItems.map((item) => {
+              const preview = getUserMediaPreview(item, previewItems);
 
-                  <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
-                    <div className="flex flex-col gap-1">
-                      <div className="flex items-center gap-2">
-                        <span className="text-[10px] tracking-[0.2em] text-emerald-300">
-                          {getMediaTypeLabel(item.mediaType)}
-                        </span>
-                        {item.originalFileName ? (
-                          <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-zinc-400">
-                            original kept
-                          </span>
-                        ) : null}
-                      </div>
-
-                      {editingId === item.mediaId ? (
-                        <div className="mt-2 flex gap-2">
-                          <input
-                            value={draftName}
-                            onChange={(e) => setDraftName(e.target.value)}
-                            className="h-9 flex-1 rounded-xl border border-white/10 bg-black/20 px-3 text-[12px] text-zinc-100 outline-none focus:border-emerald-400"
+              return (
+                <article
+                  key={item.mediaId}
+                  className="rounded-[28px] border border-white/10 bg-white/[0.04] p-4"
+                >
+                  <div className="flex gap-3">
+                    <div className="h-32 w-24 shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950">
+                      {preview.url ? (
+                        preview.kind === "video" ? (
+                          <video
+                            src={preview.url}
+                            className="h-full w-full object-cover"
+                            muted
+                            playsInline
+                            controls={false}
                           />
-                          <button
-                            type="button"
-                            onClick={() => void handleSaveName(item)}
-                            disabled={savingNameId === item.mediaId}
-                            className="rounded-full bg-white px-3 py-2 text-[11px] font-semibold text-zinc-950 hover:bg-zinc-100 disabled:opacity-50"
-                          >
-                            {savingNameId === item.mediaId ? "저장 중" : "저장"}
-                          </button>
-                        </div>
+                        ) : (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={preview.url}
+                            alt={getUserMediaTitle(item)}
+                            className="h-full w-full object-cover"
+                          />
+                        )
                       ) : (
-                        <p className="truncate text-sm font-semibold text-zinc-100">
-                          {getMediaTitle(item)}
-                        </p>
+                        <div className="grid h-full w-full place-items-center px-2 text-center text-[10px] text-zinc-500">
+                          미리보기를 준비하는 중이에요.
+                        </div>
                       )}
-
-                      <p className="text-[11px] text-zinc-500">
-                        {item.createdAt
-                          ? new Date(item.createdAt).toLocaleString("ko-KR")
-                          : "생성 시간을 확인할 수 없어요."}
-                      </p>
                     </div>
 
-                    <div className="flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        onClick={() => void handleDownload(item)}
-                        disabled={downloadingId === item.mediaId}
-                        className="flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full bg-emerald-400 px-3 py-2 text-[11px] font-semibold text-zinc-950 hover:bg-emerald-300 disabled:opacity-50"
-                      >
-                        <Download className="h-3.5 w-3.5" />
-                        <span>
-                          {downloadingId === item.mediaId
-                            ? "다운로드 중..."
-                            : "다운로드"}
-                        </span>
-                      </button>
+                    <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
+                      <div className="flex flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-[10px] tracking-[0.2em] text-emerald-300">
+                            {getMediaTypeLabel(item.mediaType)}
+                          </span>
+                          {item.originalFileName ? (
+                            <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-zinc-400">
+                              original kept
+                            </span>
+                          ) : null}
+                        </div>
 
-                      <button
-                        type="button"
-                        onClick={() => void handleShare(item)}
-                        disabled={sharingId === item.mediaId}
-                        className="flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full border border-white/10 bg-black/20 px-3 py-2 text-[11px] font-semibold text-zinc-100 hover:bg-white/5 disabled:opacity-50"
-                      >
-                        <Share2 className="h-3.5 w-3.5" />
-                        <span>
-                          {sharingId === item.mediaId
-                            ? "링크 준비 중..."
-                            : "공유하기"}
-                        </span>
-                      </button>
+                        {editingId === item.mediaId ? (
+                          <div className="mt-2 flex gap-2">
+                            <input
+                              value={draftName}
+                              onChange={(e) => setDraftName(e.target.value)}
+                              className="h-9 flex-1 rounded-xl border border-white/10 bg-black/20 px-3 text-[12px] text-zinc-100 outline-none focus:border-emerald-400"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => void handleSaveName(item)}
+                              disabled={savingNameId === item.mediaId}
+                              className="rounded-full bg-white px-3 py-2 text-[11px] font-semibold text-zinc-950 hover:bg-zinc-100 disabled:opacity-50"
+                            >
+                              {savingNameId === item.mediaId ? "저장 중" : "저장"}
+                            </button>
+                          </div>
+                        ) : (
+                          <p className="truncate text-sm font-semibold text-zinc-100">
+                            {getUserMediaTitle(item)}
+                          </p>
+                        )}
 
-                      <button
-                        type="button"
-                        onClick={() =>
-                          editingId === item.mediaId
-                            ? setEditingId(null)
-                            : handleStartRename(item)
-                        }
-                        className="flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full border border-white/10 bg-black/20 px-3 py-2 text-[11px] font-semibold text-zinc-100 hover:bg-white/5"
-                      >
-                        <PencilLine className="h-3.5 w-3.5" />
-                        <span>{editingId === item.mediaId ? "취소" : "이름 수정"}</span>
-                      </button>
+                        <p className="text-[11px] text-zinc-500">
+                          {item.createdAt
+                            ? new Date(item.createdAt).toLocaleString("ko-KR")
+                            : "생성 시간을 확인할 수 없어요."}
+                        </p>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => void handleDownload(item)}
+                          disabled={downloadingId === item.mediaId}
+                          className="flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full bg-emerald-400 px-3 py-2 text-[11px] font-semibold text-zinc-950 hover:bg-emerald-300 disabled:opacity-50"
+                        >
+                          <Download className="h-3.5 w-3.5" />
+                          <span>
+                            {downloadingId === item.mediaId
+                              ? "다운로드 중..."
+                              : "다운로드"}
+                          </span>
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() => void handleShare(item)}
+                          disabled={sharingId === item.mediaId}
+                          className="flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full border border-white/10 bg-black/20 px-3 py-2 text-[11px] font-semibold text-zinc-100 hover:bg-white/5 disabled:opacity-50"
+                        >
+                          <Share2 className="h-3.5 w-3.5" />
+                          <span>
+                            {sharingId === item.mediaId
+                              ? "링크 준비 중..."
+                              : "공유하기"}
+                          </span>
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() =>
+                            editingId === item.mediaId
+                              ? setEditingId(null)
+                              : handleStartRename(item)
+                          }
+                          className="flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full border border-white/10 bg-black/20 px-3 py-2 text-[11px] font-semibold text-zinc-100 hover:bg-white/5"
+                        >
+                          <PencilLine className="h-3.5 w-3.5" />
+                          <span>{editingId === item.mediaId ? "취소" : "이름 수정"}</span>
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </article>
-            ))}
+                </article>
+              );
+            })}
           </section>
         )}
       </div>

--- a/app/shoot/result/page.test.tsx
+++ b/app/shoot/result/page.test.tsx
@@ -176,4 +176,27 @@ describe("ShootResultPage", () => {
     expect(mockRecordFrameWebm).toHaveBeenCalledTimes(1);
     expect(mockConsumeVideoConversion).toHaveBeenCalledTimes(1);
   });
+
+  it("uses the same default display name for image and video outputs", async () => {
+    render(<ShootResultPage />);
+
+    await waitFor(() => {
+      expect(mockUploadGeneratedFourcutFile).toHaveBeenCalledTimes(2);
+    });
+
+    const imageCall = mockUploadGeneratedFourcutFile.mock.calls.find(
+      ([args]) => args.kind === "IMAGE",
+    );
+    const videoCall = mockUploadGeneratedFourcutFile.mock.calls.find(
+      ([args]) => args.kind === "VIDEO",
+    );
+
+    expect(imageCall?.[0].displayName).toBe(videoCall?.[0].displayName);
+    expect(imageCall?.[0].file.name).toBe(
+      `${videoCall?.[0].displayName}.png`,
+    );
+    expect(videoCall?.[0].file.name).toBe(
+      `${imageCall?.[0].displayName}.webm`,
+    );
+  });
 });

--- a/app/shoot/result/page.tsx
+++ b/app/shoot/result/page.tsx
@@ -82,6 +82,8 @@ export default function ShootResultPage() {
   const [isSharingVideo, setIsSharingVideo] = useState(false);
   const [hasTrimmedVideoSource, setHasTrimmedVideoSource] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const displayNameGenerationKeyRef = useRef<string | null>(null);
+  const defaultDisplayNameRef = useRef("");
   const imageGenerationKeyRef = useRef<string | null>(null);
   const videoGenerationKeyRef = useRef<string | null>(null);
   const debugVideoUrlRef = useRef<string | null>(null);
@@ -174,6 +176,14 @@ export default function ShootResultPage() {
       videoSources,
     ],
   );
+  if (displayNameGenerationKeyRef.current !== generationKey) {
+    displayNameGenerationKeyRef.current = generationKey;
+    defaultDisplayNameRef.current = buildDefaultDisplayName(
+      frameConfig?.name ?? "harucut",
+      "IMAGE",
+    );
+  }
+  const defaultDisplayName = defaultDisplayNameRef.current;
 
   useEffect(() => {
     setImageState(imageResult ? "done" : "idle");
@@ -241,10 +251,7 @@ export default function ShootResultPage() {
             canvas: canvasRef.current ?? undefined,
           });
 
-          const displayName = buildDefaultDisplayName(
-            frameConfig?.name ?? "harucut",
-            "IMAGE",
-          );
+          const displayName = defaultDisplayName;
           const file = new File([blob], `${displayName}.png`, {
             type: "image/png",
           });
@@ -315,10 +322,7 @@ export default function ShootResultPage() {
           canvas: canvasRef.current ?? undefined,
         });
 
-        const displayName = buildDefaultDisplayName(
-          frameConfig?.name ?? "harucut",
-          "VIDEO",
-        );
+        const displayName = defaultDisplayName;
         const filename = `${displayName}.webm`;
 
         if (!cancelled) {
@@ -361,6 +365,7 @@ export default function ShootResultPage() {
     };
   }, [
     consumeVideoConversion,
+    defaultDisplayName,
     effectiveBorderColor,
     frameConfig?.name,
     frameId,

--- a/app/upload/result/page.test.tsx
+++ b/app/upload/result/page.test.tsx
@@ -172,4 +172,27 @@ describe("UploadResultPage", () => {
     expect(mockRecordFrameWebm).toHaveBeenCalledTimes(1);
     expect(mockConsumeVideoConversion).toHaveBeenCalledTimes(1);
   });
+
+  it("uses the same default display name for image and video outputs", async () => {
+    render(<UploadResultPage />);
+
+    await waitFor(() => {
+      expect(mockUploadGeneratedFourcutFile).toHaveBeenCalledTimes(2);
+    });
+
+    const imageCall = mockUploadGeneratedFourcutFile.mock.calls.find(
+      ([args]) => args.kind === "IMAGE",
+    );
+    const videoCall = mockUploadGeneratedFourcutFile.mock.calls.find(
+      ([args]) => args.kind === "VIDEO",
+    );
+
+    expect(imageCall?.[0].displayName).toBe(videoCall?.[0].displayName);
+    expect(imageCall?.[0].file.name).toBe(
+      `${videoCall?.[0].displayName}.png`,
+    );
+    expect(videoCall?.[0].file.name).toBe(
+      `${imageCall?.[0].displayName}.webm`,
+    );
+  });
 });

--- a/app/upload/result/page.tsx
+++ b/app/upload/result/page.tsx
@@ -81,6 +81,8 @@ export default function UploadResultPage() {
   const [isSharingVideo, setIsSharingVideo] = useState(false);
   const [hasTrimmedVideoSource, setHasTrimmedVideoSource] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const displayNameGenerationKeyRef = useRef<string | null>(null);
+  const defaultDisplayNameRef = useRef("");
   const imageGenerationKeyRef = useRef<string | null>(null);
   const videoGenerationKeyRef = useRef<string | null>(null);
   const debugVideoUrlRef = useRef<string | null>(null);
@@ -172,6 +174,14 @@ export default function UploadResultPage() {
       videoSources,
     ],
   );
+  if (displayNameGenerationKeyRef.current !== generationKey) {
+    displayNameGenerationKeyRef.current = generationKey;
+    defaultDisplayNameRef.current = buildDefaultDisplayName(
+      frameConfig?.name ?? "harucut",
+      "IMAGE",
+    );
+  }
+  const defaultDisplayName = defaultDisplayNameRef.current;
 
   useEffect(() => {
     setImageState(imageResult ? "done" : "idle");
@@ -239,10 +249,7 @@ export default function UploadResultPage() {
             canvas: canvasRef.current ?? undefined,
           });
 
-          const displayName = buildDefaultDisplayName(
-            frameConfig?.name ?? "harucut",
-            "IMAGE",
-          );
+          const displayName = defaultDisplayName;
           const file = new File([blob], `${displayName}.png`, {
             type: "image/png",
           });
@@ -313,10 +320,7 @@ export default function UploadResultPage() {
           canvas: canvasRef.current ?? undefined,
         });
 
-        const displayName = buildDefaultDisplayName(
-          frameConfig?.name ?? "harucut",
-          "VIDEO",
-        );
+        const displayName = defaultDisplayName;
         const filename = `${displayName}.webm`;
 
         if (!cancelled) {
@@ -359,6 +363,7 @@ export default function UploadResultPage() {
     };
   }, [
     consumeVideoConversion,
+    defaultDisplayName,
     effectiveBorderColor,
     frameConfig?.name,
     frameId,

--- a/lib/userMediaPreview.test.ts
+++ b/lib/userMediaPreview.test.ts
@@ -1,0 +1,54 @@
+import { getUserMediaPreview, getUserMediaTitle } from "@/lib/userMediaPreview";
+
+describe("user media preview helpers", () => {
+  it("prefers displayName over original file name for the media title", () => {
+    expect(
+      getUserMediaTitle({
+        mediaId: 1,
+        mediaType: "PHOTO",
+        s3Key: "uploads/photo.png",
+        displayName: "harucut_20260416_213654",
+        originalFileName: "photo.png",
+      }),
+    ).toBe("harucut_20260416_213654");
+  });
+
+  it("uses the same-name photo as the preview image for a video item", () => {
+    const items = [
+      {
+        mediaId: 10,
+        mediaType: "VIDEO" as const,
+        s3Key: "uploads/result.mp4",
+        displayName: "harucut_20260416_213654",
+        downloadUrl: "https://example.com/result.mp4",
+      },
+      {
+        mediaId: 11,
+        mediaType: "PHOTO" as const,
+        s3Key: "uploads/result.png",
+        displayName: "harucut_20260416_213654",
+        downloadUrl: "https://example.com/result.png",
+      },
+    ];
+
+    expect(getUserMediaPreview(items[0], items)).toEqual({
+      kind: "image",
+      url: "https://example.com/result.png",
+    });
+  });
+
+  it("falls back to the video file when no same-name photo exists", () => {
+    const item = {
+      mediaId: 10,
+      mediaType: "VIDEO" as const,
+      s3Key: "uploads/result.mp4",
+      displayName: "harucut_20260416_213654",
+      downloadUrl: "https://example.com/result.mp4",
+    };
+
+    expect(getUserMediaPreview(item, [item])).toEqual({
+      kind: "video",
+      url: "https://example.com/result.mp4",
+    });
+  });
+});

--- a/lib/userMediaPreview.ts
+++ b/lib/userMediaPreview.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import type { UserMedia } from "@/lib/api-types";
+
+export function getUserMediaTitle(item: UserMedia) {
+  const preferredName = item.displayName?.trim() || item.displayname?.trim();
+  if (preferredName) return preferredName;
+
+  const originalName = item.originalFileName?.trim();
+  if (originalName) return originalName;
+
+  return item.s3Key.split("/").pop() || "기록";
+}
+
+function normalizeUserMediaTitle(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function getUserMediaPreview(item: UserMedia, items: UserMedia[]) {
+  if (item.mediaType === "PHOTO") {
+    return {
+      kind: "image" as const,
+      url: item.downloadUrl,
+    };
+  }
+
+  const titleKey = normalizeUserMediaTitle(getUserMediaTitle(item));
+  const matchedPhoto = items.find((candidate) => {
+    if (candidate.mediaType !== "PHOTO") return false;
+    if (!candidate.downloadUrl) return false;
+    if (candidate.mediaId === item.mediaId) return false;
+
+    return normalizeUserMediaTitle(getUserMediaTitle(candidate)) === titleKey;
+  });
+
+  if (matchedPhoto?.downloadUrl) {
+    return {
+      kind: "image" as const,
+      url: matchedPhoto.downloadUrl,
+    };
+  }
+
+  return {
+    kind: "video" as const,
+    url: item.downloadUrl,
+  };
+}


### PR DESCRIPTION
## What changed
- reused one generated base name for both image and video outputs on upload/shoot result pages
- kept the image file as `{same-name}.png` and the video file as `{same-name}.webm`
- added regression assertions so both outputs stay on the same default display name

## Why
Image and video results were each generating their own timestamp-based default name, so their filenames could differ even when they came from the same result generation flow.

## User impact
When one result flow creates both image and video, they now share the same base filename, for example `harucut_20260416_213654.png` and `harucut_20260416_213654.webm`.

## Validation
- `pnpm test -- app/upload/result/page.test.tsx`
- `pnpm test -- app/shoot/result/page.test.tsx`
- `pnpm exec eslint app/upload/result/page.tsx app/shoot/result/page.tsx app/upload/result/page.test.tsx app/shoot/result/page.test.tsx`
