### PR TITLE
fix: 비로그인 라우팅과 랜딩 노출 정리

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -13,6 +13,7 @@ export default function AppLayout() {
   const accessMode = useHarucutStore((state) => state.accessMode);
   const showGuestRestrictedNotice = useHarucutStore((state) => state.showGuestRestrictedNotice);
   const { colors } = useHarucutTheme();
+  const shouldHideRoute = accessMode === 'guest' && !pathname.startsWith('/shoot');
 
   useEffect(() => {
     if (accessMode !== 'guest') {
@@ -30,10 +31,10 @@ export default function AppLayout() {
   return (
     <SafeAreaView edges={['top']} style={{ backgroundColor: colors.background, flex: 1 }}>
       <View style={{ backgroundColor: colors.background, flex: 1 }}>
-        <View style={{ flex: 1 }}>
+        <View pointerEvents={shouldHideRoute ? 'none' : 'auto'} style={{ flex: 1, opacity: shouldHideRoute ? 0 : 1 }}>
           <Slot />
         </View>
-        <BottomNavigation />
+        {shouldHideRoute ? null : <BottomNavigation />}
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,9 +8,11 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GlobalNotice } from '@/components/harucut/global-notice';
 import { GlobalThemeToggle } from '@/components/harucut/global-theme-toggle';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { useHarucutStore } from '@/store/use-harucut-store';
 
 export default function RootLayout() {
   const { colors, isDark } = useHarucutTheme();
+  const accessMode = useHarucutStore((state) => state.accessMode);
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
@@ -22,7 +24,12 @@ export default function RootLayout() {
             contentStyle: { backgroundColor: colors.background },
             headerShown: false,
           }}
-        />
+        >
+          <Stack.Screen name="(public)" />
+          <Stack.Protected guard={accessMode !== 'anonymous'}>
+            <Stack.Screen name="(app)" />
+          </Stack.Protected>
+        </Stack>
         <GlobalThemeToggle />
         <GlobalNotice />
       </SafeAreaProvider>

--- a/apps/mobile/components/harucut/global-notice.tsx
+++ b/apps/mobile/components/harucut/global-notice.tsx
@@ -14,6 +14,7 @@ export function GlobalNotice() {
   const insets = useSafeAreaInsets();
   const notice = useHarucutStore((state) => state.notice);
   const clearNotice = useHarucutStore((state) => state.clearNotice);
+  const enterAnonymousMode = useHarucutStore((state) => state.enterAnonymousMode);
   const enterGuestMode = useHarucutStore((state) => state.enterGuestMode);
   const { colors, isDark } = useHarucutTheme();
   const styles = useMemo(() => createStyles(colors, isDark), [colors, isDark]);
@@ -38,7 +39,7 @@ export function GlobalNotice() {
         replace('/shoot');
         return;
       case 'go-landing':
-        clearNotice();
+        enterAnonymousMode();
         replace('/');
         return;
       case 'start-guest-trial':

--- a/apps/mobile/constants/harucut-data.ts
+++ b/apps/mobile/constants/harucut-data.ts
@@ -263,5 +263,3 @@ export const INITIAL_SAVED_FRAMES: SavedFrame[] = [
     updatedAt: '2026-04-17T09:15:00.000Z',
   },
 ];
-
-export const SERVICE_TAGS = ['촬영', '업로드', '테마 편집'] as const;

--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -324,6 +324,7 @@ export function MyPageScreen() {
   const replace = (path: string) => router.replace(path as never);
   const user = useHarucutStore((state) => state.user);
   const setUserProfile = useHarucutStore((state) => state.setUserProfile);
+  const enterAnonymousMode = useHarucutStore((state) => state.enterAnonymousMode);
   const themePreference = useHarucutStore((state) => state.themePreference);
   const setThemePreference = useHarucutStore((state) => state.setThemePreference);
   const [username, setUsername] = useState(user.username);
@@ -475,7 +476,14 @@ export function MyPageScreen() {
 
       <SurfaceCard style={{ gap: 12 }}>
         <Text style={styles.sectionTitle}>로그아웃</Text>
-        <ActionButton label="로그아웃" onPress={() => replace('/login')} variant="secondary" />
+        <ActionButton
+          label="로그아웃"
+          onPress={() => {
+            enterAnonymousMode();
+            replace('/');
+          }}
+          variant="secondary"
+        />
       </SurfaceCard>
 
       <SurfaceCard style={[styles.exitCard, { gap: 12 }]}>
@@ -483,7 +491,14 @@ export function MyPageScreen() {
         <Text style={styles.bodyCopy}>
           탈퇴를 요청하면 계정이 비활성화돼요. 다시 로그인하면 탈퇴를 취소하고 계정을 다시 사용할 수 있어요.
         </Text>
-        <ActionButton label="회원 탈퇴 요청" onPress={() => replace('/login')} variant="danger" />
+        <ActionButton
+          label="회원 탈퇴 요청"
+          onPress={() => {
+            enterAnonymousMode();
+            replace('/');
+          }}
+          variant="danger"
+        />
       </SurfaceCard>
     </AppScrollView>
   );

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -3,8 +3,8 @@ import { useRouter } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { HERO_IMAGE_URL, LOGIN_FIELDS, SERVICE_TAGS, SIGNUP_FIELDS } from '@/constants/harucut-data';
-import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, Pill, SectionEyebrow, SurfaceCard } from '@/components/harucut/ui';
+import { HERO_IMAGE_URL, LOGIN_FIELDS, SIGNUP_FIELDS } from '@/constants/harucut-data';
+import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, SectionEyebrow, SurfaceCard } from '@/components/harucut/ui';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
@@ -146,12 +146,6 @@ export function LandingScreen() {
             style={{ flex: 1 }}
             variant="secondary"
           />
-        </View>
-
-        <View style={styles.tagRow}>
-          {SERVICE_TAGS.map((tag) => (
-            <Pill key={tag}>{tag}</Pill>
-          ))}
         </View>
 
         <SurfaceCard>

--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -52,6 +52,7 @@ export function ShootFrameScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
   const accessMode = useHarucutStore((state) => state.accessMode);
+  const enterAnonymousMode = useHarucutStore((state) => state.enterAnonymousMode);
   const savedFrames = useHarucutStore((state) => state.savedFrames);
   const shoot = useHarucutStore((state) => state.shoot);
   const setShootFrame = useHarucutStore((state) => state.setShootFrame);
@@ -66,7 +67,15 @@ export function ShootFrameScreen() {
             ? '비회원 체험에서는 촬영과 이미지 다운로드만 할 수 있어요.'
             : '촬영할 프레임을 먼저 골라 주세요.'
         }
-        onPressBack={() => push(accessMode === 'guest' ? '/' : '/home')}
+        onPressBack={() => {
+          if (accessMode === 'guest') {
+            enterAnonymousMode();
+            push('/');
+            return;
+          }
+
+          push('/home');
+        }}
         title={accessMode === 'guest' ? '비회원 촬영 체험' : '촬영'}
       />
       <StepProgress current={1} label="프레임 선택" total={4} />

--- a/apps/mobile/store/use-harucut-store.ts
+++ b/apps/mobile/store/use-harucut-store.ts
@@ -15,7 +15,7 @@ import {
 } from '@/constants/harucut-data';
 import type { ButtonVariant, HarucutThemePreference } from '@/constants/harucut-design';
 
-type AccessMode = 'guest' | 'member';
+type AccessMode = 'anonymous' | 'guest' | 'member';
 
 type NoticeActionId =
   | 'dismiss'
@@ -82,6 +82,7 @@ type HarucutStore = {
   user: UserProfile;
   addShootShot: (asset: MediaAsset) => void;
   clearNotice: () => void;
+  enterAnonymousMode: () => void;
   enterGuestMode: () => void;
   enterMemberMode: () => void;
   addUploadAssets: (assets: MediaAsset[]) => void;
@@ -209,7 +210,7 @@ function upsertHistoryItem(
 }
 
 export const useHarucutStore = create<HarucutStore>((set, get) => ({
-  accessMode: 'member',
+  accessMode: 'anonymous',
   historyItems: INITIAL_HISTORY_ITEMS,
   notice: null,
   shoot: defaultShootSession(),
@@ -234,6 +235,14 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
       };
     }),
   clearNotice: () => set({ notice: null }),
+  enterAnonymousMode: () =>
+    set({
+      accessMode: 'anonymous',
+      notice: null,
+      shoot: defaultShootSession(),
+      themeEditor: defaultThemeEditor(),
+      upload: defaultUploadSession(),
+    }),
   enterGuestMode: () =>
     set({
       accessMode: 'guest',
@@ -275,7 +284,7 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
       return null;
     }
 
-    if (state.accessMode === 'guest') {
+    if (state.accessMode !== 'member') {
       return null;
     }
 
@@ -305,6 +314,10 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
     const previewMedia = selectedMedia(state.upload.assets, state.upload.selectedAssetIds);
 
     if (previewMedia.length === 0) {
+      return null;
+    }
+
+    if (state.accessMode !== 'member') {
       return null;
     }
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -61,17 +61,6 @@ export default function LandingPage() {
               <GuestTrialStartButton />
             </div>
 
-            <div className="mt-6 flex flex-wrap gap-2 text-[11px] text-[color:var(--hc-muted)]">
-              <span className="hc-surface-soft rounded-full border px-3 py-1">
-                촬영
-              </span>
-              <span className="hc-surface-soft rounded-full border px-3 py-1">
-                업로드
-              </span>
-              <span className="hc-surface-soft rounded-full border px-3 py-1">
-                테마 편집
-              </span>
-            </div>
           </div>
 
           <div className="mx-auto w-full max-w-[340px] sm:max-w-[360px]">


### PR DESCRIPTION
## 작업 내용
- 모바일 접근 상태를 `anonymous`, `guest`, `member`로 분리
- 비로그인 상태에서는 앱 내부 랜딩만 노출하고 `(app)` 라우트는 루트 스택에서 보호
- 비회원 체험 상태에서는 `/shoot` 플로우만 허용
- 로그아웃/탈퇴 요청/비회원 체험 종료 시 비로그인 상태로 전환
- 웹/앱 첫 화면의 `촬영`, `업로드`, `테마 편집` 기능 칩 제거

## 검증
- `pnpm typecheck:mobile`
- `pnpm lint:mobile`
- `pnpm lint:web` *(기존 `ColorThemeScript.tsx` warning 1건만 확인)*

Closes #196