### PR TITLE
fix: develop 반영 전 웹·모바일 인증 UI 및 개발 환경 안정화

### DIFF
--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -45,18 +45,57 @@ function SocialButtons() {
         <Text style={styles.socialText}>또는 소셜 계정으로 계속하기</Text>
         <View style={styles.socialLine} />
       </View>
-      <ActionButton
-        icon={<Ionicons color={HARUCUT_COLORS.text} name="chatbubble-ellipses-outline" size={16} />}
-        label="카카오 로그인"
-        onPress={() => undefined}
-        variant="secondary"
-      />
-      <ActionButton
-        icon={<Ionicons color="#FFFFFF" name="logo-electron" size={16} />}
-        label="네이버 로그인"
-        onPress={() => undefined}
-      />
+      <SocialBrandButton label="카카오 로그인" onPress={() => undefined} provider="kakao" />
+      <SocialBrandButton label="네이버 로그인" onPress={() => undefined} provider="naver" />
     </View>
+  );
+}
+
+function SocialBrandButton({
+  label,
+  onPress,
+  provider,
+}: {
+  label: string;
+  onPress: () => void;
+  provider: 'kakao' | 'naver';
+}) {
+  const isKakao = provider === 'kakao';
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.socialButton,
+        isKakao ? styles.socialKakaoButton : styles.socialNaverButton,
+        pressed ? styles.socialButtonPressed : null,
+      ]}>
+      <View style={styles.socialButtonInner}>
+        <View
+          style={[
+            styles.socialIconBox,
+            isKakao ? styles.socialKakaoIconBox : styles.socialNaverIconBox,
+          ]}>
+          {isKakao ? (
+            <View style={styles.kakaoMark}>
+              <View style={styles.kakaoMarkBubble} />
+              <View style={styles.kakaoMarkTail} />
+            </View>
+          ) : (
+            <Text style={styles.naverMark}>N</Text>
+          )}
+        </View>
+        <View style={styles.socialLabelWrap}>
+          <Text
+            style={[
+              styles.socialButtonLabel,
+              isKakao ? styles.socialKakaoLabel : styles.socialNaverLabel,
+            ]}>
+            {label}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
   );
 }
 
@@ -460,15 +499,101 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: '600',
   },
+  kakaoMark: {
+    height: 18,
+    position: 'relative',
+    width: 18,
+  },
+  kakaoMarkBubble: {
+    backgroundColor: 'rgba(0, 0, 0, 0.85)',
+    borderRadius: 7,
+    height: 13,
+    left: 1,
+    position: 'absolute',
+    top: 2,
+    width: 15,
+  },
+  kakaoMarkTail: {
+    backgroundColor: 'rgba(0, 0, 0, 0.85)',
+    bottom: 2,
+    height: 5,
+    left: 4,
+    position: 'absolute',
+    transform: [{ rotate: '45deg' }],
+    width: 5,
+  },
+  naverMark: {
+    color: '#FFFFFF',
+    fontSize: 18,
+    fontWeight: '900',
+    lineHeight: 20,
+  },
   socialDivider: {
     alignItems: 'center',
     flexDirection: 'row',
     gap: 8,
   },
+  socialButton: {
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  socialButtonInner: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    minHeight: 48,
+  },
+  socialButtonLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+    letterSpacing: -0.1,
+  },
+  socialButtonPressed: {
+    opacity: 0.9,
+  },
+  socialIconBox: {
+    alignItems: 'center',
+    height: 48,
+    justifyContent: 'center',
+    width: 48,
+  },
+  socialKakaoButton: {
+    backgroundColor: '#FEE500',
+    shadowColor: 'rgba(15, 23, 42, 0.08)',
+    shadowOffset: { height: 14, width: 0 },
+    shadowOpacity: 1,
+    shadowRadius: 24,
+  },
+  socialKakaoIconBox: {
+    backgroundColor: '#FEE500',
+  },
+  socialKakaoLabel: {
+    color: 'rgba(0, 0, 0, 0.85)',
+  },
   socialLine: {
     backgroundColor: HARUCUT_COLORS.border,
     flex: 1,
     height: 1,
+  },
+  socialLabelWrap: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    paddingRight: 48,
+  },
+  socialNaverButton: {
+    backgroundColor: '#03C75A',
+    shadowColor: 'rgba(3, 199, 90, 0.22)',
+    shadowOffset: { height: 16, width: 0 },
+    shadowOpacity: 1,
+    shadowRadius: 26,
+  },
+  socialNaverIconBox: {
+    backgroundColor: '#02B350',
+    borderRightColor: 'rgba(255, 255, 255, 0.15)',
+    borderRightWidth: 1,
+  },
+  socialNaverLabel: {
+    color: '#FFFFFF',
   },
   socialText: {
     color: HARUCUT_COLORS.muted,

--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -84,7 +84,6 @@ export function ShootCaptureScreen() {
   const router = useRouter();
   const [permission, requestPermission] = useCameraPermissions();
   const push = (path: string) => router.push(path as never);
-  const replace = (path: string) => router.replace(path as never);
   const cameraRef = useRef<CameraView | null>(null);
   const shoot = useHarucutStore((state) => state.shoot);
   const addShootShot = useHarucutStore((state) => state.addShootShot);
@@ -97,7 +96,7 @@ export function ShootCaptureScreen() {
 
   useEffect(() => {
     if (!shoot.frameId) {
-      replace('/shoot');
+      router.replace('/shoot' as never);
     }
   }, [router, shoot.frameId]);
 
@@ -213,7 +212,7 @@ export function ShootCaptureScreen() {
 
         <View style={{ gap: 8 }}>
           <Text style={styles.bodyText}>
-            카메라를 켜고 "8장 자동 촬영 시작" 버튼을 누르면 3초 간격으로 사진을 촬영해요.
+            카메라를 켜고 &quot;8장 자동 촬영 시작&quot; 버튼을 누르면 3초 간격으로 사진을 촬영해요.
           </Text>
           <Text style={styles.statusText}>카메라 {isCameraReady ? '준비 완료' : '아직 켜져 있지 않아요'}</Text>
         </View>
@@ -242,7 +241,6 @@ export function ShootCaptureScreen() {
 export function ShootSelectScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
-  const replace = (path: string) => router.replace(path as never);
   const accessMode = useHarucutStore((state) => state.accessMode);
   const shoot = useHarucutStore((state) => state.shoot);
   const toggleShootSelection = useHarucutStore((state) => state.toggleShootSelection);
@@ -250,12 +248,12 @@ export function ShootSelectScreen() {
 
   useEffect(() => {
     if (!shoot.frameId) {
-      replace('/shoot');
+      router.replace('/shoot' as never);
       return;
     }
 
     if (shoot.shots.length === 0) {
-      replace('/shoot/capture');
+      router.replace('/shoot/capture' as never);
     }
   }, [router, shoot.frameId, shoot.shots.length]);
 
@@ -336,7 +334,6 @@ export function ShootSelectScreen() {
 export function ShootResultScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
-  const replace = (path: string) => router.replace(path as never);
   const accessMode = useHarucutStore((state) => state.accessMode);
   const shoot = useHarucutStore((state) => state.shoot);
   const persistShootResult = useHarucutStore((state) => state.persistShootResult);
@@ -350,12 +347,12 @@ export function ShootResultScreen() {
 
   useEffect(() => {
     if (!shoot.frameId) {
-      replace('/shoot');
+      router.replace('/shoot' as never);
       return;
     }
 
     if (shoot.selectedShotIds.length !== 4) {
-      replace('/shoot/select');
+      router.replace('/shoot/select' as never);
       return;
     }
 

--- a/apps/mobile/screens/theme-screens.tsx
+++ b/apps/mobile/screens/theme-screens.tsx
@@ -41,8 +41,6 @@ export function ThemeFrameScreen() {
 export function ThemeStickerScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
-  const replace = (path: string) => router.replace(path as never);
-  const savedFrames = useHarucutStore((state) => state.savedFrames);
   const themeEditor = useHarucutStore((state) => state.themeEditor);
   const setThemeTitle = useHarucutStore((state) => state.setThemeTitle);
   const setThemeDescription = useHarucutStore((state) => state.setThemeDescription);
@@ -55,7 +53,7 @@ export function ThemeStickerScreen() {
 
   useEffect(() => {
     if (!themeEditor.frameId) {
-      replace('/theme');
+      router.replace('/theme' as never);
     }
   }, [router, themeEditor.frameId]);
 

--- a/apps/mobile/screens/upload-screens.tsx
+++ b/apps/mobile/screens/upload-screens.tsx
@@ -1,7 +1,7 @@
 import * as ImagePicker from 'expo-image-picker';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useRouter } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Image, Pressable, Share, StyleSheet, Text, View } from 'react-native';
 
 import { FRAME_BORDER_OPTIONS, OUTPUT_TONE_OPTIONS, type MediaAsset } from '@/constants/harucut-data';
@@ -50,7 +50,6 @@ export function UploadFrameScreen() {
 export function UploadSelectScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
-  const replace = (path: string) => router.replace(path as never);
   const upload = useHarucutStore((state) => state.upload);
   const addUploadAssets = useHarucutStore((state) => state.addUploadAssets);
   const toggleUploadSelection = useHarucutStore((state) => state.toggleUploadSelection);
@@ -58,7 +57,7 @@ export function UploadSelectScreen() {
 
   useEffect(() => {
     if (!upload.frameId) {
-      replace('/upload');
+      router.replace('/upload' as never);
     }
   }, [router, upload.frameId]);
 
@@ -171,7 +170,6 @@ export function UploadSelectScreen() {
 export function UploadResultScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
-  const replace = (path: string) => router.replace(path as never);
   const upload = useHarucutStore((state) => state.upload);
   const persistUploadResult = useHarucutStore((state) => state.persistUploadResult);
   const historyItems = useHarucutStore((state) => state.historyItems);
@@ -180,12 +178,12 @@ export function UploadResultScreen() {
 
   useEffect(() => {
     if (!upload.frameId) {
-      replace('/upload');
+      router.replace('/upload' as never);
       return;
     }
 
     if (upload.selectedAssetIds.length !== 4) {
-      replace('/upload/select');
+      router.replace('/upload/select' as never);
       return;
     }
 

--- a/apps/web/components/auth/SocialLoginSection.tsx
+++ b/apps/web/components/auth/SocialLoginSection.tsx
@@ -59,19 +59,19 @@ function SocialButton({
       type="button"
       onClick={onClick}
       className={[
-        "inline-flex h-11 w-full items-center rounded-xl text-sm font-semibold transition-colors",
+        "inline-flex h-12 w-full items-center rounded-[12px] text-sm font-semibold transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--hc-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-white hover:-translate-y-0.5",
         className,
       ].join(" ")}
     >
       <span
         className={[
-          "flex h-full w-11 items-center justify-center rounded-l-xl",
+          "flex h-full w-12 items-center justify-center rounded-l-[12px]",
           iconContainerClassName,
         ].join(" ")}
       >
         {icon}
       </span>
-      <span className="flex-1 pr-11 text-center">{label}</span>
+      <span className="flex-1 pr-12 text-center tracking-[-0.01em]">{label}</span>
     </button>
   );
 }
@@ -85,9 +85,9 @@ export function SocialLoginSection({
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center gap-2 text-[10px] text-zinc-500">
-        <span className="h-px flex-1 bg-zinc-800" />
+        <span className="h-px flex-1 bg-[color:var(--hc-border)]" />
         <span>또는 소셜 계정으로 계속하기</span>
-        <span className="h-px flex-1 bg-zinc-800" />
+        <span className="h-px flex-1 bg-[color:var(--hc-border)]" />
       </div>
 
       <div className="flex flex-col gap-2">
@@ -95,16 +95,16 @@ export function SocialLoginSection({
           onClick={() => loginKakao(redirectTo)}
           icon={<KakaoSymbol />}
           label="카카오 로그인"
-          className="border border-[color:var(--hc-border)] bg-[color:var(--hc-surface-strong)] text-[color:var(--hc-text)] shadow-[0_14px_32px_var(--hc-shadow)] hover:bg-[color:var(--hc-background-tint)]"
-          iconContainerClassName="border-r border-[color:var(--hc-border)] bg-[linear-gradient(180deg,#fff9d9,#fff3b0)]"
+          className="bg-[#FEE500] text-[rgba(0,0,0,0.85)] shadow-[0_14px_32px_rgba(15,23,42,0.08)] hover:bg-[#F7DD00]"
+          iconContainerClassName="bg-[#FEE500]"
         />
 
         <SocialButton
           onClick={() => loginNaver(redirectTo)}
           icon={<NaverSymbol />}
           label="네이버 로그인"
-          className="bg-[color:var(--hc-primary)] text-white shadow-[0_16px_36px_rgba(37,99,235,0.26)] hover:bg-[color:var(--hc-primary-strong)]"
-          iconContainerClassName="border-r border-white/20 bg-[color:var(--hc-primary-strong)]"
+          className="bg-[#03C75A] text-white shadow-[0_16px_36px_rgba(3,199,90,0.24)] hover:bg-[#02B350]"
+          iconContainerClassName="border-r border-white/15 bg-[#02B350]"
         />
       </div>
     </section>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "generate:stickers": "node scripts/generate-stickers.mjs",
     "dev": "next dev",
-    "build": "pnpm generate:stickers && next build",
+    "build": "pnpm generate:stickers && next build --webpack",
     "start": "next start",
     "lint": "eslint .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   },
   "scripts": {
     "dev": "pnpm dev:web",
-    "dev:web": "pnpm --dir apps/web dev",
+    "dev:web": "cd apps/web && node ./node_modules/next/dist/bin/next dev --hostname localhost",
     "build": "pnpm build:web",
     "build:web": "pnpm --dir apps/web build",
     "start": "pnpm start:web",
-    "start:web": "pnpm --dir apps/web start",
+    "start:web": "cd apps/web && node ./node_modules/next/dist/bin/next start --hostname localhost",
     "lint:web": "pnpm --dir apps/web lint",
     "test:web": "pnpm --dir apps/web test",
     "test:coverage:web": "pnpm --dir apps/web test:coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "files": [],
-  "exclude": [
-    "node_modules",
-    "apps/**/node_modules",
-    "apps/**/.expo"
-  ]
+  "references": [{ "path": "./apps/web" }, { "path": "./apps/mobile" }],
+  "exclude": ["node_modules", "apps/**/node_modules", "apps/**/.expo"]
 }


### PR DESCRIPTION
## 요약
- 웹/모바일 소셜 로그인 버튼을 공식 브랜드 톤에 맞게 정리했습니다.
- 모바일 인증/촬영/업로드 화면의 lint/typecheck 경고를 정리했습니다.
- 루트 `tsconfig.json`의 빈 `files` 관련 타입스크립트 경고를 해소했습니다.
- Windows 환경에서 `pnpm dev:web`와 `pnpm build:web`가 안정적으로 동작하도록 스크립트를 보정했습니다.

## 상세 변경
- `apps/web/components/auth/SocialLoginSection.tsx`
  - 카카오/네이버 로그인 버튼을 공식 컬러 기준으로 정리
- `apps/mobile/screens/public-screens.tsx`
  - 모바일 로그인/회원가입 화면의 소셜 로그인 버튼을 전용 브랜드 버튼으로 교체
- `apps/mobile/screens/shoot-screens.tsx`
- `apps/mobile/screens/theme-screens.tsx`
- `apps/mobile/screens/upload-screens.tsx`
  - ESLint/React Hook 경고 정리
- `package.json`
  - 루트 `dev:web` 실행 시 Windows 호스트 바인딩 문제를 피하도록 보정
- `apps/web/package.json`
  - Windows 환경의 Turbopack 패닉을 피하도록 웹 빌드를 `--webpack`으로 고정
- `tsconfig.json`
  - 빈 `files` 경고가 발생하지 않도록 루트 TS 설정 정리

## 검증
- `pnpm lint:web`
- `pnpm build:web`
- `pnpm lint:mobile`
- `pnpm typecheck:mobile`

Closes #187