### PR TITLE
feat: 모바일 앱 실 API 연동 전환

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -2,17 +2,46 @@ import 'react-native-reanimated';
 
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { GlobalNotice } from '@/components/harucut/global-notice';
-import { GlobalThemeToggle } from '@/components/harucut/global-theme-toggle';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { getAuthStatus } from '@/lib/auth-api';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 export default function RootLayout() {
   const { colors, isDark } = useHarucutTheme();
   const accessMode = useHarucutStore((state) => state.accessMode);
+  const bootstrapMemberSession = useHarucutStore((state) => state.bootstrapMemberSession);
+
+  useEffect(() => {
+    if (accessMode !== 'anonymous' || Platform.OS === 'web') {
+      return;
+    }
+
+    let cancelled = false;
+
+    const restoreSession = async () => {
+      try {
+        const status = await getAuthStatus();
+
+        if (!cancelled && status?.userStatus === 'ACTIVE') {
+          await bootstrapMemberSession();
+        }
+      } catch {
+        // 저장된 서버 세션이 없으면 공개 화면으로 유지합니다.
+      }
+    };
+
+    void restoreSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accessMode, bootstrapMemberSession]);
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
@@ -30,7 +59,6 @@ export default function RootLayout() {
             <Stack.Screen name="(app)" />
           </Stack.Protected>
         </Stack>
-        <GlobalThemeToggle />
         <GlobalNotice />
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/constants/harucut-data.ts
+++ b/apps/mobile/constants/harucut-data.ts
@@ -6,6 +6,8 @@ export type MediaAsset = {
   id: string;
   kind: MediaKind;
   label: string;
+  remoteMediaId?: number;
+  s3Key?: string;
   uri: string;
 };
 
@@ -16,6 +18,8 @@ export type SavedFrame = {
   caption: string;
   description: string;
   frameId: FrameId;
+  previewKey?: string;
+  remoteFrameId?: number;
   stickers: string[];
   title: string;
   updatedAt: string;
@@ -26,7 +30,9 @@ export type HistoryItem = {
   frameId: FrameId;
   id: string;
   kind: 'photo' | 'video';
+  mediaId?: number;
   previewMedia: MediaAsset[];
+  remoteS3Key?: string;
   source: 'shoot' | 'upload';
   title: string;
 };
@@ -169,96 +175,12 @@ export const SIGNUP_FIELDS = [
 ] as const;
 
 export const INITIAL_USER: UserProfile = {
-  email: 'hello@harucut.com',
+  email: '',
   loginPlatform: 'HARUCUT',
   monthlyPrice: null,
   planTier: 'BASIC',
-  profileUrl:
-    'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=300&q=80',
-  username: '하루컷 유저',
+  profileUrl: null,
+  username: '하루컷',
 };
 
-const SAMPLE_MEDIA: MediaAsset[] = [
-  {
-    id: 'media-a',
-    kind: 'image',
-    label: '오늘의 산책',
-    uri: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=600&q=80',
-  },
-  {
-    id: 'media-b',
-    kind: 'image',
-    label: '푸른 오후',
-    uri: 'https://images.unsplash.com/photo-1515886657613-9f3515b0c78f?auto=format&fit=crop&w=600&q=80',
-  },
-  {
-    id: 'media-c',
-    kind: 'image',
-    label: '전시 기록',
-    uri: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=600&q=80',
-  },
-  {
-    id: 'media-d',
-    kind: 'image',
-    label: '카페 무드',
-    uri: 'https://images.unsplash.com/photo-1519741497674-611481863552?auto=format&fit=crop&w=600&q=80',
-  },
-  {
-    id: 'media-e',
-    kind: 'image',
-    label: '주말 데이트',
-    uri: 'https://images.unsplash.com/photo-1511988617509-a57c8a288659?auto=format&fit=crop&w=600&q=80',
-  },
-  {
-    id: 'media-f',
-    kind: 'image',
-    label: '블루 스냅',
-    uri: 'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=600&q=80',
-  },
-];
-
-export const INITIAL_HISTORY_ITEMS: HistoryItem[] = [
-  {
-    createdAt: '2026-04-20T10:40:00.000Z',
-    frameId: 'classic-4',
-    id: 'history-1',
-    kind: 'photo',
-    previewMedia: SAMPLE_MEDIA.slice(0, 4),
-    source: 'shoot',
-    title: '클래식 4컷 촬영 결과',
-  },
-  {
-    createdAt: '2026-04-19T17:10:00.000Z',
-    frameId: 'polaroid-4',
-    id: 'history-2',
-    kind: 'video',
-    previewMedia: [SAMPLE_MEDIA[4], SAMPLE_MEDIA[2], SAMPLE_MEDIA[3], SAMPLE_MEDIA[5]],
-    source: 'upload',
-    title: '폴라로이드 4컷 업로드 결과',
-  },
-];
-
-export const INITIAL_SAVED_FRAMES: SavedFrame[] = [
-  {
-    accentColor: '#2563EB',
-    backgroundColor: '#EEF5FF',
-    caption: 'today archive',
-    description: '저장한 프레임을 이어서 수정하거나 같은 타입으로 바로 사용할 수 있어요.',
-    frameId: 'polaroid-4',
-    id: 'saved-frame-1',
-    stickers: ['✦', '♡'],
-    title: '블루 아카이브 프레임',
-    updatedAt: '2026-04-18T13:20:00.000Z',
-  },
-  {
-    accentColor: '#1D4ED8',
-    backgroundColor: '#FFFFFF',
-    caption: 'record your day',
-    description: '촬영 시작 화면에서 바로 이어서 선택할 수 있는 저장 프레임이에요.',
-    frameId: 'classic-4',
-    id: 'saved-frame-2',
-    stickers: ['★'],
-    title: '클래식 블루 라인',
-    updatedAt: '2026-04-17T09:15:00.000Z',
-  },
-];
+export const INITIAL_SAVED_FRAMES: SavedFrame[] = [];

--- a/apps/mobile/lib/api-client.ts
+++ b/apps/mobile/lib/api-client.ts
@@ -1,0 +1,175 @@
+import Constants from 'expo-constants';
+
+export type ApiEnvelope<T> = {
+  code?: string;
+  data: T;
+  message?: string | null;
+  status?: number;
+};
+
+type ApiPath =
+  | string
+  | {
+      direct: string;
+      proxy: string;
+    };
+
+type RequestOptions = {
+  body?: unknown;
+  cache?: RequestCache;
+  headers?: HeadersInit;
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  signal?: AbortSignal;
+};
+
+const DEFAULT_API_BASE_URL = 'https://api.harucut.com';
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/+$/, '');
+}
+
+function configuredApiBaseUrl() {
+  const fromEnv = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+  if (fromEnv) return fromEnv;
+
+  const fromExtra = Constants.expoConfig?.extra?.apiBaseUrl;
+  if (typeof fromExtra === 'string' && fromExtra.trim()) {
+    return fromExtra;
+  }
+
+  return DEFAULT_API_BASE_URL;
+}
+
+function configuredWebProxyBaseUrl() {
+  return process.env.EXPO_PUBLIC_WEB_API_BASE_URL?.trim() ?? '';
+}
+
+export function getApiConfig() {
+  const directBaseUrl = configuredApiBaseUrl();
+  const webProxyBaseUrl = configuredWebProxyBaseUrl();
+
+  if (directBaseUrl) {
+    return {
+      baseUrl: trimTrailingSlash(directBaseUrl),
+      mode: 'direct' as const,
+    };
+  }
+
+  if (webProxyBaseUrl) {
+    return {
+      baseUrl: trimTrailingSlash(webProxyBaseUrl),
+      mode: 'proxy' as const,
+    };
+  }
+
+  return {
+    baseUrl: DEFAULT_API_BASE_URL,
+    mode: 'direct' as const,
+  };
+}
+
+export function isUsingWebProxy() {
+  return getApiConfig().mode === 'proxy';
+}
+
+function resolvePath(path: ApiPath) {
+  if (typeof path === 'string') return path;
+  return getApiConfig().mode === 'proxy' ? path.proxy : path.direct;
+}
+
+function extractEnvelopeLike(value: unknown) {
+  if (!value || typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+
+  return {
+    code: typeof record.code === 'string' ? record.code : undefined,
+    message:
+      typeof record.message === 'string' || record.message === null
+        ? (record.message as string | null)
+        : undefined,
+    status: typeof record.status === 'number' ? record.status : undefined,
+  };
+}
+
+export class ApiRequestError<T = unknown> extends Error {
+  apiMessage?: string | null;
+  code?: string;
+  data?: T;
+  status?: number;
+
+  constructor(args: {
+    apiMessage?: string | null;
+    code?: string;
+    data?: T;
+    status?: number;
+  }) {
+    super(args.apiMessage || 'API request failed');
+    this.name = 'ApiRequestError';
+    this.apiMessage = args.apiMessage;
+    this.code = args.code;
+    this.data = args.data;
+    this.status = args.status;
+  }
+}
+
+export function getApiErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiRequestError && error.apiMessage) {
+    return error.apiMessage;
+  }
+
+  if (error instanceof Error && error.message && error.message !== 'API request failed') {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export async function apiRequest<T>(path: ApiPath, options: RequestOptions = {}) {
+  const { baseUrl } = getApiConfig();
+  const headers = new Headers(options.headers);
+  const hasBody = options.body !== undefined;
+
+  headers.set('Accept', headers.get('Accept') ?? 'application/json');
+
+  if (hasBody && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(`${baseUrl}${resolvePath(path)}`, {
+    body: hasBody ? JSON.stringify(options.body) : undefined,
+    cache: options.cache,
+    credentials: 'include',
+    headers,
+    method: options.method ?? 'GET',
+    signal: options.signal,
+  });
+
+  const text = await response.text();
+  let data = null as T;
+
+  if (text) {
+    try {
+      data = JSON.parse(text) as T;
+    } catch {
+      data = text as T;
+    }
+  }
+
+  if (!response.ok) {
+    const envelope = extractEnvelopeLike(data);
+    throw new ApiRequestError<T>({
+      apiMessage: envelope?.message,
+      code: envelope?.code,
+      data,
+      status: response.status,
+    });
+  }
+
+  return data;
+}
+
+export async function apiEnvelopeData<T>(path: ApiPath, options: RequestOptions = {}) {
+  const envelope = await apiRequest<ApiEnvelope<T>>(path, options);
+  return envelope.data;
+}

--- a/apps/mobile/lib/auth-api.ts
+++ b/apps/mobile/lib/auth-api.ts
@@ -1,0 +1,168 @@
+import { apiEnvelopeData, apiRequest } from '@/lib/api-client';
+
+export type UserStatus = 'ACTIVE' | 'DELETED' | 'DELETED_REQUESTED' | 'SUSPENDED';
+
+type LoginResponse = {
+  userStatus: UserStatus;
+};
+
+type AuthStatusResponse = {
+  userStatus: UserStatus;
+};
+
+type PasswordResetVerificationResponse = {
+  resetToken: string;
+};
+
+export async function loginWithEmail(email: string, password: string) {
+  return apiEnvelopeData<LoginResponse>(
+    {
+      direct: '/api/harucut/login',
+      proxy: '/api/client/auth/login',
+    },
+    {
+      body: { email, password },
+      method: 'POST',
+    },
+  );
+}
+
+export async function getAuthStatus() {
+  return apiEnvelopeData<AuthStatusResponse>(
+    {
+      direct: '/api/auth/status',
+      proxy: '/api/auth/status',
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+}
+
+export async function signupWithEmail(args: {
+  email: string;
+  password: string;
+  username: string;
+}) {
+  await apiRequest(
+    {
+      direct: '/api/harucut/register',
+      proxy: '/api/client/auth/register',
+    },
+    {
+      body: args,
+      method: 'POST',
+    },
+  );
+}
+
+export async function sendEmailAuthCode(email: string) {
+  await apiRequest(
+    {
+      direct: '/api/email-auth/code',
+      proxy: '/api/client/auth/email/code',
+    },
+    {
+      body: { email },
+      method: 'POST',
+    },
+  );
+}
+
+export async function verifyEmailAuthCode(email: string, code: string) {
+  await apiRequest(
+    {
+      direct: '/api/email-auth/verification',
+      proxy: '/api/client/auth/email/verification',
+    },
+    {
+      body: { email, code },
+      method: 'POST',
+    },
+  );
+}
+
+export async function requestPasswordResetCode(email: string) {
+  await sendEmailAuthCode(email);
+}
+
+export async function verifyPasswordResetCode(email: string, code: string) {
+  const data = await apiEnvelopeData<PasswordResetVerificationResponse>(
+    {
+      direct: '/api/harucut/reset/password/verification',
+      proxy: '/api/client/auth/password/reset/verification',
+    },
+    {
+      body: { email, code },
+      method: 'POST',
+    },
+  );
+
+  if (!data?.resetToken) {
+    throw new Error('비밀번호 재설정 토큰을 받지 못했어요.');
+  }
+
+  return data.resetToken;
+}
+
+export async function resetPassword(resetToken: string, newPassword: string) {
+  await apiRequest(
+    {
+      direct: '/api/harucut/reset/password',
+      proxy: '/api/client/auth/password/reset',
+    },
+    {
+      body: { newPassword, resetToken },
+      method: 'PATCH',
+    },
+  );
+}
+
+export async function changePassword(oldPassword: string, newPassword: string) {
+  await apiRequest(
+    {
+      direct: '/api/harucut/change/password',
+      proxy: '/api/client/auth/password/change',
+    },
+    {
+      body: { newPassword, oldPassword },
+      method: 'PATCH',
+    },
+  );
+}
+
+export async function logout() {
+  await apiRequest(
+    {
+      direct: '/api/harucut/logout',
+      proxy: '/api/client/logout',
+    },
+    {
+      method: 'DELETE',
+    },
+  );
+}
+
+export async function exitAccount() {
+  await apiRequest(
+    {
+      direct: '/api/harucut/exit',
+      proxy: '/api/client/exit',
+    },
+    {
+      method: 'DELETE',
+    },
+  );
+}
+
+export async function reactivateAccount() {
+  await apiRequest(
+    {
+      direct: '/api/harucut/reactivate',
+      proxy: '/api/client/reactivate',
+    },
+    {
+      method: 'POST',
+    },
+  );
+}

--- a/apps/mobile/lib/file-storage-api.ts
+++ b/apps/mobile/lib/file-storage-api.ts
@@ -1,0 +1,176 @@
+import { apiEnvelopeData, apiRequest } from '@/lib/api-client';
+
+export type PresignedUploadContentType = 'GIF' | 'JPEG' | 'MOV' | 'MP4' | 'PNG' | 'WEBM' | 'WEBP';
+export type PresignedUploadType =
+  | 'FOURCUT_PHOTO'
+  | 'FOURCUT_VIDEO'
+  | 'FRAME'
+  | 'FRAME_COMPONENT'
+  | 'PROFILE';
+
+type PresignedUploadResponse = {
+  contentType: string;
+  expiresIn?: string;
+  key: string;
+  uploadUrl: string;
+};
+
+type UploadLocalFileOptions = {
+  contentType?: PresignedUploadContentType;
+  filename?: string | null;
+  isTemp?: boolean;
+  type: PresignedUploadType;
+  uri: string;
+};
+
+type TranscodeTaskStatus = 'COMPLETE' | 'ERROR' | 'PROGRESSING' | 'QUEUED' | 'SUBMITTED';
+
+type TranscodeTaskSubmitResponse = {
+  jobId: string;
+  requestedAt?: string;
+  status: TranscodeTaskStatus;
+  taskId: string;
+};
+
+type TranscodeTaskStatusResponse = TranscodeTaskSubmitResponse & {
+  errorMessage?: string | null;
+  media?: unknown;
+  updatedAt?: string;
+};
+
+function extensionFromUri(uri: string) {
+  const withoutQuery = uri.split('?')[0] ?? uri;
+  return withoutQuery.split('.').pop()?.trim().toLowerCase() ?? '';
+}
+
+function filenameFromUri(uri: string, fallbackPrefix: string) {
+  const withoutQuery = uri.split('?')[0] ?? uri;
+  const name = withoutQuery.split('/').pop()?.trim();
+
+  if (name && name.includes('.')) return name;
+
+  const ext = extensionFromUri(uri) || 'jpg';
+  return `${fallbackPrefix}-${Date.now()}.${ext}`;
+}
+
+export function resolveUploadContentType(args: {
+  filename?: string | null;
+  mimeType?: string | null;
+  uri?: string;
+}): PresignedUploadContentType {
+  const mimeType = args.mimeType?.toLowerCase() ?? '';
+  const ext = (args.filename?.split('.').pop() ?? (args.uri ? extensionFromUri(args.uri) : ''))
+    .trim()
+    .toLowerCase();
+
+  if (mimeType === 'image/png' || ext === 'png') return 'PNG';
+  if (mimeType === 'image/webp' || ext === 'webp') return 'WEBP';
+  if (mimeType === 'image/gif' || ext === 'gif') return 'GIF';
+  if (mimeType === 'video/mp4' || ext === 'mp4') return 'MP4';
+  if (mimeType === 'video/webm' || ext === 'webm') return 'WEBM';
+  if (mimeType === 'video/quicktime' || mimeType === 'video/mov' || ext === 'mov') return 'MOV';
+  if (
+    mimeType === 'image/jpeg' ||
+    mimeType === 'image/jpg' ||
+    ext === 'jpg' ||
+    ext === 'jpeg'
+  ) {
+    return 'JPEG';
+  }
+
+  return 'JPEG';
+}
+
+function isVideoContentType(contentType: PresignedUploadContentType) {
+  return ['MOV', 'MP4', 'WEBM'].includes(contentType);
+}
+
+export function fourcutUploadType(contentType: PresignedUploadContentType): PresignedUploadType {
+  return isVideoContentType(contentType) ? 'FOURCUT_VIDEO' : 'FOURCUT_PHOTO';
+}
+
+async function createPresignedUpload(args: {
+  contentType: PresignedUploadContentType;
+  filename: string;
+  isTemp: boolean;
+  type: PresignedUploadType;
+}) {
+  return apiEnvelopeData<PresignedUploadResponse>(
+    {
+      direct: '/api/auth/user/files/presigned-upload',
+      proxy: '/api/client/user/files/presigned-upload',
+    },
+    {
+      body: args,
+      method: 'POST',
+    },
+  );
+}
+
+export async function getPresignedImageUrl(key: string) {
+  return apiEnvelopeData<string>(
+    {
+      direct: `/api/auth/user/files/presigned-img?key=${encodeURIComponent(key)}`,
+      proxy: `/api/client/user/files/presigned-img?key=${encodeURIComponent(key)}`,
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+}
+
+export async function uploadLocalFileWithPresigned(opts: UploadLocalFileOptions) {
+  const filename = opts.filename?.trim() || filenameFromUri(opts.uri, 'harucut');
+  const contentType = opts.contentType ?? resolveUploadContentType({ filename, uri: opts.uri });
+  const presigned = await createPresignedUpload({
+    contentType,
+    filename,
+    isTemp: opts.isTemp ?? false,
+    type: opts.type,
+  });
+
+  const fileResponse = await fetch(opts.uri);
+  const fileBlob = await fileResponse.blob();
+  const uploadResponse = await fetch(presigned.uploadUrl, {
+    body: fileBlob,
+    headers: {
+      'Content-Type': presigned.contentType,
+    },
+    method: 'PUT',
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error(`파일 업로드에 실패했어요. (${uploadResponse.status})`);
+  }
+
+  return {
+    contentType,
+    key: presigned.key,
+    objectUrl: presigned.uploadUrl.split('?')[0] ?? presigned.uploadUrl,
+  };
+}
+
+export async function requestVideoTranscode(filename: string) {
+  return apiEnvelopeData<TranscodeTaskSubmitResponse>(
+    {
+      direct: '/api/auth/user/files/transcode',
+      proxy: '/api/client/user/files/transcode',
+    },
+    {
+      body: { filename },
+      method: 'POST',
+    },
+  );
+}
+
+export async function getVideoTranscodeStatus(taskId: string) {
+  return apiEnvelopeData<TranscodeTaskStatusResponse>(
+    {
+      direct: `/api/auth/user/files/transcode/status?taskId=${encodeURIComponent(taskId)}`,
+      proxy: `/api/client/user/files/transcode/status?taskId=${encodeURIComponent(taskId)}`,
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+}

--- a/apps/mobile/lib/frame-api.ts
+++ b/apps/mobile/lib/frame-api.ts
@@ -1,0 +1,268 @@
+import type { FrameId, SavedFrame } from '@/constants/harucut-data';
+import { apiEnvelopeData, apiRequest } from '@/lib/api-client';
+
+export type RemoteFrameType = 'CLASSIC' | 'GRID' | 'POLAROID' | 'WIDE';
+
+type RemoteFrameBackground =
+  | {
+      type: 'COLOR';
+      value: string;
+    }
+  | {
+      key?: string;
+      opacity?: number;
+      type: 'IMAGE';
+    }
+  | {
+      autoPlay?: boolean;
+      key?: string;
+      loop?: boolean;
+      type: 'VIDEO';
+    };
+
+type RemoteFrameComponent = {
+  height: number;
+  id?: number | string;
+  key?: string;
+  rotation?: number;
+  scale?: number;
+  source: string;
+  style?: Record<string, unknown>;
+  styleJson?: Record<string, unknown>;
+  type: 'PHOTO' | 'STICKER' | 'TEXT';
+  width: number;
+  x: number;
+  y: number;
+  zIndex: number;
+};
+
+type RemoteFrame = {
+  background?: RemoteFrameBackground;
+  components?: RemoteFrameComponent[];
+  description?: string;
+  frameId: number;
+  frameType: RemoteFrameType;
+  source?: string;
+  title: string;
+};
+
+type FrameCreateRequest = {
+  background: RemoteFrameBackground;
+  canvasHeight: number;
+  canvasWidth: number;
+  components: RemoteFrameComponent[];
+  description: string;
+  frameType: RemoteFrameType;
+  previewKey: string;
+  title: string;
+};
+
+type ThemeFrameDraft = {
+  accentColor: string;
+  backgroundColor: string;
+  caption: string;
+  description: string;
+  frameId: FrameId;
+  previewKey: string;
+  stickers: string[];
+  title: string;
+};
+
+const FRAME_CANVAS: Record<FrameId, { height: number; width: number }> = {
+  'classic-4': { height: 1920, width: 1080 },
+  'grid-4': { height: 1600, width: 1440 },
+  'polaroid-4': { height: 1760, width: 1440 },
+  'wide-4': { height: 1640, width: 1440 },
+};
+
+function frameTypeFromFrameId(frameId: FrameId): RemoteFrameType {
+  if (frameId.startsWith('wide')) return 'WIDE';
+  if (frameId.startsWith('grid')) return 'GRID';
+  if (frameId.startsWith('polaroid')) return 'POLAROID';
+  return 'CLASSIC';
+}
+
+function frameIdFromFrameType(frameType: RemoteFrameType): FrameId {
+  switch (frameType) {
+    case 'GRID':
+      return 'grid-4';
+    case 'POLAROID':
+      return 'polaroid-4';
+    case 'WIDE':
+      return 'wide-4';
+    case 'CLASSIC':
+    default:
+      return 'classic-4';
+  }
+}
+
+function normalizeHexColor(input: string) {
+  const cleaned = input.trim().replace(/^#/, '');
+  const hex = cleaned.replace(/[^0-9a-fA-F]/g, '').slice(0, 6).toLowerCase();
+
+  if (hex.length === 3) {
+    return hex
+      .split('')
+      .map((char) => `${char}${char}`)
+      .join('');
+  }
+
+  return hex.padEnd(6, '0') || 'ffffff';
+}
+
+function withHashColor(value: string | undefined, fallback: string) {
+  const normalized = normalizeHexColor(value ?? fallback);
+  return `#${normalized}`;
+}
+
+function componentStyle(component: RemoteFrameComponent) {
+  return (component.styleJson ?? component.style ?? {}) as Record<string, unknown>;
+}
+
+function stringStyleValue(style: Record<string, unknown>, key: string) {
+  const value = style[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function toCreateFrameRequest(draft: ThemeFrameDraft): FrameCreateRequest {
+  const canvas = FRAME_CANVAS[draft.frameId];
+  const caption = draft.caption.trim();
+  const stickers = draft.stickers.filter((item) => item.trim());
+  const components: RemoteFrameComponent[] = [
+    ...(caption
+      ? [
+          {
+            height: 120,
+            source: caption,
+            styleJson: {
+              accentColor: draft.accentColor,
+              color: draft.accentColor,
+              role: 'caption',
+            },
+            rotation: 0,
+            scale: 1,
+            type: 'TEXT' as const,
+            width: canvas.width * 0.8,
+            x: canvas.width * 0.1,
+            y: canvas.height * 0.86,
+            zIndex: 1,
+          },
+        ]
+      : []),
+    ...stickers.map((sticker, index) => ({
+      height: 96,
+      source: sticker,
+      styleJson: {
+        accentColor: draft.accentColor,
+        color: draft.accentColor,
+        role: 'sticker',
+      },
+      rotation: 0,
+      scale: 1,
+      type: 'TEXT' as const,
+      width: 96,
+      x: 120 + index * 112,
+      y: 120,
+      zIndex: index + 2,
+    })),
+  ];
+
+  return {
+    background: {
+      type: 'COLOR',
+      value: normalizeHexColor(draft.backgroundColor),
+    },
+    canvasHeight: canvas.height,
+    canvasWidth: canvas.width,
+    components,
+    description: draft.description,
+    frameType: frameTypeFromFrameId(draft.frameId),
+    previewKey: draft.previewKey,
+    title: draft.title,
+  };
+}
+
+function toSavedFrame(frame: RemoteFrame): SavedFrame {
+  const components = frame.components ?? [];
+  const captionComponent = components.find(
+    (component) => component.type === 'TEXT' && componentStyle(component).role === 'caption',
+  );
+  const stickerComponents = components.filter(
+    (component) => component.type === 'TEXT' && componentStyle(component).role === 'sticker',
+  );
+  const captionStyle = captionComponent ? componentStyle(captionComponent) : {};
+  const backgroundColor =
+    frame.background?.type === 'COLOR'
+      ? withHashColor(frame.background.value, 'EEF5FF')
+      : '#EEF5FF';
+  const accentColor =
+    stringStyleValue(captionStyle, 'accentColor') ??
+    stringStyleValue(captionStyle, 'color') ??
+    '#2563EB';
+
+  return {
+    accentColor,
+    backgroundColor,
+    caption: captionComponent?.source ?? '',
+    description: frame.description ?? '',
+    frameId: frameIdFromFrameType(frame.frameType),
+    id: `remote-frame-${frame.frameId}`,
+    previewKey: frame.source,
+    remoteFrameId: frame.frameId,
+    stickers: stickerComponents.map((component) => component.source).filter(Boolean),
+    title: frame.title,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export async function listRemoteFrames() {
+  const frames = await apiEnvelopeData<RemoteFrame[]>(
+    {
+      direct: '/api/auth/user/frame',
+      proxy: '/api/client/user/frame',
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+
+  return Array.isArray(frames) ? frames.map(toSavedFrame) : [];
+}
+
+export async function createRemoteFrame(draft: ThemeFrameDraft) {
+  await apiRequest(
+    {
+      direct: '/api/auth/user/frame',
+      proxy: '/api/client/user/frame',
+    },
+    {
+      body: toCreateFrameRequest(draft),
+      method: 'POST',
+    },
+  );
+}
+
+export async function updateRemoteFrame(frameId: number, draft: ThemeFrameDraft) {
+  await apiRequest(
+    {
+      direct: `/api/auth/user/frame/${frameId}`,
+      proxy: `/api/client/user/frame/${frameId}`,
+    },
+    {
+      body: toCreateFrameRequest(draft),
+      method: 'PUT',
+    },
+  );
+}
+
+export async function deleteRemoteFrame(frameId: number) {
+  await apiRequest(
+    {
+      direct: `/api/auth/user/frame/${frameId}`,
+      proxy: `/api/client/user/frame/${frameId}`,
+    },
+    {
+      method: 'DELETE',
+    },
+  );
+}

--- a/apps/mobile/lib/user-api.ts
+++ b/apps/mobile/lib/user-api.ts
@@ -1,0 +1,76 @@
+import type { UserProfile } from '@/constants/harucut-data';
+import { apiEnvelopeData, apiRequest, isUsingWebProxy } from '@/lib/api-client';
+
+type RemoteUserInfo = {
+  email: string;
+  id: number;
+  loginPlatform?: string | null;
+  monthlyPrice?: number | null;
+  planTier?: string | null;
+  profileUrl?: string | null;
+  username: string;
+};
+
+export function toUserProfile(user: RemoteUserInfo): UserProfile {
+  return {
+    email: user.email,
+    loginPlatform: user.loginPlatform ?? 'HARUCUT',
+    monthlyPrice: user.monthlyPrice ?? null,
+    planTier: user.planTier ?? 'BASIC',
+    profileUrl: user.profileUrl ?? null,
+    username: user.username,
+  };
+}
+
+export async function getMyUserProfile() {
+  const user = await apiEnvelopeData<RemoteUserInfo>(
+    {
+      direct: '/api/auth/user/info',
+      proxy: '/api/client/user-info',
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+
+  return toUserProfile(user);
+}
+
+export async function updateUsername(username: string) {
+  const nextUsername = username.trim();
+
+  if (!nextUsername) {
+    throw new Error('닉네임을 입력해 주세요.');
+  }
+
+  if (isUsingWebProxy()) {
+    await apiRequest(
+      {
+        direct: '/api/auth/user/change/username',
+        proxy: '/api/client/user/username',
+      },
+      {
+        body: { username: nextUsername },
+        method: 'PATCH',
+      },
+    );
+    return;
+  }
+
+  await apiRequest(`/api/auth/user/change/username?username=${encodeURIComponent(nextUsername)}`, {
+    method: 'PATCH',
+  });
+}
+
+export async function updateProfileImage(s3Key: string) {
+  await apiRequest(
+    {
+      direct: '/api/auth/user/change/profile-image',
+      proxy: '/api/client/user/change/profile-image',
+    },
+    {
+      body: { s3Key },
+      method: 'PATCH',
+    },
+  );
+}

--- a/apps/mobile/lib/user-media-api.ts
+++ b/apps/mobile/lib/user-media-api.ts
@@ -1,0 +1,176 @@
+import type { FrameId, HistoryItem, MediaAsset } from '@/constants/harucut-data';
+import { apiEnvelopeData, apiRequest } from '@/lib/api-client';
+import {
+  fourcutUploadType,
+  resolveUploadContentType,
+  uploadLocalFileWithPresigned,
+} from '@/lib/file-storage-api';
+
+export type UserMediaType = 'PHOTO' | 'VIDEO';
+
+export type UserMedia = {
+  createdAt?: string;
+  displayName?: string | null;
+  displayname?: string | null;
+  downloadUrl?: string;
+  mediaId: number;
+  mediaType: UserMediaType;
+  originalFileName?: string;
+  originalS3Key?: string;
+  s3Key: string;
+  transcodeJobId?: string;
+};
+
+type HistoryItemOptions = {
+  frameId?: FrameId;
+  source?: HistoryItem['source'];
+  title?: string;
+};
+
+function getUserMediaTitle(item: UserMedia) {
+  const preferredName = item.displayName?.trim() || item.displayname?.trim();
+  if (preferredName) return preferredName;
+
+  const originalName = item.originalFileName?.trim();
+  if (originalName) return originalName.replace(/\.[^.]+$/, '');
+
+  return item.s3Key.split('/').pop()?.replace(/\.[^.]+$/, '') || '저장한 기록';
+}
+
+function getCreatedAt(item: UserMedia) {
+  const createdAt = item.createdAt ? new Date(item.createdAt) : null;
+
+  return createdAt && !Number.isNaN(createdAt.getTime()) ? createdAt.toISOString() : '';
+}
+
+function mediaToAsset(item: UserMedia): MediaAsset | null {
+  if (!item.downloadUrl) {
+    return null;
+  }
+
+  return {
+    id: `remote-media-${item.mediaId}`,
+    kind: item.mediaType === 'VIDEO' ? 'video' : 'image',
+    label: getUserMediaTitle(item),
+    remoteMediaId: item.mediaId,
+    uri: item.downloadUrl,
+  };
+}
+
+export function mediaToHistoryItem(item: UserMedia, options: HistoryItemOptions = {}): HistoryItem {
+  const asset = mediaToAsset(item);
+  const title = options.title?.trim() || getUserMediaTitle(item);
+
+  return {
+    createdAt: getCreatedAt(item),
+    frameId: options.frameId ?? 'classic-4',
+    id: `remote-history-${item.mediaId}`,
+    kind: item.mediaType === 'VIDEO' ? 'video' : 'photo',
+    mediaId: item.mediaId,
+    previewMedia: asset ? [asset] : [],
+    remoteS3Key: item.s3Key,
+    source: options.source ?? 'upload',
+    title,
+  };
+}
+
+export async function listMyMedia(type?: UserMediaType) {
+  const query = type ? `?type=${encodeURIComponent(type)}` : '';
+  const media = await apiEnvelopeData<UserMedia[]>(
+    {
+      direct: `/api/auth/user/media${query}`,
+      proxy: `/api/client/user/media${query}`,
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+
+  return Array.isArray(media) ? media : [];
+}
+
+export async function listRemoteHistoryItems() {
+  const media = await listMyMedia();
+
+  return media
+    .sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+
+      return bTime - aTime;
+    })
+    .map((item) => mediaToHistoryItem(item));
+}
+
+export async function registerUserMedia(args: {
+  displayName?: string;
+  mediaType: UserMediaType;
+  s3Key: string;
+}) {
+  return apiEnvelopeData<UserMedia>(
+    {
+      direct: '/api/auth/user/media',
+      proxy: '/api/client/user/media',
+    },
+    {
+      body: args,
+      method: 'POST',
+    },
+  );
+}
+
+export async function getMediaDownloadUrl(mediaId: number) {
+  return apiEnvelopeData<string>(
+    {
+      direct: `/api/auth/user/media/${mediaId}/download-url`,
+      proxy: `/api/client/user/media/${mediaId}/download-url`,
+    },
+    {
+      cache: 'no-store',
+    },
+  );
+}
+
+export async function updateMediaDisplayName(mediaId: number, displayName: string) {
+  return apiEnvelopeData<UserMedia>(
+    {
+      direct: `/api/auth/user/media/${mediaId}/display-name`,
+      proxy: `/api/client/user/media/${mediaId}/display-name`,
+    },
+    {
+      body: { displayName },
+      method: 'PATCH',
+    },
+  );
+}
+
+export async function uploadFourcutResult(args: {
+  displayName: string;
+  frameId: FrameId;
+  source: HistoryItem['source'];
+  uri: string;
+}) {
+  const contentType = resolveUploadContentType({
+    filename: `${args.displayName}.jpg`,
+    uri: args.uri,
+  });
+  const uploaded = await uploadLocalFileWithPresigned({
+    contentType,
+    filename: `${args.displayName}.jpg`,
+    type: fourcutUploadType(contentType),
+    uri: args.uri,
+  });
+  const media = await registerUserMedia({
+    displayName: args.displayName,
+    mediaType: uploaded.contentType === 'MOV' || uploaded.contentType === 'MP4' || uploaded.contentType === 'WEBM'
+      ? 'VIDEO'
+      : 'PHOTO',
+    s3Key: uploaded.key,
+  });
+
+  return mediaToHistoryItem(media, {
+    frameId: args.frameId,
+    source: args.source,
+    title: args.displayName,
+  });
+}

--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -1,14 +1,18 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Image, Pressable, Share, StyleSheet, Text, View } from 'react-native';
 
 import { FramePreview } from '@/components/harucut/frame';
 import { ActionButton, AppScrollView, FormField, PageHeader, Pill, SurfaceCard } from '@/components/harucut/ui';
-import { FRAME_CATALOG, QUICK_LINKS, type HistoryItem } from '@/constants/harucut-data';
+import { FRAME_CATALOG, type HistoryItem } from '@/constants/harucut-data';
 import type { HarucutThemePreference } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { changePassword, exitAccount, logout } from '@/lib/auth-api';
+import { getApiErrorMessage } from '@/lib/api-client';
+import { uploadLocalFileWithPresigned } from '@/lib/file-storage-api';
+import { updateProfileImage, updateUsername } from '@/lib/user-api';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 type HarucutThemeColors = ReturnType<typeof useHarucutTheme>['colors'];
@@ -40,7 +44,16 @@ function historyPreviewUri(item: HistoryItem) {
 }
 
 function formatDate(value: string) {
-  return new Date(value).toLocaleString('ko-KR', {
+  if (!value) {
+    return '날짜 없음';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '날짜 없음';
+  }
+
+  return date.toLocaleString('ko-KR', {
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
@@ -72,16 +85,35 @@ export function HomeScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
   const historyItems = useHarucutStore((state) => state.historyItems);
+  const historyError = useHarucutStore((state) => state.historyError);
+  const historyStatus = useHarucutStore((state) => state.historyStatus);
+  const loadRemoteFrames = useHarucutStore((state) => state.loadRemoteFrames);
+  const accessMode = useHarucutStore((state) => state.accessMode);
+  const loadRemoteHistory = useHarucutStore((state) => state.loadRemoteHistory);
   const savedFrames = useHarucutStore((state) => state.savedFrames);
   const user = useHarucutStore((state) => state.user);
 
-  const recentMoment = historyItems[0]
-    ? new Date(historyItems[0].createdAt).toLocaleDateString('ko-KR', {
-        day: 'numeric',
-        month: 'long',
-        weekday: 'short',
-      })
-    : '첫 기록을 남겨보세요';
+  const todayMoment = new Date().toLocaleDateString('ko-KR', {
+    day: 'numeric',
+    month: 'long',
+    weekday: 'short',
+  });
+  const recentItems = historyItems.slice(0, 4);
+  const isHistoryLoading =
+    historyStatus === 'loading' ||
+    (accessMode === 'member' && historyStatus === 'idle');
+
+  useEffect(() => {
+    if (accessMode === 'member' && historyStatus === 'idle') {
+      void loadRemoteHistory();
+    }
+  }, [accessMode, historyStatus, loadRemoteHistory]);
+
+  useEffect(() => {
+    if (accessMode === 'member') {
+      void loadRemoteFrames();
+    }
+  }, [accessMode, loadRemoteFrames]);
 
   return (
     <AppScrollView>
@@ -93,13 +125,11 @@ export function HomeScreen() {
       />
 
       <SurfaceCard style={{ gap: 16 }}>
-        <Pill>{recentMoment}</Pill>
+        <Pill>{todayMoment}</Pill>
         <View style={{ gap: 10 }}>
           <Text style={styles.heroTitle}>찍고 저장하고,</Text>
           <Text style={styles.heroTitleAccent}>다시 꺼내 보는 하루컷</Text>
-          <Text style={styles.bodyCopy}>
-            복잡한 설명 없이 바로 시작할 수 있게 준비했어요. 원하는 방식으로 만들고 기록에 남겨두세요.
-          </Text>
+          <Text style={styles.bodyCopy}>촬영하거나 업로드해서 기록에 남겨두세요.</Text>
         </View>
 
         <View style={styles.rowButtons}>
@@ -117,15 +147,6 @@ export function HomeScreen() {
             variant="secondary"
           />
         </View>
-
-        <View style={styles.quickGrid}>
-          {QUICK_LINKS.map((item) => (
-            <Pressable key={item.href} onPress={() => push(item.href)} style={styles.quickItem}>
-              <Ionicons color={colors.primary} name={item.icon} size={16} />
-              <Text style={styles.quickText}>{item.label}</Text>
-            </Pressable>
-          ))}
-        </View>
       </SurfaceCard>
 
       <SurfaceCard style={{ gap: 14 }}>
@@ -140,11 +161,43 @@ export function HomeScreen() {
         </View>
 
         <View style={styles.recentGrid}>
-          {historyItems.slice(0, 4).map((item) => (
-            <View key={item.id} style={styles.thumbCard}>
-              <Image source={{ uri: historyPreviewUri(item) }} style={styles.thumbImage} />
+          {isHistoryLoading ? (
+            Array.from({ length: 4 }, (_, index) => (
+              <View key={`recent-loading-${index}`} style={[styles.thumbCard, styles.thumbLoading]} />
+            ))
+          ) : recentItems.length > 0 ? (
+            recentItems.map((item) => {
+              const previewUri = historyPreviewUri(item);
+
+              return (
+                <View key={item.id} style={styles.thumbCard}>
+                  {previewUri && item.kind === 'photo' ? (
+                    <Image source={{ uri: previewUri }} style={styles.thumbImage} />
+                  ) : (
+                    <View style={styles.thumbPlaceholder}>
+                      <Ionicons
+                        color={colors.primary}
+                        name={item.kind === 'video' ? 'play-circle-outline' : 'image-outline'}
+                        size={24}
+                      />
+                      <Text style={styles.thumbPlaceholderText}>
+                        {item.kind === 'video' ? '영상' : '미리보기 없음'}
+                      </Text>
+                    </View>
+                  )}
+                </View>
+              );
+            })
+          ) : (
+            <View style={styles.recentEmptyCard}>
+              <Text style={styles.linkTitle}>아직 저장한 결과가 없어요.</Text>
+              <Text style={styles.linkBody}>
+                {historyStatus === 'error'
+                  ? (historyError ?? '저장한 결과를 불러오지 못했어요.')
+                  : '촬영하거나 업로드하면 여기에 표시돼요.'}
+              </Text>
             </View>
-          ))}
+          )}
         </View>
       </SurfaceCard>
 
@@ -196,8 +249,13 @@ export function HistoryScreen() {
   const { colors, styles } = useAppScreenTheme();
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
+  const accessMode = useHarucutStore((state) => state.accessMode);
+  const historyError = useHarucutStore((state) => state.historyError);
   const historyItems = useHarucutStore((state) => state.historyItems);
+  const historyStatus = useHarucutStore((state) => state.historyStatus);
+  const loadRemoteHistory = useHarucutStore((state) => state.loadRemoteHistory);
   const renameHistoryItem = useHarucutStore((state) => state.renameHistoryItem);
+  const showNotice = useHarucutStore((state) => state.showNotice);
   const [filter, setFilter] = useState<'ALL' | 'PHOTO' | 'VIDEO'>('ALL');
   const [search, setSearch] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -214,6 +272,15 @@ export function HistoryScreen() {
 
   const photoCount = historyItems.filter((item) => item.kind === 'photo').length;
   const videoCount = historyItems.filter((item) => item.kind === 'video').length;
+  const isHistoryLoading =
+    historyStatus === 'loading' ||
+    (accessMode === 'member' && historyStatus === 'idle');
+
+  useEffect(() => {
+    if (accessMode === 'member' && historyStatus === 'idle') {
+      void loadRemoteHistory();
+    }
+  }, [accessMode, historyStatus, loadRemoteHistory]);
 
   return (
     <AppScrollView>
@@ -256,9 +323,19 @@ export function HistoryScreen() {
         </View>
       </SurfaceCard>
 
-      {filteredItems.length === 0 ? (
+      {isHistoryLoading ? (
         <SurfaceCard>
-          <Text style={styles.bodyCopy}>저장한 기록이 아직 없어요.</Text>
+          <Text style={styles.bodyCopy}>저장한 기록을 불러오는 중이에요.</Text>
+        </SurfaceCard>
+      ) : historyStatus === 'error' ? (
+        <SurfaceCard>
+          <Text style={styles.bodyCopy}>{historyError ?? '저장한 기록을 불러오지 못했어요.'}</Text>
+        </SurfaceCard>
+      ) : filteredItems.length === 0 ? (
+        <SurfaceCard>
+          <Text style={styles.bodyCopy}>
+            {historyItems.length === 0 ? '저장한 기록이 아직 없어요.' : '검색 결과가 없어요.'}
+          </Text>
         </SurfaceCard>
       ) : (
         filteredItems.map((item) => (
@@ -297,8 +374,17 @@ export function HistoryScreen() {
                     label={editingId === item.id ? '저장' : '이름 수정'}
                     onPress={() => {
                       if (editingId === item.id) {
-                        renameHistoryItem(item.id, draftName.trim() || item.title);
-                        setEditingId(null);
+                        void renameHistoryItem(item.id, draftName.trim() || item.title)
+                          .then(() => setEditingId(null))
+                          .catch((error) =>
+                            showNotice({
+                              actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+                              eyebrow: 'SAVE ERROR',
+                              icon: 'warning-outline',
+                              message: getApiErrorMessage(error, '파일 이름을 저장하지 못했어요.'),
+                              title: '이름 변경 실패',
+                            }),
+                          );
                         return;
                       }
 
@@ -323,14 +409,31 @@ export function MyPageScreen() {
   const router = useRouter();
   const replace = (path: string) => router.replace(path as never);
   const user = useHarucutStore((state) => state.user);
+  const refreshUserProfile = useHarucutStore((state) => state.refreshUserProfile);
   const setUserProfile = useHarucutStore((state) => state.setUserProfile);
   const enterAnonymousMode = useHarucutStore((state) => state.enterAnonymousMode);
+  const showNotice = useHarucutStore((state) => state.showNotice);
   const themePreference = useHarucutStore((state) => state.themePreference);
   const setThemePreference = useHarucutStore((state) => state.setThemePreference);
   const [username, setUsername] = useState(user.username);
   const [oldPassword, setOldPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setUsername(user.username);
+  }, [user.username]);
+
+  const showError = (title: string, message: string) => {
+    showNotice({
+      actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+      eyebrow: 'ACCOUNT ERROR',
+      icon: 'warning-outline',
+      message,
+      title,
+    });
+  };
 
   const handlePickProfile = async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -341,7 +444,85 @@ export function MyPageScreen() {
     });
 
     if (!result.canceled && result.assets[0]?.uri) {
-      setUserProfile({ profileUrl: result.assets[0].uri });
+      setSubmitting(true);
+
+      try {
+        const asset = result.assets[0];
+        const uploaded = await uploadLocalFileWithPresigned({
+          filename: asset.fileName ?? 'profile.jpg',
+          isTemp: false,
+          type: 'PROFILE',
+          uri: asset.uri,
+        });
+        await updateProfileImage(uploaded.key);
+        setUserProfile({ profileUrl: uploaded.objectUrl });
+        await refreshUserProfile();
+      } catch (error) {
+        showError('프로필 이미지 변경 실패', getApiErrorMessage(error, '프로필 이미지를 변경하지 못했어요.'));
+      } finally {
+        setSubmitting(false);
+      }
+    }
+  };
+
+  const handleUpdateUsername = async () => {
+    setSubmitting(true);
+
+    try {
+      await updateUsername(username);
+      await refreshUserProfile();
+    } catch (error) {
+      showError('닉네임 변경 실패', getApiErrorMessage(error, '닉네임을 변경하지 못했어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleChangePassword = async () => {
+    if (!oldPassword || !newPassword || newPassword !== confirmPassword) {
+      showError('비밀번호 변경 실패', '현재 비밀번호와 새 비밀번호 확인 값을 다시 확인해 주세요.');
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      await changePassword(oldPassword, newPassword);
+      setOldPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (error) {
+      showError('비밀번호 변경 실패', getApiErrorMessage(error, '비밀번호를 변경하지 못했어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    setSubmitting(true);
+
+    try {
+      await logout();
+    } catch {
+      // 로컬 세션 정리는 계속 진행합니다.
+    } finally {
+      enterAnonymousMode();
+      replace('/');
+      setSubmitting(false);
+    }
+  };
+
+  const handleExit = async () => {
+    setSubmitting(true);
+
+    try {
+      await exitAccount();
+      enterAnonymousMode();
+      replace('/');
+    } catch (error) {
+      showError('회원 탈퇴 요청 실패', getApiErrorMessage(error, '회원 탈퇴 요청을 처리하지 못했어요.'));
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -349,7 +530,9 @@ export function MyPageScreen() {
     <AppScrollView>
       <PageHeader
         description="계정 정보와 보안 설정을 관리할 수 있어요."
-        onPressRight={() => undefined}
+        onPressRight={() => void refreshUserProfile().catch((error) =>
+          showError('계정 정보 새로고침 실패', getApiErrorMessage(error, '계정 정보를 불러오지 못했어요.')),
+        )}
         rightSlot={<Ionicons color={colors.text} name="refresh-outline" size={18} />}
         title="내 계정"
       />
@@ -381,7 +564,7 @@ export function MyPageScreen() {
 
         <ActionButton
           icon={<Ionicons color={colors.text} name="image-outline" size={16} />}
-          label="프로필 이미지 업로드"
+          label={submitting ? '처리 중...' : '프로필 이미지 업로드'}
           onPress={handlePickProfile}
           variant="secondary"
         />
@@ -391,7 +574,7 @@ export function MyPageScreen() {
         <Text style={styles.sectionTitle}>닉네임 변경</Text>
         <Text style={styles.bodyCopy}>서비스에서 표시될 이름을 수정할 수 있어요.</Text>
         <FormField label="닉네임" onChangeText={setUsername} placeholder="닉네임을 입력해 주세요" value={username} />
-        <ActionButton label="저장" onPress={() => setUserProfile({ username: username.trim() || user.username })} />
+        <ActionButton label={submitting ? '저장 중...' : '저장'} onPress={() => void handleUpdateUsername()} />
       </SurfaceCard>
 
       <SurfaceCard style={{ gap: 12 }}>
@@ -418,14 +601,8 @@ export function MyPageScreen() {
           value={confirmPassword}
         />
         <ActionButton
-          label="비밀번호 변경"
-          onPress={() => {
-            if (newPassword && newPassword === confirmPassword) {
-              setOldPassword('');
-              setNewPassword('');
-              setConfirmPassword('');
-            }
-          }}
+          label={submitting ? '변경 중...' : '비밀번호 변경'}
+          onPress={() => void handleChangePassword()}
         />
       </SurfaceCard>
 
@@ -477,11 +654,8 @@ export function MyPageScreen() {
       <SurfaceCard style={{ gap: 12 }}>
         <Text style={styles.sectionTitle}>로그아웃</Text>
         <ActionButton
-          label="로그아웃"
-          onPress={() => {
-            enterAnonymousMode();
-            replace('/');
-          }}
+          label={submitting ? '로그아웃 중...' : '로그아웃'}
+          onPress={() => void handleLogout()}
           variant="secondary"
         />
       </SurfaceCard>
@@ -493,10 +667,7 @@ export function MyPageScreen() {
         </Text>
         <ActionButton
           label="회원 탈퇴 요청"
-          onPress={() => {
-            enterAnonymousMode();
-            replace('/');
-          }}
+          onPress={() => void handleExit()}
           variant="danger"
         />
       </SurfaceCard>
@@ -538,13 +709,13 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       color: colors.text,
       fontSize: 28,
       fontWeight: '700',
-      lineHeight: 34,
+      lineHeight: 33.6,
     },
     heroTitleAccent: {
       color: colors.primaryStrong,
       fontSize: 28,
       fontWeight: '700',
-      lineHeight: 34,
+      lineHeight: 33.6,
     },
     historyCardRow: {
       flexDirection: 'row',
@@ -607,27 +778,20 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       flexWrap: 'wrap',
       gap: 10,
     },
-    quickItem: {
-      alignItems: 'center',
-      backgroundColor: tintedSurface,
-      borderColor: colors.border,
-      borderRadius: 18,
-      borderWidth: 1,
-      flexDirection: 'row',
-      gap: 8,
-      paddingHorizontal: 14,
-      paddingVertical: 14,
-      width: '48%',
-    },
-    quickText: {
-      color: colors.text,
-      fontSize: 13,
-      fontWeight: '700',
-    },
     recentGrid: {
       flexDirection: 'row',
       flexWrap: 'wrap',
       gap: 10,
+    },
+    recentEmptyCard: {
+      backgroundColor: tintedSurface,
+      borderColor: colors.border,
+      borderRadius: 18,
+      borderStyle: 'dashed',
+      borderWidth: 1,
+      gap: 6,
+      padding: 16,
+      width: '100%',
     },
     rowButtons: {
       flexDirection: 'row',
@@ -716,6 +880,22 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
     thumbImage: {
       height: '100%',
       width: '100%',
+    },
+    thumbLoading: {
+      opacity: 0.48,
+    },
+    thumbPlaceholder: {
+      alignItems: 'center',
+      flex: 1,
+      gap: 6,
+      justifyContent: 'center',
+      padding: 10,
+    },
+    thumbPlaceholderText: {
+      color: colors.muted,
+      fontSize: 10,
+      fontWeight: '700',
+      textAlign: 'center',
     },
   });
 }

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -4,8 +4,19 @@ import { useEffect, useMemo, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { HERO_IMAGE_SOURCE, LOGIN_FIELDS, SIGNUP_FIELDS } from '@/constants/harucut-data';
-import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, SectionEyebrow, SurfaceCard } from '@/components/harucut/ui';
+import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, SurfaceCard } from '@/components/harucut/ui';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { getApiErrorMessage } from '@/lib/api-client';
+import {
+  loginWithEmail,
+  reactivateAccount,
+  requestPasswordResetCode,
+  resetPassword,
+  sendEmailAuthCode,
+  signupWithEmail,
+  verifyEmailAuthCode,
+  verifyPasswordResetCode,
+} from '@/lib/auth-api';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 type HarucutThemeColors = ReturnType<typeof useHarucutTheme>['colors'];
@@ -121,23 +132,18 @@ export function LandingScreen() {
   const showGuestTrialNotice = useHarucutStore((state) => state.showGuestTrialNotice);
 
   return (
-    <AppScrollView contentContainerStyle={{ flexGrow: 1, justifyContent: 'space-between' }}>
+    <AppScrollView contentContainerStyle={styles.landingScrollContent}>
       <View style={styles.landingHeader}>
         <BrandMark href="/" />
-        <View style={styles.headerActions}>
-          <ActionButton label="로그인" onPress={() => push('/login')} variant="secondary" />
-          <ActionButton label="회원가입" onPress={() => push('/signup')} />
-        </View>
       </View>
 
-      <View style={{ gap: 24 }}>
-        <SectionEyebrow>오늘 하루를 네 컷으로 남겨보세요</SectionEyebrow>
-        <View style={{ gap: 14 }}>
-          <Text style={styles.heroTitle}>오늘의 순간을</Text>
-          <Text style={styles.heroTitleGradient}>다시 보고 싶은 네 컷으로</Text>
-          <Text style={styles.heroBody}>
-            촬영하고, 고르고, 저장하세요. 오늘 하루 기록을 가볍게 남길 수 있어요.
-          </Text>
+      <View style={styles.landingMain}>
+        <View style={styles.heroCopy}>
+          <View style={styles.heroTitleStack}>
+            <Text style={styles.heroTitle}>오늘의 순간을</Text>
+            <Text style={styles.heroTitleGradient}>다시 보고 싶은 네 컷으로</Text>
+          </View>
+          <Text style={styles.heroBody}>찍고, 고르고, 바로 저장하세요.</Text>
         </View>
 
         <View style={styles.heroActions}>
@@ -150,7 +156,7 @@ export function LandingScreen() {
           />
         </View>
 
-        <SurfaceCard>
+        <SurfaceCard style={styles.heroPreviewCard}>
           <View style={styles.heroImageFrame}>
             <Image
               accessibilityLabel="다양한 친구들이 야외에서 셀카를 찍는 네 컷 프레임 예시"
@@ -159,7 +165,7 @@ export function LandingScreen() {
               style={styles.heroImage}
             />
           </View>
-          <View style={{ gap: 8, marginTop: 16 }}>
+          <View style={styles.heroCardCopy}>
             <Text style={styles.heroCardTitle}>찍는 순간보다 {'\n'}다시 꺼내 볼 때 더 좋은 네 컷</Text>
             <Text style={styles.heroCardBody}>
               완성한 결과는 기록 페이지에서 다시 보고 공유할 수 있어요.
@@ -176,9 +182,36 @@ export function LoginScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
   const replace = (path: string) => router.replace(path as never);
-  const enterMemberMode = useHarucutStore((state) => state.enterMemberMode);
+  const bootstrapMemberSession = useHarucutStore((state) => state.bootstrapMemberSession);
   const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
   const [remember, setRemember] = useState(true);
+
+  const handleLogin = async () => {
+    if (!form.email.trim() || !form.password) {
+      setError('이메일과 비밀번호를 입력해 주세요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const loginData = await loginWithEmail(form.email.trim(), form.password);
+
+      if (loginData?.userStatus === 'DELETED_REQUESTED') {
+        await reactivateAccount();
+      }
+
+      await bootstrapMemberSession();
+      replace('/home');
+    } catch (loginError) {
+      setError(getApiErrorMessage(loginError, '로그인에 실패했어요. 이메일과 비밀번호를 확인해 주세요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <AuthShell
@@ -223,12 +256,10 @@ export function LoginScreen() {
         </View>
 
         <ActionButton
-          label="로그인"
-          onPress={() => {
-            enterMemberMode();
-            replace('/home');
-          }}
+          label={submitting ? '로그인 중...' : '로그인'}
+          onPress={() => void handleLogin()}
         />
+        {error ? <Text style={styles.formError}>{error}</Text> : null}
       </SurfaceCard>
     </AuthShell>
   );
@@ -242,6 +273,8 @@ export function SignupScreen() {
   const [code, setCode] = useState('');
   const [form, setForm] = useState({ confirmPassword: '', password: '', username: '' });
   const [codeExpiresAt, setCodeExpiresAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
   const [verified, setVerified] = useState(false);
   const remainingSeconds = useMemo(() => {
     if (!codeExpiresAt) return 0;
@@ -260,6 +293,77 @@ export function SignupScreen() {
 
     return () => clearInterval(timer);
   }, [codeExpiresAt, verified]);
+
+  const handleSendCode = async () => {
+    if (!email.trim()) {
+      setError('이메일을 입력해 주세요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await sendEmailAuthCode(email.trim());
+      setCodeExpiresAt(Date.now() + 5 * 60 * 1000);
+    } catch (sendError) {
+      setError(getApiErrorMessage(sendError, '인증 코드를 보내지 못했어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    if (!email.trim() || !code.trim()) {
+      setError('이메일과 인증 코드를 입력해 주세요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await verifyEmailAuthCode(email.trim(), code.trim());
+      setVerified(true);
+    } catch (verifyError) {
+      setError(getApiErrorMessage(verifyError, '인증 코드가 올바르지 않거나 만료되었어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSignup = async () => {
+    if (!verified) {
+      setError('이메일 인증을 먼저 완료해 주세요.');
+      return;
+    }
+
+    if (!form.username.trim() || !form.password) {
+      setError('닉네임과 비밀번호를 입력해 주세요.');
+      return;
+    }
+
+    if (form.password !== form.confirmPassword) {
+      setError('비밀번호 확인이 일치하지 않아요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await signupWithEmail({
+        email: email.trim(),
+        password: form.password,
+        username: form.username.trim(),
+      });
+      push('/login');
+    } catch (signupError) {
+      setError(getApiErrorMessage(signupError, '회원가입에 실패했어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <AuthShell
@@ -315,13 +419,13 @@ export function SignupScreen() {
             <View style={styles.heroActions}>
               <ActionButton
                 label={codeExpiresAt ? '코드 다시 보내기' : '코드 보내기'}
-                onPress={() => setCodeExpiresAt(Date.now() + 5 * 60 * 1000)}
+                onPress={() => void handleSendCode()}
                 style={{ flex: 1 }}
                 variant="secondary"
               />
               <ActionButton
-                label="인증 확인"
-                onPress={() => setVerified(code.trim().length >= 4)}
+                label={submitting ? '확인 중...' : '인증 확인'}
+                onPress={() => void handleVerifyCode()}
                 style={{ flex: 1 }}
               />
             </View>
@@ -339,7 +443,8 @@ export function SignupScreen() {
           />
         ))}
 
-        <ActionButton label="회원가입" onPress={() => push('/login')} />
+        <ActionButton label={submitting ? '처리 중...' : '회원가입'} onPress={() => void handleSignup()} />
+        {error ? <Text style={styles.formError}>{error}</Text> : null}
       </SurfaceCard>
     </AuthShell>
   );
@@ -352,8 +457,74 @@ export function ForgotPasswordScreen() {
   const [step, setStep] = useState<'RESET_PASSWORD' | 'VERIFY_CODE'>('VERIFY_CODE');
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [resetToken, setResetToken] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleRequestCode = async () => {
+    if (!email.trim()) {
+      setError('이메일을 입력해 주세요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await requestPasswordResetCode(email.trim());
+    } catch (requestError) {
+      setError(getApiErrorMessage(requestError, '인증 코드를 보내지 못했어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    if (!email.trim() || !code.trim()) {
+      setError('이메일과 인증 코드를 입력해 주세요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const token = await verifyPasswordResetCode(email.trim(), code.trim());
+      setResetToken(token);
+      setStep('RESET_PASSWORD');
+    } catch (verifyError) {
+      setError(getApiErrorMessage(verifyError, '인증 코드가 올바르지 않거나 만료되었어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (!resetToken) {
+      setError('비밀번호 재설정 인증을 먼저 완료해 주세요.');
+      setStep('VERIFY_CODE');
+      return;
+    }
+
+    if (!newPassword.trim() || newPassword !== confirmPassword) {
+      setError('새 비밀번호와 확인 값이 일치하지 않아요.');
+      return;
+    }
+
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      await resetPassword(resetToken, newPassword);
+      push('/login');
+    } catch (resetError) {
+      setError(getApiErrorMessage(resetError, '비밀번호를 변경하지 못했어요.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <AuthShell
@@ -364,17 +535,19 @@ export function ForgotPasswordScreen() {
           <FormField label="이메일" onChangeText={setEmail} placeholder="example@harucut.com" value={email} />
           <FormField label="인증 코드" onChangeText={setCode} placeholder="인증 코드 입력" value={code} />
           <View style={styles.heroActions}>
-            <ActionButton label="코드 다시 보내기" onPress={() => undefined} style={{ flex: 1 }} variant="secondary" />
             <ActionButton
-              label="인증 확인"
-              onPress={() => {
-                if (code.trim().length >= 4) {
-                  setStep('RESET_PASSWORD');
-                }
-              }}
+              label={submitting ? '전송 중...' : '코드 다시 보내기'}
+              onPress={() => void handleRequestCode()}
+              style={{ flex: 1 }}
+              variant="secondary"
+            />
+            <ActionButton
+              label={submitting ? '확인 중...' : '인증 확인'}
+              onPress={() => void handleVerifyCode()}
               style={{ flex: 1 }}
             />
           </View>
+          {error ? <Text style={styles.formError}>{error}</Text> : null}
           <Text onPress={() => push('/login')} style={styles.authBackLink}>
             로그인으로 돌아가기
           </Text>
@@ -396,13 +569,10 @@ export function ForgotPasswordScreen() {
             value={confirmPassword}
           />
           <ActionButton
-            label="비밀번호 변경"
-            onPress={() => {
-              if (newPassword.trim() && newPassword === confirmPassword) {
-                push('/login');
-              }
-            }}
+            label={submitting ? '변경 중...' : '비밀번호 변경'}
+            onPress={() => void handleResetPassword()}
           />
+          {error ? <Text style={styles.formError}>{error}</Text> : null}
         </SurfaceCard>
       )}
     </AuthShell>
@@ -455,9 +625,10 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       fontSize: 10,
       fontWeight: '700',
     },
-    headerActions: {
-      flexDirection: 'row',
-      gap: 10,
+    formError: {
+      color: colors.danger,
+      fontSize: 11,
+      lineHeight: 17,
     },
     heroActions: {
       flexDirection: 'row',
@@ -483,30 +654,53 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       height: '100%',
       width: '100%',
     },
+    heroCardCopy: {
+      gap: 6,
+    },
     heroImageFrame: {
+      alignSelf: 'center',
       aspectRatio: 0.75,
       backgroundColor: colors.backgroundTint,
       borderColor: colors.border,
       borderRadius: 24,
       borderWidth: 1,
       overflow: 'hidden',
+      width: '86%',
     },
     heroTitle: {
       color: colors.text,
       fontSize: 34,
       fontWeight: '700',
-      letterSpacing: -1.2,
+      letterSpacing: 0,
+      lineHeight: 40.8,
     },
     heroTitleGradient: {
       color: colors.primaryStrong,
       fontSize: 34,
       fontWeight: '700',
-      letterSpacing: -1.2,
+      letterSpacing: 0,
+      lineHeight: 40.8,
+    },
+    heroTitleStack: {
+      gap: 0,
+    },
+    heroCopy: {
+      gap: 12,
     },
     landingHeader: {
       alignItems: 'center',
       flexDirection: 'row',
       justifyContent: 'space-between',
+    },
+    landingMain: {
+      gap: 22,
+    },
+    landingScrollContent: {
+      flexGrow: 1,
+      gap: 28,
+    },
+    heroPreviewCard: {
+      gap: 14,
     },
     rememberRow: {
       alignItems: 'center',

--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -11,6 +11,7 @@ import { ActionButton, AppScrollView, FormField, PageHeader, Pill, StepProgress,
 import { FRAME_BORDER_OPTIONS, OUTPUT_TONE_OPTIONS, type MediaAsset } from '@/constants/harucut-data';
 import type { HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { getApiErrorMessage } from '@/lib/api-client';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 function delay(ms: number) {
@@ -54,9 +55,16 @@ export function ShootFrameScreen() {
   const accessMode = useHarucutStore((state) => state.accessMode);
   const enterAnonymousMode = useHarucutStore((state) => state.enterAnonymousMode);
   const savedFrames = useHarucutStore((state) => state.savedFrames);
+  const loadRemoteFrames = useHarucutStore((state) => state.loadRemoteFrames);
   const shoot = useHarucutStore((state) => state.shoot);
   const setShootFrame = useHarucutStore((state) => state.setShootFrame);
   const selectSavedFrameForShoot = useHarucutStore((state) => state.selectSavedFrameForShoot);
+
+  useEffect(() => {
+    if (accessMode === 'member') {
+      void loadRemoteFrames();
+    }
+  }, [accessMode, loadRemoteFrames]);
 
   return (
     <AppScrollView>
@@ -89,7 +97,7 @@ export function ShootFrameScreen() {
         <SavedFramesPanel
           emptyText="저장된 프레임이 없습니다."
           frames={savedFrames}
-          onRefresh={() => undefined}
+          onRefresh={() => void loadRemoteFrames()}
           onSelect={selectSavedFrameForShoot}
           selectedFrameId={shoot.frameId}
           selectedSavedFrameId={shoot.selectedSavedFrameId}
@@ -381,6 +389,7 @@ export function ShootResultScreen() {
   const showGuestShareNotice = useHarucutStore((state) => state.showGuestShareNotice);
   const showNotice = useHarucutStore((state) => state.showNotice);
   const [draftName, setDraftName] = useState('');
+  const [saveStatus, setSaveStatus] = useState<'error' | 'idle' | 'saving' | 'saved'>('idle');
   const previewRef = useRef<View | null>(null);
   const isGuest = accessMode === 'guest';
 
@@ -395,10 +404,47 @@ export function ShootResultScreen() {
       return;
     }
 
-    if (!isGuest) {
-      persistShootResult();
+    if (isGuest || shoot.persistedHistoryId || saveStatus !== 'idle') {
+      return;
     }
-  }, [isGuest, persistShootResult, router, shoot.frameId, shoot.selectedShotIds.length]);
+
+    const saveResult = async () => {
+      setSaveStatus('saving');
+
+      try {
+        if (!previewRef.current) {
+          throw new Error('저장할 결과 화면을 찾지 못했어요.');
+        }
+
+        const uri = await captureRef(previewRef.current, {
+          format: 'jpg',
+          quality: 0.96,
+        });
+        await persistShootResult(uri);
+        setSaveStatus('saved');
+      } catch (error) {
+        setSaveStatus('error');
+        showNotice({
+          actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+          eyebrow: 'SAVE ERROR',
+          icon: 'warning-outline',
+          message: getApiErrorMessage(error, '촬영 결과를 서버에 저장하지 못했어요.'),
+          title: '결과 저장 실패',
+        });
+      }
+    };
+
+    void saveResult();
+  }, [
+    isGuest,
+    persistShootResult,
+    router,
+    saveStatus,
+    shoot.frameId,
+    shoot.persistedHistoryId,
+    shoot.selectedShotIds.length,
+    showNotice,
+  ]);
 
   const currentHistory = historyItems.find((item) => item.id === shoot.persistedHistoryId) ?? null;
   const previewMedia =
@@ -468,6 +514,12 @@ export function ShootResultScreen() {
         ) : null}
       </SurfaceCard>
 
+      {saveStatus === 'saving' ? (
+        <SurfaceCard>
+          <Text style={styles.bodyText}>결과를 서버에 저장하는 중이에요.</Text>
+        </SurfaceCard>
+      ) : null}
+
       {!isGuest && currentHistory ? (
         <SurfaceCard style={{ gap: 12 }}>
           <Text style={styles.sectionTitle}>이미지 다운로드</Text>
@@ -475,7 +527,17 @@ export function ShootResultScreen() {
           <FormField label="파일 이름" onChangeText={setDraftName} value={draftName} />
           <ActionButton
             label="이름 저장"
-            onPress={() => renameHistoryItem(currentHistory.id, draftName.trim() || currentHistory.title)}
+            onPress={() =>
+              void renameHistoryItem(currentHistory.id, draftName.trim() || currentHistory.title).catch((error) =>
+                showNotice({
+                  actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+                  eyebrow: 'SAVE ERROR',
+                  icon: 'warning-outline',
+                  message: getApiErrorMessage(error, '파일 이름을 저장하지 못했어요.'),
+                  title: '이름 변경 실패',
+                }),
+              )
+            }
             variant="secondary"
           />
           <View style={styles.rowButtons}>

--- a/apps/mobile/screens/theme-screens.tsx
+++ b/apps/mobile/screens/theme-screens.tsx
@@ -1,13 +1,15 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useRouter } from 'expo-router';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { captureRef } from 'react-native-view-shot';
 
 import { FramePickerSection, FramePreview, SavedFramesPanel } from '@/components/harucut/frame';
 import { ActionButton, AppScrollView, FormField, PageHeader, Pill, StepProgress, SurfaceCard } from '@/components/harucut/ui';
 import { BACKGROUND_SWATCHES, THEME_STICKERS } from '@/constants/harucut-data';
 import type { HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { getApiErrorMessage } from '@/lib/api-client';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 function useThemeScreenStyles() {
@@ -19,10 +21,18 @@ function useThemeScreenStyles() {
 export function ThemeFrameScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
+  const accessMode = useHarucutStore((state) => state.accessMode);
   const savedFrames = useHarucutStore((state) => state.savedFrames);
   const themeEditor = useHarucutStore((state) => state.themeEditor);
+  const loadRemoteFrames = useHarucutStore((state) => state.loadRemoteFrames);
   const setThemeFrame = useHarucutStore((state) => state.setThemeFrame);
   const selectSavedFrameForTheme = useHarucutStore((state) => state.selectSavedFrameForTheme);
+
+  useEffect(() => {
+    if (accessMode === 'member') {
+      void loadRemoteFrames();
+    }
+  }, [accessMode, loadRemoteFrames]);
 
   return (
     <AppScrollView>
@@ -40,7 +50,7 @@ export function ThemeFrameScreen() {
         emptyText="이 프레임 타입으로 저장한 프레임이 아직 없어요."
         frames={savedFrames}
         onAction={() => push('/theme/sticker')}
-        onRefresh={() => undefined}
+        onRefresh={() => void loadRemoteFrames()}
         onSelect={selectSavedFrameForTheme}
         selectedFrameId={themeEditor.frameId}
         selectedSavedFrameId={themeEditor.selectedSavedFrameId}
@@ -63,12 +73,63 @@ export function ThemeStickerScreen() {
   const toggleThemeSticker = useHarucutStore((state) => state.toggleThemeSticker);
   const saveThemeFrame = useHarucutStore((state) => state.saveThemeFrame);
   const removeSavedFrame = useHarucutStore((state) => state.removeSavedFrame);
+  const showNotice = useHarucutStore((state) => state.showNotice);
+  const [saving, setSaving] = useState(false);
+  const previewRef = useRef<View | null>(null);
 
   useEffect(() => {
     if (!themeEditor.frameId) {
       router.replace('/theme' as never);
     }
   }, [router, themeEditor.frameId]);
+
+  const showError = (title: string, error: unknown, fallback: string) => {
+    showNotice({
+      actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+      eyebrow: 'FRAME ERROR',
+      icon: 'warning-outline',
+      message: getApiErrorMessage(error, fallback),
+      title,
+    });
+  };
+
+  const handleSaveFrame = async () => {
+    setSaving(true);
+
+    try {
+      if (!previewRef.current) {
+        throw new Error('저장할 프레임 미리보기를 찾지 못했어요.');
+      }
+
+      const uri = await captureRef(previewRef.current, {
+        format: 'jpg',
+        quality: 0.96,
+      });
+      await saveThemeFrame(uri);
+      push('/theme');
+    } catch (error) {
+      showError('프레임 저장 실패', error, '프레임을 서버에 저장하지 못했어요.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemoveFrame = async () => {
+    if (!themeEditor.selectedSavedFrameId) {
+      return;
+    }
+
+    setSaving(true);
+
+    try {
+      await removeSavedFrame(themeEditor.selectedSavedFrameId);
+      push('/theme');
+    } catch (error) {
+      showError('프레임 삭제 실패', error, '프레임을 삭제하지 못했어요.');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <AppScrollView>
@@ -95,12 +156,14 @@ export function ThemeStickerScreen() {
 
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.sectionTitle}>미리보기</Text>
-        <FramePreview
-          accentColor={themeEditor.accentColor}
-          backgroundColor={themeEditor.backgroundColor}
-          caption={themeEditor.caption}
-          frameId={themeEditor.frameId}
-        />
+        <View collapsable={false} ref={previewRef}>
+          <FramePreview
+            accentColor={themeEditor.accentColor}
+            backgroundColor={themeEditor.backgroundColor}
+            caption={themeEditor.caption}
+            frameId={themeEditor.frameId}
+          />
+        </View>
         <View style={styles.stickerRow}>
           {themeEditor.stickers.map((sticker) => (
             <Pill key={sticker}>{sticker}</Pill>
@@ -166,20 +229,14 @@ export function ThemeStickerScreen() {
         </Text>
         <ActionButton
           icon={<Ionicons color="#FFFFFF" name="save-outline" size={16} />}
-          label={themeEditor.selectedSavedFrameId ? '수정 저장' : '저장'}
-          onPress={() => {
-            saveThemeFrame();
-            push('/theme');
-          }}
+          label={saving ? '저장 중...' : themeEditor.selectedSavedFrameId ? '수정 저장' : '저장'}
+          onPress={() => void handleSaveFrame()}
         />
         {themeEditor.selectedSavedFrameId ? (
           <ActionButton
             icon={<Ionicons color="#FFFFFF" name="trash-outline" size={16} />}
             label="삭제"
-            onPress={() => {
-              removeSavedFrame(themeEditor.selectedSavedFrameId as string);
-              push('/theme');
-            }}
+            onPress={() => void handleRemoveFrame()}
             variant="danger"
           />
         ) : null}

--- a/apps/mobile/screens/upload-screens.tsx
+++ b/apps/mobile/screens/upload-screens.tsx
@@ -1,14 +1,16 @@
 import * as ImagePicker from 'expo-image-picker';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useRouter } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Image, Pressable, Share, StyleSheet, Text, View } from 'react-native';
+import { captureRef } from 'react-native-view-shot';
 
 import { FramePickerSection, FramePreview, SavedFramesPanel } from '@/components/harucut/frame';
 import { ActionButton, AppScrollView, FormField, PageHeader, Pill, StepProgress, SurfaceCard } from '@/components/harucut/ui';
 import { FRAME_BORDER_OPTIONS, OUTPUT_TONE_OPTIONS, type MediaAsset } from '@/constants/harucut-data';
 import type { HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { getApiErrorMessage } from '@/lib/api-client';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 async function shareMedia(title: string, uri: string | undefined) {
@@ -25,10 +27,18 @@ function useUploadStyles() {
 export function UploadFrameScreen() {
   const router = useRouter();
   const push = (path: string) => router.push(path as never);
+  const accessMode = useHarucutStore((state) => state.accessMode);
   const savedFrames = useHarucutStore((state) => state.savedFrames);
+  const loadRemoteFrames = useHarucutStore((state) => state.loadRemoteFrames);
   const upload = useHarucutStore((state) => state.upload);
   const setUploadFrame = useHarucutStore((state) => state.setUploadFrame);
   const selectSavedFrameForUpload = useHarucutStore((state) => state.selectSavedFrameForUpload);
+
+  useEffect(() => {
+    if (accessMode === 'member') {
+      void loadRemoteFrames();
+    }
+  }, [accessMode, loadRemoteFrames]);
 
   return (
     <AppScrollView>
@@ -49,7 +59,7 @@ export function UploadFrameScreen() {
         description="같은 타입으로 저장한 프레임을 불러와 바로 이어서 만들 수 있어요."
         emptyText="저장된 프레임이 없습니다."
         frames={savedFrames}
-        onRefresh={() => undefined}
+        onRefresh={() => void loadRemoteFrames()}
         onSelect={selectSavedFrameForUpload}
         selectedFrameId={upload.frameId}
         selectedSavedFrameId={upload.selectedSavedFrameId}
@@ -204,7 +214,10 @@ export function UploadResultScreen() {
   const persistUploadResult = useHarucutStore((state) => state.persistUploadResult);
   const historyItems = useHarucutStore((state) => state.historyItems);
   const renameHistoryItem = useHarucutStore((state) => state.renameHistoryItem);
+  const showNotice = useHarucutStore((state) => state.showNotice);
   const [draftName, setDraftName] = useState('');
+  const [saveStatus, setSaveStatus] = useState<'error' | 'idle' | 'saving' | 'saved'>('idle');
+  const previewRef = useRef<View | null>(null);
 
   useEffect(() => {
     if (!upload.frameId) {
@@ -217,8 +230,46 @@ export function UploadResultScreen() {
       return;
     }
 
-    persistUploadResult();
-  }, [persistUploadResult, router, upload.frameId, upload.selectedAssetIds.length]);
+    if (upload.persistedHistoryId || saveStatus !== 'idle') {
+      return;
+    }
+
+    const saveResult = async () => {
+      setSaveStatus('saving');
+
+      try {
+        if (!previewRef.current) {
+          throw new Error('저장할 결과 화면을 찾지 못했어요.');
+        }
+
+        const uri = await captureRef(previewRef.current, {
+          format: 'jpg',
+          quality: 0.96,
+        });
+        await persistUploadResult(uri);
+        setSaveStatus('saved');
+      } catch (error) {
+        setSaveStatus('error');
+        showNotice({
+          actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+          eyebrow: 'SAVE ERROR',
+          icon: 'warning-outline',
+          message: getApiErrorMessage(error, '업로드 결과를 서버에 저장하지 못했어요.'),
+          title: '결과 저장 실패',
+        });
+      }
+    };
+
+    void saveResult();
+  }, [
+    persistUploadResult,
+    router,
+    saveStatus,
+    showNotice,
+    upload.frameId,
+    upload.persistedHistoryId,
+    upload.selectedAssetIds.length,
+  ]);
 
   const currentHistory = historyItems.find((item) => item.id === upload.persistedHistoryId) ?? null;
   const previewMedia =
@@ -244,11 +295,19 @@ export function UploadResultScreen() {
       </SurfaceCard>
 
       <SurfaceCard style={{ gap: 14 }}>
-        <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
+        <View collapsable={false} ref={previewRef}>
+          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
+        </View>
         {upload.includeVideo ? (
           <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
         ) : null}
       </SurfaceCard>
+
+      {saveStatus === 'saving' ? (
+        <SurfaceCard>
+          <Text style={styles.bodyText}>결과를 서버에 저장하는 중이에요.</Text>
+        </SurfaceCard>
+      ) : null}
 
       {currentHistory ? (
         <SurfaceCard style={{ gap: 12 }}>
@@ -257,7 +316,17 @@ export function UploadResultScreen() {
           <FormField label="파일 이름" onChangeText={setDraftName} value={draftName} />
           <ActionButton
             label="이름 저장"
-            onPress={() => renameHistoryItem(currentHistory.id, draftName.trim() || currentHistory.title)}
+            onPress={() =>
+              void renameHistoryItem(currentHistory.id, draftName.trim() || currentHistory.title).catch((error) =>
+                showNotice({
+                  actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+                  eyebrow: 'SAVE ERROR',
+                  icon: 'warning-outline',
+                  message: getApiErrorMessage(error, '파일 이름을 저장하지 못했어요.'),
+                  title: '이름 변경 실패',
+                }),
+              )
+            }
             variant="secondary"
           />
           <View style={styles.rowButtons}>

--- a/apps/mobile/store/use-harucut-store.ts
+++ b/apps/mobile/store/use-harucut-store.ts
@@ -2,8 +2,6 @@ import { create } from 'zustand';
 
 import {
   FRAME_BORDER_OPTIONS,
-  FRAME_CATALOG,
-  INITIAL_HISTORY_ITEMS,
   INITIAL_SAVED_FRAMES,
   INITIAL_USER,
   type FrameId,
@@ -14,8 +12,15 @@ import {
   type UserProfile,
 } from '@/constants/harucut-data';
 import type { ButtonVariant, HarucutThemePreference } from '@/constants/harucut-design';
+import { getApiErrorMessage } from '@/lib/api-client';
+import { deleteRemoteFrame, listRemoteFrames, createRemoteFrame, updateRemoteFrame } from '@/lib/frame-api';
+import { uploadLocalFileWithPresigned } from '@/lib/file-storage-api';
+import { getMyUserProfile } from '@/lib/user-api';
+import { listRemoteHistoryItems, updateMediaDisplayName, uploadFourcutResult } from '@/lib/user-media-api';
 
 type AccessMode = 'anonymous' | 'guest' | 'member';
+type RemoteHistoryStatus = 'idle' | 'loading' | 'ready' | 'error';
+type RemoteFrameStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 type NoticeActionId =
   | 'dismiss'
@@ -73,7 +78,11 @@ type ThemeEditorState = {
 
 type HarucutStore = {
   accessMode: AccessMode;
+  frameError: string | null;
+  frameStatus: RemoteFrameStatus;
+  historyError: string | null;
   historyItems: HistoryItem[];
+  historyStatus: RemoteHistoryStatus;
   notice: NoticeState | null;
   shoot: ShootSession;
   themeEditor: ThemeEditorState;
@@ -86,15 +95,19 @@ type HarucutStore = {
   enterGuestMode: () => void;
   enterMemberMode: () => void;
   addUploadAssets: (assets: MediaAsset[]) => void;
-  persistShootResult: () => string | null;
-  persistUploadResult: () => string | null;
-  removeSavedFrame: (id: string) => void;
-  renameHistoryItem: (id: string, title: string) => void;
+  bootstrapMemberSession: () => Promise<void>;
+  loadRemoteFrames: () => Promise<void>;
+  loadRemoteHistory: () => Promise<void>;
+  persistShootResult: (previewUri?: string | null) => Promise<string | null>;
+  persistUploadResult: (previewUri?: string | null) => Promise<string | null>;
+  refreshUserProfile: () => Promise<void>;
+  removeSavedFrame: (id: string) => Promise<void>;
+  renameHistoryItem: (id: string, title: string) => Promise<void>;
   resetShootSession: () => void;
   resetThemeEditor: () => void;
   resetUploadSession: () => void;
   savedFrames: SavedFrame[];
-  saveThemeFrame: () => string;
+  saveThemeFrame: (previewUri?: string | null) => Promise<string | null>;
   selectSavedFrameForShoot: (frame: SavedFrame) => void;
   selectSavedFrameForTheme: (frame: SavedFrame) => void;
   selectSavedFrameForUpload: (frame: SavedFrame) => void;
@@ -153,6 +166,12 @@ function selectedMedia(items: MediaAsset[], selectedIds: string[]) {
 }
 
 const defaultBorderColor = FRAME_BORDER_OPTIONS[0].value;
+const frameNames: Record<FrameId, string> = {
+  'classic-4': '클래식 4컷',
+  'grid-4': '2x2 그리드',
+  'polaroid-4': '폴라로이드 4컷',
+  'wide-4': '와이드 4컷',
+};
 
 function defaultShootSession(): ShootSession {
   return {
@@ -194,7 +213,12 @@ function defaultThemeEditor(): ThemeEditorState {
 }
 
 function frameName(frameId: FrameId) {
-  return FRAME_CATALOG.find((item) => item.frameId === frameId)?.name ?? '하루컷 프레임';
+  return frameNames[frameId] ?? '하루컷 프레임';
+}
+
+function remoteFrameIdFromSavedId(id: string) {
+  const value = Number(id.replace('remote-frame-', ''));
+  return Number.isFinite(value) ? value : null;
 }
 
 function upsertHistoryItem(
@@ -211,7 +235,11 @@ function upsertHistoryItem(
 
 export const useHarucutStore = create<HarucutStore>((set, get) => ({
   accessMode: 'anonymous',
-  historyItems: INITIAL_HISTORY_ITEMS,
+  frameError: null,
+  frameStatus: 'idle',
+  historyError: null,
+  historyItems: [],
+  historyStatus: 'idle',
   notice: null,
   shoot: defaultShootSession(),
   themeEditor: defaultThemeEditor(),
@@ -238,15 +266,28 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
   enterAnonymousMode: () =>
     set({
       accessMode: 'anonymous',
+      frameError: null,
+      frameStatus: 'idle',
+      historyError: null,
+      historyItems: [],
+      historyStatus: 'idle',
       notice: null,
+      savedFrames: INITIAL_SAVED_FRAMES,
       shoot: defaultShootSession(),
       themeEditor: defaultThemeEditor(),
       upload: defaultUploadSession(),
+      user: INITIAL_USER,
     }),
   enterGuestMode: () =>
     set({
       accessMode: 'guest',
+      frameError: null,
+      frameStatus: 'idle',
+      historyError: null,
+      historyItems: [],
+      historyStatus: 'idle',
       notice: null,
+      savedFrames: INITIAL_SAVED_FRAMES,
       shoot: defaultShootSession(),
       themeEditor: defaultThemeEditor(),
       upload: defaultUploadSession(),
@@ -254,6 +295,11 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
   enterMemberMode: () =>
     set({
       accessMode: 'member',
+      frameError: null,
+      frameStatus: 'idle',
+      historyError: null,
+      historyItems: [],
+      historyStatus: 'idle',
       notice: null,
     }),
   addUploadAssets: (assets) =>
@@ -276,7 +322,57 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
         },
       };
     }),
-  persistShootResult: () => {
+  bootstrapMemberSession: async () => {
+    set({ accessMode: 'member', notice: null });
+    await Promise.all([
+      get().refreshUserProfile(),
+      get().loadRemoteHistory(),
+      get().loadRemoteFrames(),
+    ]);
+  },
+  refreshUserProfile: async () => {
+    const user = await getMyUserProfile();
+    set({ user });
+  },
+  loadRemoteFrames: async () => {
+    set({ frameError: null, frameStatus: 'loading' });
+
+    try {
+      const savedFrames = await listRemoteFrames();
+
+      set({
+        frameError: null,
+        frameStatus: 'ready',
+        savedFrames,
+      });
+    } catch (error) {
+      set({
+        frameError: getApiErrorMessage(error, '저장한 프레임을 불러오지 못했어요.'),
+        frameStatus: 'error',
+        savedFrames: [],
+      });
+    }
+  },
+  loadRemoteHistory: async () => {
+    set({ historyError: null, historyStatus: 'loading' });
+
+    try {
+      const historyItems = await listRemoteHistoryItems();
+
+      set({
+        historyError: null,
+        historyItems,
+        historyStatus: 'ready',
+      });
+    } catch (error) {
+      set({
+        historyError: getApiErrorMessage(error, '저장한 결과를 불러오지 못했어요.'),
+        historyItems: [],
+        historyStatus: 'error',
+      });
+    }
+  },
+  persistShootResult: async (previewUri) => {
     const state = get();
     const previewMedia = selectedMedia(state.shoot.shots, state.shoot.selectedShotIds);
 
@@ -288,28 +384,34 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
       return null;
     }
 
-    const id = state.shoot.persistedHistoryId ?? createId('shoot-result');
-    const nextItem: HistoryItem = {
-      createdAt: new Date().toISOString(),
+    if (state.shoot.persistedHistoryId) {
+      return state.shoot.persistedHistoryId;
+    }
+
+    if (!previewUri) {
+      throw new Error('저장할 결과 이미지를 만들지 못했어요.');
+    }
+
+    const nextItem = await uploadFourcutResult({
+      displayName: `${frameName(state.shoot.frameId)} 촬영 결과`,
       frameId: state.shoot.frameId,
-      id,
-      kind: state.shoot.includeVideo ? 'video' : 'photo',
-      previewMedia,
       source: 'shoot',
-      title: `${frameName(state.shoot.frameId)} 촬영 결과`,
-    };
+      uri: previewUri,
+    });
 
     set((current) => ({
+      historyError: null,
       historyItems: upsertHistoryItem(current.historyItems, nextItem, current.shoot.persistedHistoryId),
+      historyStatus: 'ready',
       shoot: {
         ...current.shoot,
-        persistedHistoryId: id,
+        persistedHistoryId: nextItem.id,
       },
     }));
 
-    return id;
+    return nextItem.id;
   },
-  persistUploadResult: () => {
+  persistUploadResult: async (previewUri) => {
     const state = get();
     const previewMedia = selectedMedia(state.upload.assets, state.upload.selectedAssetIds);
 
@@ -321,39 +423,75 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
       return null;
     }
 
-    const id = state.upload.persistedHistoryId ?? createId('upload-result');
-    const nextItem: HistoryItem = {
-      createdAt: new Date().toISOString(),
+    if (state.upload.persistedHistoryId) {
+      return state.upload.persistedHistoryId;
+    }
+
+    if (!previewUri) {
+      throw new Error('저장할 결과 이미지를 만들지 못했어요.');
+    }
+
+    const nextItem = await uploadFourcutResult({
+      displayName: `${frameName(state.upload.frameId)} 업로드 결과`,
       frameId: state.upload.frameId,
-      id,
-      kind: state.upload.includeVideo ? 'video' : 'photo',
-      previewMedia,
       source: 'upload',
-      title: `${frameName(state.upload.frameId)} 업로드 결과`,
-    };
+      uri: previewUri,
+    });
 
     set((current) => ({
+      historyError: null,
       historyItems: upsertHistoryItem(current.historyItems, nextItem, current.upload.persistedHistoryId),
+      historyStatus: 'ready',
       upload: {
         ...current.upload,
-        persistedHistoryId: id,
+        persistedHistoryId: nextItem.id,
       },
     }));
 
-    return id;
+    return nextItem.id;
   },
-  removeSavedFrame: (id) =>
+  removeSavedFrame: async (id) => {
+    const frame = get().savedFrames.find((item) => item.id === id);
+    const remoteFrameId = frame?.remoteFrameId ?? remoteFrameIdFromSavedId(id);
+
+    if (remoteFrameId) {
+      await deleteRemoteFrame(remoteFrameId);
+    }
+
     set((state) => ({
-      savedFrames: state.savedFrames.filter((frame) => frame.id !== id),
+      savedFrames: state.savedFrames.filter((item) => item.id !== id),
       themeEditor:
         state.themeEditor.selectedSavedFrameId === id
           ? { ...defaultThemeEditor(), frameId: state.themeEditor.frameId }
           : state.themeEditor,
-    })),
-  renameHistoryItem: (id, title) =>
+    }));
+  },
+  renameHistoryItem: async (id, title) => {
+    const nextTitle = title.trim();
+    const item = get().historyItems.find((historyItem) => historyItem.id === id);
+
+    if (!nextTitle) {
+      return;
+    }
+
+    if (item?.mediaId) {
+      const updated = await updateMediaDisplayName(item.mediaId, nextTitle);
+      const updatedTitle = updated.displayName?.trim() || updated.displayname?.trim() || nextTitle;
+
+      set((state) => ({
+        historyItems: state.historyItems.map((historyItem) =>
+          historyItem.id === id ? { ...historyItem, title: updatedTitle } : historyItem,
+        ),
+      }));
+      return;
+    }
+
     set((state) => ({
-      historyItems: state.historyItems.map((item) => (item.id === id ? { ...item, title } : item)),
-    })),
+      historyItems: state.historyItems.map((historyItem) =>
+        historyItem.id === id ? { ...historyItem, title: nextTitle } : historyItem,
+      ),
+    }));
+  },
   resetShootSession: () =>
     set((state) => ({
       shoot: { ...defaultShootSession(), frameId: state.shoot.frameId },
@@ -367,35 +505,62 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
       upload: { ...defaultUploadSession(), frameId: state.upload.frameId },
     })),
   savedFrames: INITIAL_SAVED_FRAMES,
-  saveThemeFrame: () => {
+  saveThemeFrame: async (previewUri) => {
     const state = get();
     const current = state.themeEditor;
-    const id = current.selectedSavedFrameId ?? createId('saved-frame');
-    const nextFrame: SavedFrame = {
+    const title = current.title.trim() || '새 테마 프레임';
+
+    if (!previewUri) {
+      throw new Error('프레임 미리보기를 만들지 못했어요.');
+    }
+
+    const uploaded = await uploadLocalFileWithPresigned({
+      contentType: 'JPEG',
+      filename: `${title}.jpg`,
+      isTemp: false,
+      type: 'FRAME',
+      uri: previewUri,
+    });
+
+    const selectedFrame = current.selectedSavedFrameId
+      ? state.savedFrames.find((frame) => frame.id === current.selectedSavedFrameId)
+      : null;
+    const remoteFrameId =
+      selectedFrame?.remoteFrameId ??
+      (current.selectedSavedFrameId ? remoteFrameIdFromSavedId(current.selectedSavedFrameId) : null);
+    const draft = {
       accentColor: current.accentColor,
       backgroundColor: current.backgroundColor,
       caption: current.caption,
       description: current.description,
       frameId: current.frameId,
-      id,
+      previewKey: uploaded.key,
       stickers: current.stickers,
-      title: current.title.trim() || '새 테마 프레임',
-      updatedAt: new Date().toISOString(),
+      title,
     };
 
-    set((store) => {
-      const nextFrames = store.savedFrames.some((frame) => frame.id === id)
-        ? store.savedFrames.map((frame) => (frame.id === id ? nextFrame : frame))
-        : [nextFrame, ...store.savedFrames];
+    if (remoteFrameId) {
+      await updateRemoteFrame(remoteFrameId, draft);
+    } else {
+      await createRemoteFrame(draft);
+    }
 
-      return {
-        savedFrames: nextFrames,
+    await get().loadRemoteFrames();
+
+    const nextFrame = get().savedFrames.find((frame) => {
+      if (remoteFrameId) return frame.remoteFrameId === remoteFrameId;
+      return frame.title === title && frame.previewKey === uploaded.key;
+    });
+    const id = nextFrame?.id ?? current.selectedSavedFrameId ?? null;
+
+    if (id) {
+      set((store) => ({
         themeEditor: {
           ...store.themeEditor,
           selectedSavedFrameId: id,
         },
-      };
-    });
+      }));
+    }
 
     return id;
   },


### PR DESCRIPTION
## 요약

- 모바일 앱 인증/사용자/미디어/파일/프레임 API 클라이언트 추가
- 로그인, 회원가입, 이메일 인증, 비밀번호 재설정, 마이페이지 수정 흐름을 실제 API로 연결
- 촬영/업로드 결과 저장과 기록 이름 수정, 저장 프레임 조회/생성/수정/삭제를 서버 연동으로 전환
- 샘플 기록/샘플 저장 프레임 제거

## 검증

- `pnpm typecheck:mobile`
- `pnpm lint:mobile`
- `pnpm --dir apps/mobile exec expo export --platform web`
- 운영 API 계정으로 로그인/보호 API/presigned upload/임시 프레임 생성·삭제 확인

Closes #204