### PR TITLE
chore: 워크스페이스 포맷 설정 추가

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+dist
+coverage
+playwright-report
+test-results
+storybook-static
+.swc
+.expo
+*.tsbuildinfo
+pnpm-lock.yaml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 88,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:e2e:install:web": "pnpm --dir apps/web test:e2e:install",
     "storybook:web": "pnpm --dir apps/web storybook",
     "build-storybook:web": "pnpm --dir apps/web build-storybook",
+    "format": "prettier --check . --ignore-unknown",
+    "format:write": "prettier --write . --ignore-unknown",
     "generate:stickers:web": "pnpm --dir apps/web generate:stickers",
     "dev:mobile": "pnpm --dir apps/mobile start",
     "android:mobile": "pnpm --dir apps/mobile android",
@@ -34,5 +36,7 @@
     "verify:standard": "python scripts/verify_workspace.py --group standard"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "prettier": "^3.8.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
 
   apps/mobile:
     dependencies:
@@ -161,10 +165,10 @@ importers:
         version: 1.58.2
       '@storybook/nextjs':
         specifier: ^10.2.8
-        version: 10.2.8(esbuild@0.25.12)(next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.2(esbuild@0.25.12))
+        version: 10.2.8(esbuild@0.25.12)(next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.2(esbuild@0.25.12))
       '@storybook/react':
         specifier: 10.2.8
-        version: 10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
+        version: 10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
@@ -206,7 +210,7 @@ importers:
         version: 1.58.2
       storybook:
         specifier: ^10.2.8
-        version: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tailwindcss:
         specifier: ^4
         version: 4.1.17
@@ -5883,6 +5887,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
@@ -9662,9 +9671,9 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/builder-webpack5@10.2.8(esbuild@0.25.12)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@10.2.8(esbuild@0.25.12)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/core-webpack': 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 7.1.4(webpack@5.105.2(esbuild@0.25.12))
@@ -9672,7 +9681,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.2(esbuild@0.25.12))
       html-webpack-plugin: 5.6.6(webpack@5.105.2(esbuild@0.25.12))
       magic-string: 0.30.21
-      storybook: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       style-loader: 4.0.0(webpack@5.105.2(esbuild@0.25.12))
       terser-webpack-plugin: 5.3.16(esbuild@0.25.12)(webpack@5.105.2(esbuild@0.25.12))
       ts-dedent: 2.2.0
@@ -9689,9 +9698,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/core-webpack@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/core-webpack@10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
-      storybook: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       ts-dedent: 2.2.0
 
   '@storybook/global@5.0.0': {}
@@ -9701,7 +9710,7 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
-  '@storybook/nextjs@10.2.8(esbuild@0.25.12)(next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.2(esbuild@0.25.12))':
+  '@storybook/nextjs@10.2.8(esbuild@0.25.12)(next@16.0.7(@babel/core@7.28.5)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.2(esbuild@0.25.12))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
@@ -9717,9 +9726,9 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/runtime': 7.28.6
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.105.2(esbuild@0.25.12))
-      '@storybook/builder-webpack5': 10.2.8(esbuild@0.25.12)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 10.2.8(esbuild@0.25.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
-      '@storybook/react': 10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 10.2.8(esbuild@0.25.12)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 10.2.8(esbuild@0.25.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
+      '@storybook/react': 10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)
       '@types/semver': 7.7.1
       babel-loader: 9.2.1(@babel/core@7.28.5)(webpack@5.105.2(esbuild@0.25.12))
       css-loader: 6.11.0(webpack@5.105.2(esbuild@0.25.12))
@@ -9735,7 +9744,7 @@ snapshots:
       resolve-url-loader: 5.0.0
       sass-loader: 16.0.7(webpack@5.105.2(esbuild@0.25.12))
       semver: 7.7.3
-      storybook: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       style-loader: 3.3.4(webpack@5.105.2(esbuild@0.25.12))
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
       tsconfig-paths: 4.2.0
@@ -9761,9 +9770,9 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@10.2.8(esbuild@0.25.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@10.2.8(esbuild@0.25.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/core-webpack': 10.2.8(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.105.2(esbuild@0.25.12))
       '@types/semver': 7.7.1
       magic-string: 0.30.21
@@ -9772,7 +9781,7 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       resolve: 1.22.11
       semver: 7.7.3
-      storybook: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tsconfig-paths: 4.2.0
       webpack: 5.105.2(esbuild@0.25.12)
     optionalDependencies:
@@ -9798,20 +9807,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
+  '@storybook/react-dom-shim@10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
 
-  '@storybook/react@10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)':
+  '@storybook/react@10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+      '@storybook/react-dom-shim': 10.2.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
       react: 19.2.1
       react-docgen: 8.0.2
       react-dom: 19.2.1(react@19.2.1)
-      storybook: 10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      storybook: 10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -14312,6 +14321,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@3.8.3: {}
+
   pretty-bytes@5.6.0: {}
 
   pretty-error@4.0.0:
@@ -15110,7 +15121,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@10.2.8(@testing-library/dom@10.4.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  storybook@10.2.8(@testing-library/dom@10.4.0)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -15124,6 +15135,8 @@ snapshots:
       semver: 7.7.3
       use-sync-external-store: 1.6.0(react@19.2.1)
       ws: 8.19.0
+    optionalDependencies:
+      prettier: 3.8.3
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil


### PR DESCRIPTION
## 작업 내용
- 루트 Prettier 설정 파일 추가
- `format`, `format:write` 스크립트 추가
- Prettier devDependency와 lockfile 반영

## 검증
- `pnpm install --frozen-lockfile`
- `pnpm format` 실행 결과 기존 파일 다수의 포맷 미정렬을 확인했습니다. 이 PR에서는 설정만 추가하고 일괄 포맷 변경은 별도 작업으로 분리합니다.

Closes #198