### PR TITLE
refactor: 웹·모바일 프레임 선택과 미리보기 흐름 정리

### DIFF
--- a/apps/mobile/components/harucut/frame.tsx
+++ b/apps/mobile/components/harucut/frame.tsx
@@ -1,6 +1,18 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useMemo } from 'react';
-import { Image, Pressable, StyleSheet, Text, View, type DimensionValue } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useMemo, useState } from 'react';
+import {
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+  type StyleProp,
+  type DimensionValue,
+  type ViewStyle,
+} from 'react-native';
 
 import { ActionButton, Pill, SurfaceCard } from '@/components/harucut/ui';
 import {
@@ -18,6 +30,13 @@ type FrameSlot = {
   top: DimensionValue;
   width: DimensionValue;
 };
+
+type FramePickerLayoutMode = 'carousel' | 'grid';
+
+const FRAME_PICKER_PREVIEW_BOX = {
+  height: 176,
+  width: 132,
+} as const;
 
 const FRAME_LAYOUTS: Record<FrameId, { aspectRatio: number; slots: FrameSlot[] }> = {
   'classic-4': {
@@ -70,22 +89,28 @@ export function FramePreview({
   caption,
   frameId,
   media = [],
+  style,
 }: {
   accentColor?: string;
   backgroundColor?: string;
   caption?: string;
   frameId: FrameId;
   media?: MediaAsset[];
+  style?: StyleProp<ViewStyle>;
 }) {
   const { colors } = useHarucutTheme();
   const styles = useFrameStyles();
   const layout = FRAME_LAYOUTS[frameId];
-  const frameMeta = FRAME_CATALOG.find((item) => item.frameId === frameId);
   const resolvedAccent = accentColor ?? colors.primary;
   const resolvedBackground = backgroundColor ?? colors.cardStrong;
 
   return (
-    <View style={[styles.previewShell, { aspectRatio: layout.aspectRatio, backgroundColor: resolvedBackground }]}>
+    <View
+      style={[
+        styles.previewShell,
+        { aspectRatio: layout.aspectRatio, backgroundColor: resolvedBackground },
+        style,
+      ]}>
       <View style={[styles.previewOutline, { borderColor: resolvedAccent }]} />
       {layout.slots.map((slot, index) => {
         const currentMedia = media[index];
@@ -110,9 +135,7 @@ export function FramePreview({
                   </View>
                 ) : null}
               </>
-            ) : (
-              <Text style={[styles.slotLabel, { color: resolvedAccent }]}>{frameMeta?.shortLabel ?? index + 1}</Text>
-            )}
+            ) : null}
           </View>
         );
       })}
@@ -133,35 +156,165 @@ export function FramePickerSection({
   selectedFrameId: FrameId;
 }) {
   const styles = useFrameStyles();
+  const { width } = useWindowDimensions();
+  const { colors } = useHarucutTheme();
+  const [layoutMode, setLayoutMode] = useState<FramePickerLayoutMode>('grid');
+  const carouselCardWidth = Math.min(Math.max(width - 92, 260), 336);
+  const carouselSidePadding = Math.max((width - carouselCardWidth) / 2, 16);
+  const carouselCardGap = 12;
+  const carouselTrailingPadding = carouselSidePadding + 56;
+  const carouselSnapOffsets = FRAME_CATALOG.map(
+    (_, index) => index * (carouselCardWidth + carouselCardGap),
+  );
 
   return (
     <>
-      <View style={styles.grid}>
-        {FRAME_CATALOG.map((frame) => {
-          const selected = frame.frameId === selectedFrameId;
-          return (
-            <Pressable
-              key={frame.frameId}
-              onPress={() => onSelect(frame.frameId)}
-              style={[styles.frameCard, selected ? styles.frameCardSelected : null]}>
-              <Pill active={selected}>{frame.badge}</Pill>
-              <Text style={styles.frameTitle}>{frame.name}</Text>
-              <Text style={styles.frameSubtitle}>{frame.shortLabel}</Text>
-              <View style={styles.framePreviewWrap}>
-                <FramePreview frameId={frame.frameId} />
-              </View>
-              <View style={styles.frameTags}>
-                {frame.recommendedFor.slice(0, 2).map((item) => (
-                  <Pill key={`${frame.frameId}-${item}`}>{item}</Pill>
-                ))}
-              </View>
-            </Pressable>
-          );
-        })}
+      <View style={styles.layoutControls}>
+        <Text style={styles.layoutLabel}>프레임 보기 방식</Text>
+        <View style={styles.layoutOptions}>
+          <Pill active={layoutMode === 'grid'} onPress={() => setLayoutMode('grid')}>
+            2열 그리드
+          </Pill>
+          <Pill active={layoutMode === 'carousel'} onPress={() => setLayoutMode('carousel')}>
+            가로 카드
+          </Pill>
+        </View>
       </View>
+
+      {layoutMode === 'grid' ? (
+        <View style={styles.grid}>
+          {FRAME_CATALOG.map((frame) => (
+            <FramePickerCard
+              key={frame.frameId}
+              frame={frame}
+              layoutMode="grid"
+              onPress={() => onSelect(frame.frameId)}
+              selected={frame.frameId === selectedFrameId}
+            />
+          ))}
+        </View>
+      ) : (
+        <View style={styles.carouselSection}>
+          <View style={styles.carouselShell}>
+            <ScrollView
+              bounces={false}
+              decelerationRate="fast"
+              disableIntervalMomentum
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              snapToOffsets={carouselSnapOffsets}
+              contentContainerStyle={[
+                styles.carouselContent,
+                {
+                  paddingLeft: carouselSidePadding,
+                  paddingRight: carouselTrailingPadding,
+                },
+              ]}>
+              {FRAME_CATALOG.map((frame) => (
+                <FramePickerCard
+                  key={frame.frameId}
+                  frame={frame}
+                  layoutMode="carousel"
+                  onPress={() => onSelect(frame.frameId)}
+                  selected={frame.frameId === selectedFrameId}
+                  width={carouselCardWidth}
+                />
+              ))}
+            </ScrollView>
+            <LinearGradient
+              colors={[colors.background, 'transparent']}
+              pointerEvents="none"
+              start={{ x: 0, y: 0.5 }}
+              end={{ x: 1, y: 0.5 }}
+              style={[styles.carouselFade, styles.carouselFadeLeft]}
+            />
+            <LinearGradient
+              colors={['transparent', colors.background]}
+              pointerEvents="none"
+              start={{ x: 0, y: 0.5 }}
+              end={{ x: 1, y: 0.5 }}
+              style={[styles.carouselFade, styles.carouselFadeRight]}
+            />
+          </View>
+        </View>
+      )}
       <ActionButton label={confirmLabel} onPress={onConfirm} />
     </>
   );
+}
+
+function FramePickerCard({
+  frame,
+  layoutMode,
+  onPress,
+  selected,
+  width,
+}: {
+  frame: (typeof FRAME_CATALOG)[number];
+  layoutMode: FramePickerLayoutMode;
+  onPress: () => void;
+  selected: boolean;
+  width?: number;
+}) {
+  const { colors } = useHarucutTheme();
+  const styles = useFrameStyles();
+  const previewLayout = getContainedPreviewLayout(frame.frameId);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.frameCard,
+        layoutMode === 'grid' ? styles.frameCardGrid : styles.frameCardCarousel,
+        selected ? styles.frameCardSelected : null,
+        pressed ? styles.frameCardPressed : null,
+        width ? { width } : null,
+      ]}>
+      <View
+        style={[
+          styles.framePreviewWrap,
+          layoutMode === 'grid'
+            ? styles.framePreviewWrapGrid
+            : styles.framePreviewWrapCarousel,
+        ]}>
+        <View style={styles.framePreviewViewport}>
+          <FramePreview frameId={frame.frameId} style={previewLayout} />
+        </View>
+      </View>
+
+      <View style={styles.frameHeader}>
+        <Text style={styles.frameTitle}>{frame.name}</Text>
+        <View
+          style={[
+            styles.selectionBadge,
+            selected ? styles.selectionBadgeActive : null,
+          ]}>
+          <Ionicons
+            color={selected ? '#FFFFFF' : colors.muted}
+            name={selected ? 'checkmark' : 'ellipse-outline'}
+            size={14}
+          />
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+function getContainedPreviewLayout(frameId: FrameId) {
+  const aspectRatio = FRAME_LAYOUTS[frameId].aspectRatio;
+  const { width, height } = FRAME_PICKER_PREVIEW_BOX;
+
+  if (aspectRatio * height <= width) {
+    return {
+      height,
+      width: height * aspectRatio,
+    } satisfies ViewStyle;
+  }
+
+  return {
+    height: width / aspectRatio,
+    width,
+  } satisfies ViewStyle;
 }
 
 export function SavedFramesPanel({
@@ -198,8 +351,8 @@ export function SavedFramesPanel({
           <Text style={styles.savedTitle}>{title}</Text>
           {description ? <Text style={styles.savedDescription}>{description}</Text> : null}
         </View>
-        <Pressable onPress={onRefresh}>
-          <Text style={[styles.savedRefresh, { color: colors.primary }]}>새로고침</Text>
+        <Pressable accessibilityLabel="새로고침" onPress={onRefresh} style={styles.savedRefreshButton}>
+          <Ionicons color={colors.primary} name="refresh" size={16} />
         </Pressable>
       </View>
 
@@ -259,14 +412,45 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       lineHeight: 18,
       marginTop: 16,
     },
+    carouselContent: {
+      gap: 12,
+      paddingVertical: 4,
+    },
+    carouselFade: {
+      bottom: 0,
+      position: 'absolute',
+      top: 0,
+      width: 28,
+    },
+    carouselFadeLeft: {
+      left: 0,
+    },
+    carouselFadeRight: {
+      right: 0,
+    },
+    carouselSection: {
+      gap: 10,
+    },
+    carouselShell: {
+      marginHorizontal: -16,
+      overflow: 'hidden',
+    },
     frameCard: {
       backgroundColor: colors.card,
       borderColor: colors.border,
       borderRadius: HARUCUT_RADII.card,
       borderWidth: 1,
-      gap: 10,
+      gap: 12,
       padding: 14,
+    },
+    frameCardCarousel: {
+      width: 296,
+    },
+    frameCardGrid: {
       width: '48%',
+    },
+    frameCardPressed: {
+      opacity: 0.92,
     },
     frameCardSelected: {
       borderColor: colors.primary,
@@ -274,34 +458,61 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       shadowOffset: { height: 18, width: 0 },
       shadowOpacity: isDark ? 0.34 : 1,
       shadowRadius: 32,
+      transform: [{ translateY: -2 }],
+    },
+    frameHeader: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: 10,
+      justifyContent: 'space-between',
+      minHeight: 26,
     },
     framePreviewWrap: {
+      alignItems: 'center',
       backgroundColor: colors.backgroundTint,
       borderColor: colors.border,
       borderRadius: HARUCUT_RADII.lg,
       borderWidth: 1,
+      justifyContent: 'center',
       overflow: 'hidden',
+    },
+    framePreviewWrapCarousel: {
+      minHeight: FRAME_PICKER_PREVIEW_BOX.height + 32,
+      padding: 16,
+    },
+    framePreviewWrapGrid: {
+      minHeight: FRAME_PICKER_PREVIEW_BOX.height + 24,
       padding: 12,
     },
-    frameSubtitle: {
-      color: colors.muted,
-      fontSize: 11,
-      fontWeight: '600',
-    },
-    frameTags: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: 6,
-    },
-    frameTitle: {
-      color: colors.text,
-      fontSize: 15,
-      fontWeight: '700',
+    framePreviewViewport: {
+      alignItems: 'center',
+      height: FRAME_PICKER_PREVIEW_BOX.height,
+      justifyContent: 'center',
+      width: FRAME_PICKER_PREVIEW_BOX.width,
     },
     grid: {
       flexDirection: 'row',
       flexWrap: 'wrap',
       gap: 12,
+    },
+    frameTitle: {
+      color: colors.text,
+      fontSize: 15,
+      fontWeight: '700',
+      flex: 1,
+    },
+    layoutControls: {
+      gap: 10,
+      marginBottom: 4,
+    },
+    layoutLabel: {
+      color: colors.muted,
+      fontSize: 12,
+      fontWeight: '700',
+    },
+    layoutOptions: {
+      flexDirection: 'row',
+      gap: 8,
     },
     previewOutline: {
       borderRadius: 24,
@@ -364,6 +575,15 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       fontSize: 11,
       fontWeight: '700',
     },
+    savedRefreshButton: {
+      alignItems: 'center',
+      borderColor: colors.border,
+      borderRadius: HARUCUT_RADII.chip,
+      borderWidth: 1,
+      height: 32,
+      justifyContent: 'center',
+      width: 32,
+    },
     savedStatus: {
       color: colors.primaryStrong,
       fontSize: 10,
@@ -373,6 +593,20 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       color: colors.text,
       fontSize: 15,
       fontWeight: '700',
+    },
+    selectionBadge: {
+      alignItems: 'center',
+      backgroundColor: colors.cardStrong,
+      borderColor: colors.border,
+      borderRadius: HARUCUT_RADII.chip,
+      borderWidth: 1,
+      height: 22,
+      justifyContent: 'center',
+      width: 22,
+    },
+    selectionBadgeActive: {
+      backgroundColor: colors.primary,
+      borderColor: colors.primary,
     },
     slot: {
       backgroundColor: colors.cardMuted,
@@ -385,13 +619,6 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     slotImage: {
       height: '100%',
       width: '100%',
-    },
-    slotLabel: {
-      fontSize: 10,
-      fontWeight: '700',
-      left: 8,
-      position: 'absolute',
-      top: 8,
     },
     videoBadge: {
       alignItems: 'center',

--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -78,8 +78,7 @@ export function ShootFrameScreen() {
       />
       {accessMode === 'member' ? (
         <SavedFramesPanel
-          description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 촬영할 수 있어요."
-          emptyText="이 타입으로 저장한 프레임이 아직 없어요."
+          emptyText="저장된 프레임이 없습니다."
           frames={savedFrames}
           onRefresh={() => undefined}
           onSelect={selectSavedFrameForShoot}
@@ -207,10 +206,6 @@ export function ShootCaptureScreen() {
             </View>
           )}
 
-          <View style={styles.slotBadge}>
-            <Text style={styles.slotBadgeText}>슬롯 {(shoot.shots.length % 4) + 1} / 4</Text>
-          </View>
-
           {isShooting && countdown ? (
             <View style={styles.countdownOverlay}>
               <View style={styles.countdownCircle}>
@@ -271,6 +266,13 @@ export function ShootSelectScreen() {
   }, [router, shoot.frameId, shoot.shots.length]);
 
   const selectedCount = shoot.selectedShotIds.length;
+  const previewMedia = useMemo(
+    () =>
+      shoot.selectedShotIds
+        .map((id) => shoot.shots.find((item) => item.id === id))
+        .filter((item): item is MediaAsset => Boolean(item)),
+    [shoot.selectedShotIds, shoot.shots],
+  );
 
   return (
     <AppScrollView>
@@ -280,6 +282,13 @@ export function ShootSelectScreen() {
         onPressBack={() => push('/shoot/capture')}
         title="사진 선택"
       />
+
+      <SurfaceCard style={{ gap: 14 }}>
+        <Text style={styles.sectionTitle}>프레임 미리보기</Text>
+        <View style={{ alignItems: 'center' }}>
+          <FramePreview accentColor={shoot.borderColor} frameId={shoot.frameId} media={previewMedia} />
+        </View>
+      </SurfaceCard>
 
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.bodyText}>방금 촬영한 사진 {shoot.shots.length}장 중에서 4장을 골라 주세요.</Text>
@@ -618,20 +627,6 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     sectionTitle: {
       color: colors.text,
       fontSize: 18,
-      fontWeight: '700',
-    },
-    slotBadge: {
-      backgroundColor: colors.overlayStrong,
-      borderRadius: 999,
-      left: 10,
-      paddingHorizontal: 10,
-      paddingVertical: 6,
-      position: 'absolute',
-      top: 10,
-    },
-    slotBadgeText: {
-      color: '#FFFFFF',
-      fontSize: 10,
       fontWeight: '700',
     },
     statusRow: {

--- a/apps/mobile/screens/upload-screens.tsx
+++ b/apps/mobile/screens/upload-screens.tsx
@@ -47,7 +47,7 @@ export function UploadFrameScreen() {
       />
       <SavedFramesPanel
         description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 만들 수 있어요."
-        emptyText="이 타입으로 저장한 프레임이 아직 없어요."
+        emptyText="저장된 프레임이 없습니다."
         frames={savedFrames}
         onRefresh={() => undefined}
         onSelect={selectSavedFrameForUpload}
@@ -78,6 +78,13 @@ export function UploadSelectScreen() {
   const selectedCount = upload.selectedAssetIds.length;
   const selectedHasVideo = upload.assets.some(
     (item) => upload.selectedAssetIds.includes(item.id) && item.kind === 'video'
+  );
+  const previewMedia = useMemo(
+    () =>
+      upload.selectedAssetIds
+        .map((id) => upload.assets.find((item) => item.id === id))
+        .filter((item): item is MediaAsset => Boolean(item)),
+    [upload.assets, upload.selectedAssetIds],
   );
 
   const handlePickAssets = async () => {
@@ -110,6 +117,13 @@ export function UploadSelectScreen() {
         onPressBack={() => push('/upload')}
         title="업로드할 사진 선택"
       />
+
+      <SurfaceCard style={{ gap: 14 }}>
+        <Text style={styles.sectionTitle}>프레임 미리보기</Text>
+        <View style={{ alignItems: 'center' }}>
+          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
+        </View>
+      </SurfaceCard>
 
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.bodyText}>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -53,6 +53,8 @@
   --hc-theme-toggle-active-bg: rgba(37, 99, 235, 0.12);
   --hc-theme-toggle-active-text: #1d4ed8;
   --hc-theme-toggle-shadow: 0 18px 48px rgba(37, 99, 235, 0.18);
+  --hc-frame-picker-preview-outer: #303846;
+  --hc-frame-picker-preview-inner: #f4f7fb;
   --hc-page-gradient-app:
     radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 28%),
     linear-gradient(180deg, #f8fbff 0%, #eef5ff 100%);
@@ -145,6 +147,8 @@ html[data-theme="dark"] {
   --hc-theme-toggle-active-bg: rgba(56, 189, 248, 0.16);
   --hc-theme-toggle-active-text: #e0f2fe;
   --hc-theme-toggle-shadow: 0 18px 48px rgba(0, 0, 0, 0.3);
+  --hc-frame-picker-preview-outer: #e7ecf2;
+  --hc-frame-picker-preview-inner: #171c24;
   --hc-page-gradient-app: #09090b;
   --hc-page-gradient-showcase:
     radial-gradient(circle at top, rgba(56, 189, 248, 0.14), transparent 24%),

--- a/apps/web/app/shoot/capture/page.tsx
+++ b/apps/web/app/shoot/capture/page.tsx
@@ -37,10 +37,6 @@ export default function CapturePage() {
     layout && layout.slots.length > 0
       ? layout.slots[shotCount % layout.slots.length]
       : null;
-  const currentSlotOrder =
-    layout && layout.slots.length > 0
-      ? (shotCount % layout.slots.length) + 1
-      : null;
 
   return (
     <main className="hc-page-app min-h-dvh px-4 py-6 text-[color:var(--hc-text)]">
@@ -90,9 +86,6 @@ export default function CapturePage() {
                   muted
                   className="h-full w-full scale-x-[-1] object-cover"
                 />
-                <div className="pointer-events-none absolute left-2 top-2 z-20 rounded-full bg-black/60 px-2 py-0.5 text-[10px] text-white">
-                  슬롯 {currentSlotOrder} / 4
-                </div>
                 {themeData ? (
                   <ThemeOverlaySvg
                     layout={layout}

--- a/apps/web/app/shoot/page.tsx
+++ b/apps/web/app/shoot/page.tsx
@@ -57,7 +57,7 @@ function ShootPageContent() {
     <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)]">
       <div className="mx-auto flex w-full max-w-md flex-col gap-4">
         <PageHeader
-          title={accessMode === "guest" ? "비회원 촬영 체험" : "촬영"}
+          title={accessMode === "guest" ? "비회원 촬영 체험" : undefined}
           backHref={accessMode === "guest" ? "/" : "/home"}
           backLabel={accessMode === "guest" ? "처음으로" : "홈으로"}
           brandHref={accessMode === "guest" ? "/shoot" : "/home"}
@@ -82,8 +82,7 @@ function ShootPageContent() {
         {accessMode === "member" ? (
           <SavedFramesSection
             title="저장한 프레임"
-            description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 촬영할 수 있어요."
-            emptyText="이 타입으로 저장한 프레임이 아직 없어요."
+            emptyText="저장된 프레임이 없습니다."
             selectedFrameId={selectedFrameId}
             frames={frames}
             isLoading={isLoading}

--- a/apps/web/app/shoot/select/page.tsx
+++ b/apps/web/app/shoot/select/page.tsx
@@ -91,7 +91,6 @@ export default function ShootSelectPage() {
           images={shotPhotos}
           selectedIndexes={selectedIndexes}
           maxSelect={4}
-          guideText={`방금 촬영한 사진 ${shots.length}장 중에서 4장을 골라 주세요.`}
           emptyStateText="촬영한 사진이 없어요. 다시 촬영해 주세요."
           nextButtonLabel="다음 단계로"
           onToggleSelect={toggleSelect}

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -75,7 +75,7 @@ function UploadFramePageContent() {
         <SavedFramesSection
           title="저장한 프레임"
           description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 만들 수 있어요."
-          emptyText="이 타입으로 저장한 프레임이 아직 없어요."
+          emptyText="저장된 프레임이 없습니다."
           selectedFrameId={selectedFrameId}
           frames={frames}
           isLoading={isLoading}

--- a/apps/web/app/upload/select/page.tsx
+++ b/apps/web/app/upload/select/page.tsx
@@ -117,11 +117,6 @@ export default function UploadSelectPage() {
           media={media}
           selectedIndexes={selectedIndexes}
           maxSelect={4}
-          guideText={
-            media.length === 0
-              ? "먼저 사진이나 영상을 업로드해 주세요."
-              : `업로드한 미디어 ${media.length}개 중에서 4개를 골라 주세요.`
-          }
           emptyStateText="아직 업로드한 사진이 없어요. 아래 버튼으로 사진이나 영상을 추가해 주세요."
           nextButtonLabel="다음 단계로"
           onToggleSelect={toggleSelect}

--- a/apps/web/components/frame/FrameOutputOptionsPanel.tsx
+++ b/apps/web/components/frame/FrameOutputOptionsPanel.tsx
@@ -58,13 +58,17 @@ export function FrameOutputOptionsPanel({
                     type="button"
                     onClick={() => onBorderColorChange(color.value)}
                     className={[
-                      "h-8 rounded-full border px-3 text-[11px]",
+                      "inline-flex h-9 items-center gap-2 rounded-full border px-3.5 text-[11px]",
                       borderColor === color.value
                         ? "border-[color:var(--hc-primary)] text-[color:var(--hc-primary-strong)]"
                         : "border-zinc-700 text-zinc-300",
                     ].join(" ")}
                   >
-                    {color.label}
+                    <span
+                      className="h-3 w-3 rounded-full border border-black/10"
+                      style={{ backgroundColor: color.value }}
+                    />
+                    <span>{color.label}</span>
                   </button>
                 ))}
               </div>
@@ -80,7 +84,7 @@ export function FrameOutputOptionsPanel({
                   value={borderColor}
                   onChange={(e) => onBorderColorChange(normalizeHexColor(e.target.value))}
                   className="hc-input h-9 flex-1 rounded-lg border px-3 text-[11px]"
-                  placeholder="#18181b"
+                  placeholder="#23262d"
                 />
               </div>
             </div>

--- a/apps/web/components/frame/FramePicker.tsx
+++ b/apps/web/components/frame/FramePicker.tsx
@@ -1,8 +1,17 @@
 "use client";
 
+import { Check, Circle } from "lucide-react";
+import { useState } from "react";
 import { FRAME_CONFIGS, type FrameId } from "@/constants/frames";
 import { FramePreview } from "@/components/frame/FramePreview";
 import { FRAME_CATALOG } from "@/lib/frameCatalog";
+
+type FramePickerLayoutMode = "carousel" | "grid";
+
+const FRAME_PICKER_PREVIEW_VIEWPORT =
+  "flex h-[176px] w-[132px] items-center justify-center";
+const PREVIEW_BORDER_COLOR = "var(--hc-frame-picker-preview-outer)";
+const PREVIEW_SLOT_COLOR = "var(--hc-frame-picker-preview-inner)";
 
 type FramePickerProps = {
   selectedFrameId: FrameId;
@@ -17,66 +26,91 @@ export function FramePicker({
   onConfirm,
   confirmLabel = "선택한 프레임으로 진행하기",
 }: FramePickerProps) {
+  const [layoutMode, setLayoutMode] = useState<FramePickerLayoutMode>("grid");
+
   return (
     <>
       <section className="flex flex-col gap-3">
-        <div className="grid grid-cols-2 gap-4">
-          {FRAME_CONFIGS.map((frame) => {
-            const isSelected = frame.id === selectedFrameId;
-            const meta = FRAME_CATALOG.find((item) => item.id === frame.id);
-
-            return (
-              <button
-                key={frame.id}
-                type="button"
-                onClick={() => onChangeSelected(frame.id)}
-                className={[
-                  "group relative overflow-hidden rounded-[28px] border px-3 py-3 text-left transition-all",
-                  isSelected
-                    ? "border-[color:var(--hc-primary)] bg-zinc-900 shadow-[0_0_0_1px_var(--hc-accent-soft-border)]"
-                    : "border-zinc-800 bg-zinc-900/70 hover:border-zinc-600 hover:bg-zinc-900",
-                ].join(" ")}
+        <div className="flex flex-col gap-2">
+          <p className="text-[11px] font-semibold text-zinc-500">
+            프레임 보기 방식
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setLayoutMode("grid")}
+              className="hc-button-secondary rounded-full border px-3 py-1.5 text-[11px] font-semibold"
+            >
+              <span
+                className={
+                  layoutMode === "grid"
+                    ? "text-[color:var(--hc-primary)]"
+                    : "text-zinc-400"
+                }
               >
-                <div
-                  className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${
-                    meta?.surfaceClassName ?? "from-white/5 to-transparent"
-                  }`}
-                />
-
-                <div className="relative flex flex-col gap-3">
-                  <div>
-                    <span className="inline-flex rounded-full border border-white/10 bg-white/10 px-2 py-1 text-[10px] text-zinc-100">
-                      {meta?.badge ?? "FRAME"}
-                    </span>
-                    <p className="mt-2 text-sm font-semibold text-zinc-50">
-                      {frame.name}
-                    </p>
-                    <p className="mt-1 text-[11px] text-zinc-400">
-                      {meta?.shortLabel ?? "FRAME"}
-                    </p>
-                  </div>
-
-                  <div className="flex h-[200px] w-full items-center justify-center rounded-2xl border border-white/10 bg-black/20 p-3">
-                    <FramePreview frameId={frame.id} className="" />
-                  </div>
-
-                  {meta ? (
-                    <div className="flex flex-wrap gap-1.5">
-                      {meta.recommendedFor.slice(0, 2).map((item) => (
-                        <span
-                          key={item}
-                          className="rounded-full border border-white/10 bg-black/20 px-2 py-1 text-[10px] text-zinc-300"
-                        >
-                          {item}
-                        </span>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              </button>
-            );
-          })}
+                2열 그리드
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setLayoutMode("carousel")}
+              className="hc-button-secondary rounded-full border px-3 py-1.5 text-[11px] font-semibold"
+            >
+              <span
+                className={
+                  layoutMode === "carousel"
+                    ? "text-[color:var(--hc-primary)]"
+                    : "text-zinc-400"
+                }
+              >
+                가로 카드
+              </span>
+            </button>
+          </div>
         </div>
+
+        {layoutMode === "grid" ? (
+          <div className="grid grid-cols-2 gap-4">
+            {FRAME_CONFIGS.map((frame) => (
+              <FramePickerCard
+                key={frame.id}
+                frameId={frame.id}
+                frameName={frame.name}
+                selected={frame.id === selectedFrameId}
+                onClick={() => onChangeSelected(frame.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div>
+            <div
+              className="overflow-x-auto pb-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              style={{
+                paddingInlineStart:
+                  "max(0.75rem, calc((100% - min(78vw, 20rem)) / 2))",
+                paddingInlineEnd:
+                  "max(0.75rem, calc((100% - min(78vw, 20rem)) / 2))",
+                scrollPaddingInlineStart:
+                  "max(0.75rem, calc((100% - min(78vw, 20rem)) / 2))",
+                scrollPaddingInlineEnd:
+                  "max(0.75rem, calc((100% - min(78vw, 20rem)) / 2))",
+              }}
+            >
+              <div className="flex snap-x snap-mandatory gap-4">
+                {FRAME_CONFIGS.map((frame) => (
+                  <FramePickerCard
+                    key={frame.id}
+                    frameId={frame.id}
+                    frameName={frame.name}
+                    selected={frame.id === selectedFrameId}
+                    onClick={() => onChangeSelected(frame.id)}
+                    mode="carousel"
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
       </section>
 
       <div className="mt-2 flex justify-end">
@@ -89,5 +123,75 @@ export function FramePicker({
         </button>
       </div>
     </>
+  );
+}
+
+function FramePickerCard({
+  frameId,
+  frameName,
+  selected,
+  onClick,
+  mode = "grid",
+}: {
+  frameId: FrameId;
+  frameName: string;
+  selected: boolean;
+  onClick: () => void;
+  mode?: FramePickerLayoutMode;
+}) {
+  const meta = FRAME_CATALOG.find((item) => item.id === frameId);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        "group relative overflow-hidden rounded-[28px] border p-3 text-left transition-all",
+        mode === "grid"
+          ? "w-full"
+          : "w-[min(78vw,320px)] shrink-0 snap-center sm:w-[320px]",
+        selected
+          ? "border-[color:var(--hc-primary)] bg-zinc-900 shadow-[0_0_0_1px_var(--hc-accent-soft-border)]"
+          : "border-zinc-800 bg-zinc-900/70 hover:border-zinc-600 hover:bg-zinc-900",
+      ].join(" ")}
+    >
+      <div
+        className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${
+          meta?.surfaceClassName ?? "from-white/5 to-transparent"
+        }`}
+      />
+
+      <div className="relative flex flex-col gap-3">
+        <div
+          className={[
+            "flex items-center justify-center rounded-2xl border border-white/10 bg-black/20",
+            mode === "grid" ? "min-h-[220px] p-3" : "min-h-[220px] p-4",
+          ].join(" ")}
+        >
+          <div className={FRAME_PICKER_PREVIEW_VIEWPORT}>
+            <FramePreview
+              frameId={frameId}
+              className="max-h-full max-w-full"
+              borderColor={PREVIEW_BORDER_COLOR}
+              slotColor={PREVIEW_SLOT_COLOR}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-zinc-50">{frameName}</p>
+          <span
+            className={[
+              "inline-flex h-6 w-6 items-center justify-center rounded-full border",
+              selected
+                ? "border-[color:var(--hc-primary)] bg-[color:var(--hc-primary)] text-[color:var(--hc-primary-contrast)]"
+                : "border-white/10 bg-black/20 text-zinc-400",
+            ].join(" ")}
+          >
+            {selected ? <Check className="h-3.5 w-3.5" /> : <Circle className="h-3.5 w-3.5" />}
+          </span>
+        </div>
+      </div>
+    </button>
   );
 }

--- a/apps/web/components/frame/FramePreview.tsx
+++ b/apps/web/components/frame/FramePreview.tsx
@@ -19,6 +19,7 @@ type FramePreviewProps = {
   media?: (FrameMedia | null)[];
   images?: (string | null)[];
   borderColor?: string;
+  slotColor?: string;
   theme?: ThemeExportJson | null;
   outputFilter?: FourcutFilterId;
 };
@@ -29,6 +30,7 @@ export function FramePreview({
   media,
   images,
   borderColor,
+  slotColor,
   theme,
   outputFilter = "NONE",
 }: FramePreviewProps) {
@@ -44,14 +46,14 @@ export function FramePreview({
     className,
   ].join(" ");
 
-  const slotBase = "bg-zinc-800/90 rounded-md";
+  const resolvedSlotColor = slotColor ?? "rgba(39,39,42,0.9)";
 
   return (
     <div
       className={["relative", outer].join(" ")}
       style={{
         aspectRatio: `${totalWidth} / ${totalHeight}`,
-        backgroundColor: borderColor,
+        backgroundColor: borderColor || undefined,
       }}
     >
       {slots.map((slot, idx) => {
@@ -107,7 +109,11 @@ export function FramePreview({
         }
 
         return (
-          <div key={idx} className={`${slotBase} absolute`} style={baseStyle} />
+          <div
+            key={idx}
+            className="absolute rounded-md"
+            style={{ ...baseStyle, backgroundColor: resolvedSlotColor }}
+          />
         );
       })}
 

--- a/apps/web/components/frame/FrameSelectPanel.test.tsx
+++ b/apps/web/components/frame/FrameSelectPanel.test.tsx
@@ -11,7 +11,6 @@ describe("FrameSelectPanel", () => {
       { type: "image" as const, src: "/4.png" },
     ],
     maxSelect: 4,
-    guideText: "guide",
     nextButtonLabel: "다음 단계",
     onToggleSelect: jest.fn(),
     onReset: jest.fn(),

--- a/apps/web/components/frame/FrameSelectPanel.tsx
+++ b/apps/web/components/frame/FrameSelectPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useMemo } from "react";
-import { CheckCircle2, RotateCcw, X } from "lucide-react";
+import { RotateCcw } from "lucide-react";
 import { FramePreview, type FrameMedia } from "@/components/frame/FramePreview";
 import type { FrameId } from "@/constants/frames";
 import type { FourcutFilterId } from "@/lib/frameFilters";
@@ -14,7 +14,6 @@ type FrameSelectPanelProps = {
   media?: FrameMedia[];
   selectedIndexes: (number | null)[];
   maxSelect: number;
-  guideText: string;
   emptyStateText?: string;
   nextButtonLabel: string;
   onToggleSelect: (index: number) => void;
@@ -32,7 +31,6 @@ export function FrameSelectPanel({
   media,
   selectedIndexes,
   maxSelect,
-  guideText,
   emptyStateText = "선택 가능한 사진이나 영상이 아직 없어요.",
   nextButtonLabel,
   onToggleSelect,
@@ -61,106 +59,25 @@ export function FrameSelectPanel({
     [selectedIndexes],
   );
   const canProceed = selectedCount === maxSelect;
-  const progressLabel = `${selectedCount} / ${maxSelect}`;
-  const nextSlotIndex = selectedIndexes.findIndex((index) => index == null);
-  const selectionHint =
-    nextSlotIndex === -1
-      ? "선택이 모두 끝났어요. 다음 단계에서 결과를 확인해 보세요."
-      : `${nextSlotIndex + 1}번 칸에 넣을 미디어를 골라 주세요. 아래 목록에서 눌러 바로 채울 수 있어요.`;
 
   return (
     <div className="flex flex-col gap-4 xl:grid xl:grid-cols-[minmax(0,1fr)_320px] xl:items-start">
       <section className="flex flex-col gap-3">
-        <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-sm font-semibold text-zinc-100">선택 현황</p>
-              <p className="mt-1 text-[11px] text-zinc-500">{guideText}</p>
+        {frameId ? (
+          <section className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3 xl:hidden">
+            <p className="text-sm font-semibold text-zinc-100">프레임 미리보기</p>
+            <div className="flex justify-center">
+              <FramePreview
+                frameId={frameId}
+                media={slotMedia}
+                theme={themeData}
+                borderColor={borderColor}
+                outputFilter={outputFilter}
+                className="w-full max-w-[220px]"
+              />
             </div>
-            <span className="rounded-full border border-white/10 bg-black/20 px-2.5 py-1 text-[10px] text-zinc-300">
-              {progressLabel}
-            </span>
-          </div>
-          <div className="hc-accent-chip mt-3 rounded-2xl border px-3 py-2 text-[11px]">
-            {selectionHint}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-sm font-semibold text-zinc-100">선택 슬롯</p>
-              <p className="mt-1 text-[11px] text-zinc-500">
-                선택한 순서대로 프레임의 1번, 2번, 3번, 4번 칸에 들어가요.
-              </p>
-            </div>
-            {canProceed ? (
-              <span className="hc-accent-chip inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px]">
-                <CheckCircle2 className="h-3.5 w-3.5" />
-                선택 완료
-              </span>
-            ) : null}
-          </div>
-
-          <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
-            {selectedIndexes.map((selectedIndex, slotIndex) => {
-              const item = selectedIndex == null ? null : baseItems[selectedIndex] ?? null;
-              const isActive = nextSlotIndex === slotIndex || (nextSlotIndex === -1 && item != null);
-
-              return (
-                <div
-                  key={slotIndex}
-                  className={[
-                    "relative overflow-hidden rounded-2xl border bg-black/30",
-                    item ? "border-white/10" : "border-dashed border-white/10",
-                    isActive ? "ring-2 ring-[color:var(--hc-accent-soft-border)]" : "",
-                  ].join(" ")}
-                >
-                  <div className="absolute left-2 top-2 z-10 rounded-full bg-black/70 px-2 py-1 text-[10px] text-zinc-100">
-                    {slotIndex + 1}번
-                  </div>
-
-                  {item ? (
-                    <>
-                      {item.type === "video" ? (
-                        <video
-                          src={item.src}
-                          className="aspect-[3/4] w-full object-cover"
-                          autoPlay
-                          loop
-                          muted
-                          playsInline
-                        />
-                      ) : (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={item.src}
-                          alt={`selected-slot-${slotIndex + 1}`}
-                          className="aspect-[3/4] w-full object-cover"
-                        />
-                      )}
-
-                      {selectedIndex != null ? (
-                        <button
-                          type="button"
-                          onClick={() => onToggleSelect(selectedIndex)}
-                          className="absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-full border border-white/10 bg-black/70 px-2 py-1 text-[10px] text-zinc-100 hover:bg-black/80"
-                        >
-                          <X className="h-3.5 w-3.5" />
-                          해제
-                        </button>
-                      ) : null}
-                    </>
-                  ) : (
-                    <div className="grid aspect-[3/4] place-items-center px-3 text-center text-[11px] text-zinc-500">
-                      {isActive ? "다음 선택 칸" : "선택 대기"}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </section>
+          </section>
+        ) : null}
 
         <section className="space-y-2">
           {baseItems.length === 0 ? (
@@ -204,10 +121,6 @@ export function FrameSelectPanel({
                       />
                     )}
 
-                    <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent px-2 py-2 text-[10px] text-zinc-100">
-                      {isSelected ? `${order}번 칸에 배치` : "선택 가능"}
-                    </div>
-
                     <span className="pointer-events-none absolute left-1 top-1 rounded-full bg-black/70 px-1.5 py-0.5 text-[9px] text-zinc-200">
                       #{index + 1}
                     </span>
@@ -247,8 +160,8 @@ export function FrameSelectPanel({
 
       <aside className="flex flex-col gap-3 xl:sticky xl:top-6">
         {frameId ? (
-          <section className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3">
-            <p className="text-[11px] font-medium text-zinc-200">프레임 미리보기</p>
+          <section className="hidden flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3 xl:flex">
+            <p className="text-sm font-semibold text-zinc-100">프레임 미리보기</p>
             <div className="flex justify-center">
               <FramePreview
                 frameId={frameId}
@@ -256,7 +169,7 @@ export function FrameSelectPanel({
                 theme={themeData}
                 borderColor={borderColor}
                 outputFilter={outputFilter}
-                className="w-full max-w-[250px]"
+                className="w-full max-w-[240px]"
               />
             </div>
           </section>

--- a/apps/web/components/frame/SavedFramesSection.tsx
+++ b/apps/web/components/frame/SavedFramesSection.tsx
@@ -1,5 +1,6 @@
 ﻿"use client";
 
+import { RotateCcw } from "lucide-react";
 import { useMemo } from "react";
 import type { FrameId } from "@/constants/frames";
 import { FramePreview } from "@/components/frame/FramePreview";
@@ -56,9 +57,11 @@ export function SavedFramesSection({
         <button
           type="button"
           onClick={onRefresh}
-          className="rounded-full border border-zinc-700 px-3 py-1 text-[11px] text-zinc-300 hover:bg-zinc-800"
+          aria-label="새로고침"
+          title="새로고침"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-zinc-700 text-zinc-300 hover:bg-zinc-800"
         >
-          새로고침
+          <RotateCcw className="h-3.5 w-3.5" />
         </button>
       </div>
 

--- a/apps/web/components/layout/PageHeader.tsx
+++ b/apps/web/components/layout/PageHeader.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { BrandMark } from "./BrandMark";
 
 type Props = {
-  title: ReactNode;
+  title?: ReactNode;
   description?: ReactNode;
   backHref?: string;
   backLabel?: string;
@@ -36,7 +36,9 @@ export function PageHeader({
               className="mb-1 opacity-80"
             />
           ) : null}
-          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          {title ? (
+            <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          ) : null}
         </div>
 
         {rightSlot ? (

--- a/apps/web/constants/colors.ts
+++ b/apps/web/constants/colors.ts
@@ -1,18 +1,16 @@
 export const BORDER_COLORS = [
-  { id: "black", label: "블랙", value: "#000000" },
-  { id: "white", label: "화이트", value: "#ffffff" },
-  { id: "zinc", label: "다크 그레이", value: "#18181b" },
-  { id: "pink", label: "핑크", value: "#f973b6" },
-  { id: "blue", label: "블루", value: "#38bdf8" },
+  { id: "ink", label: "잉크 차콜", value: "#23262d" },
+  { id: "ivory", label: "소프트 아이보리", value: "#f3efe7" },
+  { id: "slate", label: "뮤트 슬레이트", value: "#66758c" },
+  { id: "taupe", label: "웜 토프", value: "#9b8778" },
 ] as const;
 
 export type BorderColorId = (typeof BORDER_COLORS)[number]["id"];
 export type BorderColorValue = (typeof BORDER_COLORS)[number]["value"];
 
 export const BACKGROUND_COLORS = [
-  { id: "white", label: "화이트", value: "ffffff" },
-  { id: "black", label: "블랙", value: "000000" },
-  { id: "zinc", label: "다크 그레이", value: "111827" },
-  { id: "pink", label: "핑크", value: "f973b6" },
-  { id: "blue", label: "블루", value: "38bdf8" },
+  { id: "ivory", label: "소프트 아이보리", value: "f3efe7" },
+  { id: "ink", label: "잉크 차콜", value: "23262d" },
+  { id: "slate", label: "뮤트 슬레이트", value: "66758c" },
+  { id: "taupe", label: "웜 토프", value: "9b8778" },
 ] as const;

--- a/apps/web/lib/themeBackground.ts
+++ b/apps/web/lib/themeBackground.ts
@@ -2,7 +2,7 @@
 
 import type { ThemeExportJson } from "@/lib/types/themeEditor";
 
-export const DEFAULT_FRAME_BACKGROUND_COLOR = "#18181b";
+export const DEFAULT_FRAME_BACKGROUND_COLOR = "#23262d";
 
 export function normalizeHexColor(
   input?: string | null,


### PR DESCRIPTION
## 요약
웹·모바일 프레임 선택 흐름 정리.
프레임 비교 직관성 강화, 중복 안내 문구 축소.

## 변경 사항
- 프레임 선택 카드와 가로 스크롤 표현 더 단순하게 정리
- 선택 단계 뷰포트별 프레임 미리보기 위치 조정, 웹 데스크톱 미리보기 복구
- 선택/촬영 화면의 슬롯 상태 문구와 보조 안내 제거
- 저장된 프레임 빈 상태 문구와 새로고침 UI 간결하게 정리
- 출력 옵션 기본 프레임 색상 프리셋을 차분한 톤으로 조정, 색상 칩 추가

## 이유
- 설명성 텍스트 과다로 프레임 자체 비교에 시선 분산
- 기본 프레임 색상 채도와 대비가 주변 UI 대비 과도

## 영향
- 웹·모바일 모두 프레임 선택을 더 시각 중심으로 인지
- 선택/촬영 화면의 정보 밀도 완화
- 기본 출력 스타일을 더 자연스럽고 안정적인 톤으로 정리

## 검증
- `pnpm typecheck:mobile`
- `pnpm lint:mobile`
- `pnpm test:web`
- `pnpm build:web`

## 참고
- Closes #190
- 실제 브라우저/기기 수동 시각 확인은 이번 세션 범위 밖