### PR TITLE
[이슈 #179] WebCodecs로 결과 영상 생성 안정화

### DIFF
--- a/app/shoot/result/page.tsx
+++ b/app/shoot/result/page.tsx
@@ -31,6 +31,10 @@ import {
   registerGeneratedWebmDebug,
   unregisterGeneratedWebmDebug,
 } from "@/lib/generatedVideoDebug";
+import {
+  registerGeneratedPngDebug,
+  unregisterGeneratedPngDebug,
+} from "@/lib/generatedImageDebug";
 import { isNotNull } from "@/lib/guards";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
 import { shareOrCopyLink } from "@/lib/share";
@@ -40,6 +44,7 @@ import { updateMediaDisplayName, getMediaDownloadUrl } from "@/lib/userMediaApi"
 import { useVideoConversionQuotaStore } from "@/lib/videoConversionQuotaStore";
 
 const VIDEO_DEBUG_SCOPE = "shoot-result";
+const IMAGE_DEBUG_SCOPE = "shoot-result-image";
 
 type ProcessingState = "idle" | "processing" | "done" | "error";
 
@@ -82,6 +87,7 @@ export default function ShootResultPage() {
   const [isSharingVideo, setIsSharingVideo] = useState(false);
   const [hasTrimmedVideoSource, setHasTrimmedVideoSource] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const debugImageUrlRef = useRef<string | null>(null);
   const displayNameGenerationKeyRef = useRef<string | null>(null);
   const defaultDisplayNameRef = useRef("");
   const imageGenerationKeyRef = useRef<string | null>(null);
@@ -252,6 +258,15 @@ export default function ShootResultPage() {
           });
 
           const displayName = defaultDisplayName;
+          if (!cancelled) {
+            debugImageUrlRef.current = registerGeneratedPngDebug({
+              scope: IMAGE_DEBUG_SCOPE,
+              blob,
+              filename: `${displayName}.png`,
+              previousUrl: debugImageUrlRef.current,
+            });
+          }
+
           const file = new File([blob], `${displayName}.png`, {
             type: "image/png",
           });
@@ -386,6 +401,8 @@ export default function ShootResultPage() {
 
   useEffect(() => {
     return () => {
+      unregisterGeneratedPngDebug(IMAGE_DEBUG_SCOPE, debugImageUrlRef.current);
+      debugImageUrlRef.current = null;
       unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
       debugVideoUrlRef.current = null;
     };
@@ -644,6 +661,8 @@ export default function ShootResultPage() {
             onClick={() => {
               imageGenerationKeyRef.current = null;
               videoGenerationKeyRef.current = null;
+              unregisterGeneratedPngDebug(IMAGE_DEBUG_SCOPE, debugImageUrlRef.current);
+              debugImageUrlRef.current = null;
               unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
               debugVideoUrlRef.current = null;
               clearResults();

--- a/app/upload/result/page.tsx
+++ b/app/upload/result/page.tsx
@@ -31,6 +31,10 @@ import {
   registerGeneratedWebmDebug,
   unregisterGeneratedWebmDebug,
 } from "@/lib/generatedVideoDebug";
+import {
+  registerGeneratedPngDebug,
+  unregisterGeneratedPngDebug,
+} from "@/lib/generatedImageDebug";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
 import { shareOrCopyLink } from "@/lib/share";
 import { resolveFrameBackgroundColor } from "@/lib/themeBackground";
@@ -39,6 +43,7 @@ import { updateMediaDisplayName, getMediaDownloadUrl } from "@/lib/userMediaApi"
 import { useVideoConversionQuotaStore } from "@/lib/videoConversionQuotaStore";
 
 const VIDEO_DEBUG_SCOPE = "upload-result";
+const IMAGE_DEBUG_SCOPE = "upload-result-image";
 
 type ProcessingState = "idle" | "processing" | "done" | "error";
 
@@ -81,6 +86,7 @@ export default function UploadResultPage() {
   const [isSharingVideo, setIsSharingVideo] = useState(false);
   const [hasTrimmedVideoSource, setHasTrimmedVideoSource] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const debugImageUrlRef = useRef<string | null>(null);
   const displayNameGenerationKeyRef = useRef<string | null>(null);
   const defaultDisplayNameRef = useRef("");
   const imageGenerationKeyRef = useRef<string | null>(null);
@@ -250,6 +256,15 @@ export default function UploadResultPage() {
           });
 
           const displayName = defaultDisplayName;
+          if (!cancelled) {
+            debugImageUrlRef.current = registerGeneratedPngDebug({
+              scope: IMAGE_DEBUG_SCOPE,
+              blob,
+              filename: `${displayName}.png`,
+              previousUrl: debugImageUrlRef.current,
+            });
+          }
+
           const file = new File([blob], `${displayName}.png`, {
             type: "image/png",
           });
@@ -384,6 +399,8 @@ export default function UploadResultPage() {
 
   useEffect(() => {
     return () => {
+      unregisterGeneratedPngDebug(IMAGE_DEBUG_SCOPE, debugImageUrlRef.current);
+      debugImageUrlRef.current = null;
       unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
       debugVideoUrlRef.current = null;
     };
@@ -642,6 +659,8 @@ export default function UploadResultPage() {
             onClick={() => {
               imageGenerationKeyRef.current = null;
               videoGenerationKeyRef.current = null;
+              unregisterGeneratedPngDebug(IMAGE_DEBUG_SCOPE, debugImageUrlRef.current);
+              debugImageUrlRef.current = null;
               unregisterGeneratedWebmDebug(VIDEO_DEBUG_SCOPE, debugVideoUrlRef.current);
               debugVideoUrlRef.current = null;
               clearResults();

--- a/lib/canvas/composeFrame.ts
+++ b/lib/canvas/composeFrame.ts
@@ -24,7 +24,7 @@ type SlotDrawable =
 type OverlayImageMap = Map<string, HTMLImageElement>;
 type SupportedVideoEncoderConfig = {
   encoderConfig: VideoEncoderConfig;
-  muxerVideoOptions: NonNullable<MuxerOptions<ArrayBufferTarget>["video"]>;
+  muxerVideoOptions: NonNullable<MuxerOptions<any>["video"]>;
 };
 
 function ensureCtx(canvas: HTMLCanvasElement) {
@@ -244,7 +244,7 @@ async function resolveVideoEncoderConfig(
 
     if (support?.supported) {
       return {
-        encoderConfig: support.config,
+        encoderConfig: support.config ?? candidate.encoderConfig,
         muxerVideoOptions: candidate.muxerVideoOptions,
       };
     }

--- a/lib/canvas/composeFrame.ts
+++ b/lib/canvas/composeFrame.ts
@@ -5,6 +5,7 @@ import {
   type FourcutFilterId,
 } from "@/lib/frameFilters";
 import type { ThemeExportJson } from "@/lib/types/themeEditor";
+import type { MuxerOptions } from "webm-muxer";
 
 export type FrameLayout = {
   totalWidth: number;
@@ -21,6 +22,10 @@ type SlotDrawable =
   | { kind: "video"; el: HTMLVideoElement };
 
 type OverlayImageMap = Map<string, HTMLImageElement>;
+type SupportedVideoEncoderConfig = {
+  encoderConfig: VideoEncoderConfig;
+  muxerVideoOptions: NonNullable<MuxerOptions<ArrayBufferTarget>["video"]>;
+};
 
 function ensureCtx(canvas: HTMLCanvasElement) {
   const ctx = canvas.getContext("2d");
@@ -152,7 +157,7 @@ async function loadDrawables(sources: FrameSource[]): Promise<SlotDrawable[]> {
       if (source.type === "video") {
         const video = await loadVideo(source.src);
         const initialFrameTime =
-          Number.isFinite(video.duration) && video.duration > 0.001 ? 0.001 : 0;
+          Number.isFinite(video.duration) && video.duration > 0.1 ? 0.1 : 0;
         await seekVideoToTime(video, initialFrameTime);
         return { kind: "video", el: video };
       }
@@ -185,6 +190,81 @@ async function loadOverlayImages(theme: ThemeExportJson | null) {
   );
 
   return map;
+}
+
+async function resolveVideoEncoderConfig(
+  width: number,
+  height: number,
+  fps: number,
+): Promise<SupportedVideoEncoderConfig> {
+  const bitrate = Math.max(
+    8_000_000,
+    Math.round(width * height * fps * 0.12),
+  );
+
+  const candidates: SupportedVideoEncoderConfig[] = [
+    {
+      encoderConfig: {
+        codec: "vp09.00.10.08",
+        width,
+        height,
+        bitrate,
+        framerate: fps,
+        latencyMode: "quality",
+      },
+      muxerVideoOptions: {
+        codec: "V_VP9",
+        width,
+        height,
+        frameRate: fps,
+      },
+    },
+    {
+      encoderConfig: {
+        codec: "vp8",
+        width,
+        height,
+        bitrate,
+        framerate: fps,
+        latencyMode: "quality",
+      },
+      muxerVideoOptions: {
+        codec: "V_VP8",
+        width,
+        height,
+        frameRate: fps,
+      },
+    },
+  ];
+
+  for (const candidate of candidates) {
+    const support = await VideoEncoder.isConfigSupported(
+      candidate.encoderConfig,
+    ).catch(() => null);
+
+    if (support?.supported) {
+      return {
+        encoderConfig: support.config,
+        muxerVideoOptions: candidate.muxerVideoOptions,
+      };
+    }
+  }
+
+  throw new Error("No supported WebCodecs video encoder configuration found");
+}
+
+async function syncVideoDrawablesToElapsedTime(
+  drawables: Array<{ kind: "video"; el: HTMLVideoElement }>,
+  elapsedSeconds: number,
+) {
+  await Promise.all(
+    drawables.map((drawable) =>
+      seekVideoToTime(
+        drawable.el,
+        resolveVideoFrameTime(elapsedSeconds, drawable.el.duration),
+      ),
+    ),
+  );
 }
 
 function drawThemeOverlay(
@@ -371,65 +451,58 @@ export async function recordFrameWebm(opts: {
       drawable.kind === "video",
   );
 
-  await Promise.all(
-    videoDrawables.map(async (drawable) => {
-      try {
-        drawable.el.currentTime = resolveVideoFrameTime(0, drawable.el.duration);
-        await drawable.el.play();
-      } catch {}
-    }),
+  const frameDurationMicroseconds = Math.round(1_000_000 / fps);
+  const totalFrames = Math.max(1, Math.round(seconds * fps) + 1);
+  const encoderSupport = await resolveVideoEncoderConfig(
+    layout.totalWidth,
+    layout.totalHeight,
+    fps,
   );
-
-  const activeStream = canvas.captureStream(fps);
-  const mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9")
-    ? "video/webm;codecs=vp9"
-    : MediaRecorder.isTypeSupported("video/webm;codecs=vp8")
-      ? "video/webm;codecs=vp8"
-      : "video/webm";
-
-  const recorder = new MediaRecorder(activeStream, { mimeType });
-  const chunks: BlobPart[] = [];
-
-  recorder.ondataavailable = (event) => {
-    if (event.data && event.data.size > 0) chunks.push(event.data);
-  };
-
-  const stopped = new Promise<Blob>((resolve, reject) => {
-    recorder.onstop = () => {
-      try {
-        resolve(new Blob(chunks, { type: "video/webm" }));
-      } catch (error) {
-        reject(error);
-      }
-    };
-    recorder.onerror = () => reject(new Error("recorder error"));
+  const { ArrayBufferTarget, Muxer } = await import("webm-muxer");
+  const muxer = new Muxer({
+    target: new ArrayBufferTarget(),
+    video: encoderSupport.muxerVideoOptions,
+    firstTimestampBehavior: "offset",
   });
 
-  recorder.start();
-
-  await new Promise<void>((resolve) => {
-    const startedAt = performance.now();
-    const intervalId = window.setInterval(() => {
-      const elapsed = (performance.now() - startedAt) / 1000;
-
-      drawFrameOnce(
-        ctx,
-        layout,
-        borderColor,
-        drawables,
-        outputFilter,
-        theme,
-        overlayImages,
-      );
-
-      if (elapsed >= seconds) {
-        window.clearInterval(intervalId);
-        resolve();
-      }
-    }, 1000 / fps);
+  const encoder = new VideoEncoder({
+    output: (chunk, meta) => {
+      muxer.addVideoChunk(chunk, meta);
+    },
+    error: (error) => {
+      throw error;
+    },
   });
 
-  recorder.stop();
+  encoder.configure(encoderSupport.encoderConfig);
+
+  for (let frameIndex = 0; frameIndex < totalFrames; frameIndex += 1) {
+    const elapsed = frameIndex / fps;
+    await syncVideoDrawablesToElapsedTime(videoDrawables, elapsed);
+
+    drawFrameOnce(
+      ctx,
+      layout,
+      borderColor,
+      drawables,
+      outputFilter,
+      theme,
+      overlayImages,
+    );
+
+    const frame = new VideoFrame(canvas, {
+      timestamp: frameIndex * frameDurationMicroseconds,
+      duration: frameDurationMicroseconds,
+    });
+    encoder.encode(frame, {
+      keyFrame: frameIndex === 0 || frameIndex % fps === 0,
+    });
+    frame.close();
+  }
+
+  await encoder.flush();
+  encoder.close();
+  muxer.finalize();
 
   videoDrawables.forEach((drawable) => {
     try {
@@ -437,5 +510,5 @@ export async function recordFrameWebm(opts: {
     } catch {}
   });
 
-  return stopped;
+  return new Blob([muxer.target.buffer], { type: "video/webm" });
 }

--- a/lib/fourcutProcessing.ts
+++ b/lib/fourcutProcessing.ts
@@ -49,6 +49,7 @@ export async function uploadGeneratedFourcutFile(args: {
   extension: GeneratedFourcutAsset["extension"];
 }) {
   const { file, kind, extension } = args;
+
   const uploaded = await uploadFourcutMedia(file, {
     displayName: args.displayName,
   });

--- a/lib/generatedImageDebug.ts
+++ b/lib/generatedImageDebug.ts
@@ -1,0 +1,106 @@
+"use client";
+
+type GeneratedImageDebugEntry = {
+  filename: string;
+  url: string;
+  download: () => void;
+  open: () => string | null;
+};
+
+declare global {
+  interface Window {
+    __harucutGeneratedPng?: Record<string, GeneratedImageDebugEntry>;
+    downloadHarucutGeneratedPng?: (scope?: string) => void;
+    openHarucutGeneratedPng?: (scope?: string) => string | null;
+  }
+}
+
+function triggerDownload(url: string, filename: string) {
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+}
+
+function installGlobalCommands() {
+  window.downloadHarucutGeneratedPng = (scope = "latest") => {
+    const entries = window.__harucutGeneratedPng;
+    if (!entries) return;
+
+    const resolved = entries[scope] ?? entries.latest;
+    resolved?.download();
+  };
+
+  window.openHarucutGeneratedPng = (scope = "latest") => {
+    const entries = window.__harucutGeneratedPng;
+    if (!entries) return null;
+
+    const resolved = entries[scope] ?? entries.latest;
+    return resolved?.open() ?? null;
+  };
+}
+
+function cleanupGlobalCommandsIfEmpty() {
+  const entries = window.__harucutGeneratedPng;
+  if (entries && Object.keys(entries).length > 0) {
+    return;
+  }
+
+  delete window.__harucutGeneratedPng;
+  delete window.downloadHarucutGeneratedPng;
+  delete window.openHarucutGeneratedPng;
+}
+
+export function registerGeneratedPngDebug(args: {
+  scope: string;
+  blob: Blob;
+  filename: string;
+  previousUrl?: string | null;
+}) {
+  if (args.previousUrl) {
+    URL.revokeObjectURL(args.previousUrl);
+  }
+
+  const url = URL.createObjectURL(args.blob);
+  const entry: GeneratedImageDebugEntry = {
+    filename: args.filename,
+    url,
+    download: () => triggerDownload(url, args.filename),
+    open: () => {
+      window.open(url, "_blank", "noopener");
+      return url;
+    },
+  };
+
+  window.__harucutGeneratedPng = window.__harucutGeneratedPng ?? {};
+  window.__harucutGeneratedPng[args.scope] = entry;
+  window.__harucutGeneratedPng.latest = entry;
+  installGlobalCommands();
+
+  return url;
+}
+
+export function unregisterGeneratedPngDebug(
+  scope: string,
+  currentUrl?: string | null,
+) {
+  if (currentUrl) {
+    URL.revokeObjectURL(currentUrl);
+  }
+
+  const entries = window.__harucutGeneratedPng;
+  if (!entries) {
+    cleanupGlobalCommandsIfEmpty();
+    return;
+  }
+
+  delete entries[scope];
+
+  if (entries.latest?.url === currentUrl) {
+    delete entries.latest;
+  }
+
+  cleanupGlobalCommandsIfEmpty();
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "19.2.1",
     "react-konva": "^19.2.1",
     "use-image": "^1.1.4",
+    "webm-muxer": "^5.1.4",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       use-image:
         specifier: ^1.1.4
         version: 1.1.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      webm-muxer:
+        specifier: ^5.1.4
+        version: 5.1.4
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.4)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
@@ -1680,6 +1683,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/dom-webcodecs@0.1.18':
+    resolution: {integrity: sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -1745,6 +1751,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/wicg-file-system-access@2020.9.8':
+    resolution: {integrity: sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -5065,6 +5074,10 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webm-muxer@5.1.4:
+    resolution: {integrity: sha512-ditzgFVFbfqPaugkIr4mGhAdob5K9HY6Rzlh7TRsA368yA1sp/m5O7nQCcMLdgFDeNGtFPg8B+MeXLtpzKWX6Q==}
+    deprecated: This library is superseded by Mediabunny. Please migrate to it.
+
   webpack-dev-middleware@6.1.3:
     resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
     engines: {node: '>= 14.15.0'}
@@ -7044,6 +7057,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/dom-webcodecs@0.1.18': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -7110,6 +7125,8 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/wicg-file-system-access@2020.9.8': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -11069,6 +11086,11 @@ snapshots:
       graceful-fs: 4.2.11
 
   webidl-conversions@7.0.0: {}
+
+  webm-muxer@5.1.4:
+    dependencies:
+      '@types/dom-webcodecs': 0.1.18
+      '@types/wicg-file-system-access': 2020.9.8
 
   webpack-dev-middleware@6.1.3(webpack@5.105.2(esbuild@0.25.12)):
     dependencies:


### PR DESCRIPTION
## �۾� ����
- ���� ���� ���� ���θ� `MediaRecorder` ���ݿ��� `WebCodecs + webm-muxer` �������� ��ȯ�߽��ϴ�.
- ���ε� ����/�Կ� ���� �������� ����ó�� ���� ���� �� ���� ���ε带 �����ϵ�, �����׿� WebM/Png Ȯ�� ���δ� ���� �������ϴ�.
- ���� ���� �⺻ ���ϸ��� �̹����� ������ base name�� �����ϵ��� �����߽��ϴ�.
- ���� �������� �ߺ� ���� ���� ������ �����ϸ鼭 �� ���ڵ� ���ο� �°� �����߽��ϴ�.

## ���� ����
���� ����Ʈ ���� ������ �������� �ǽð� ĸó Ÿ�ֿ̹� �����ؼ�,
- ���̰� 8�ʺ��� ª�����ų�
- �������� ũ�� �������ų�
- wide/grid/polaroid ���� ū ���̾ƿ����� Ư�� �����̴� ������ �־����ϴ�.

## ����
### �ڵ� �׽�Ʈ
- `pnpm test -- lib/canvas/composeFrame.test.ts`
- `pnpm test -- app/upload/result/page.test.tsx`
- `pnpm test -- app/shoot/result/page.test.tsx`
- `pnpm exec eslint lib/fourcutProcessing.ts lib/canvas/composeFrame.ts app/upload/result/page.tsx app/shoot/result/page.tsx lib/generatedImageDebug.ts`

### ���� QA
�������� ���� ���� 4���� classic / wide / grid / polaroid�� ���� ���ÿ��� ���� Ȯ���߽��ϴ�.

- classic-4: ���� �� 7.999��, �� 29.37fps
- wide-4: ���� �� 7.999��, �� 29.37fps
- grid-4: ���� �� 7.999��, �� 30fps
- polaroid-4: ���� �� 7.999��, �� 28.50fps

PNG�� 4�� ������ ���� ���� �̹����� ���������� ����� ���� Ȯ���߽��ϴ�.

## �̽�
- close #179
