### PR TITLE
fix: 웹·모바일 화면 여백과 프레임 미리보기 보정

### DIFF
--- a/apps/mobile/components/harucut/frame.tsx
+++ b/apps/mobile/components/harucut/frame.tsx
@@ -417,6 +417,11 @@ export function SavedFramesPanel({
 }
 
 function createStyles(colors: HarucutColors, isDark: boolean) {
+  const framePreviewBackground = isDark ? colors.backgroundTint : '#FFFFFF';
+  const framePreviewBorder = isDark ? colors.border : 'rgba(148, 163, 184, 0.22)';
+  const emptySlotBackground = isDark ? colors.cardMuted : '#F8FAFC';
+  const emptySlotBorder = isDark ? 'rgba(147, 197, 253, 0.14)' : 'rgba(148, 163, 184, 0.18)';
+
   return StyleSheet.create({
     caption: {
       bottom: '8%',
@@ -489,12 +494,17 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     },
     framePreviewWrap: {
       alignItems: 'center',
-      backgroundColor: colors.backgroundTint,
-      borderColor: colors.border,
+      backgroundColor: framePreviewBackground,
+      borderColor: framePreviewBorder,
       borderRadius: HARUCUT_RADII.lg,
       borderWidth: 1,
+      elevation: isDark ? 0 : 1,
       justifyContent: 'center',
       overflow: 'hidden',
+      shadowColor: isDark ? colors.shadow : 'rgba(15, 23, 42, 0.10)',
+      shadowOffset: { height: 8, width: 0 },
+      shadowOpacity: isDark ? 0 : 0.08,
+      shadowRadius: 18,
     },
     framePreviewWrapCarousel: {
       minHeight: FRAME_PICKER_PREVIEW_BOX.height + 32,
@@ -629,8 +639,8 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       borderColor: colors.primary,
     },
     slot: {
-      backgroundColor: colors.cardMuted,
-      borderColor: isDark ? 'rgba(147, 197, 253, 0.14)' : 'rgba(37, 99, 235, 0.12)',
+      backgroundColor: emptySlotBackground,
+      borderColor: emptySlotBorder,
       borderRadius: 14,
       borderWidth: 1,
       overflow: 'hidden',

--- a/apps/mobile/components/harucut/ui.tsx
+++ b/apps/mobile/components/harucut/ui.tsx
@@ -10,6 +10,8 @@ import { HARUCUT_RADII, HARUCUT_SPACING, type ButtonVariant, type HarucutColors 
 import { getGlobalThemeScrollPadding } from '@/constants/overlay-ui';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 
+const EXTRA_TOP_PADDING = 24;
+
 function useUiStyles() {
   const { colors, isDark } = useHarucutTheme();
 
@@ -39,6 +41,7 @@ export function AppScrollView({
       <ScrollView
         contentContainerStyle={[
           styles.screenContent,
+          { paddingTop: HARUCUT_SPACING.screen + EXTRA_TOP_PADDING },
           { paddingBottom: bottomPadding },
           contentContainerStyle,
         ]}

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -129,8 +129,7 @@ export default function HomePage() {
               </span>
             </h1>
             <p className="max-w-xl text-[14px] leading-6 text-zinc-300 sm:text-[15px] sm:leading-7">
-              복잡한 설명 없이 바로 시작할 수 있게 준비했어요. 원하는 방식으로
-              만들고 기록에 남겨두세요.
+              촬영하거나 업로드해서 기록에 남겨두세요.
             </p>
           </div>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -33,7 +33,7 @@ export default function LandingPage() {
               오늘 하루를 네 컷으로 남겨보세요
             </div>
 
-            <h1 className="mt-5 text-[30px] font-semibold tracking-[-0.04em] text-[color:var(--hc-text)] sm:text-[34px] md:text-[56px] md:leading-[1.02]">
+            <h1 className="mt-5 text-[30px] font-semibold leading-[1.2] tracking-[-0.04em] text-[color:var(--hc-text)] sm:text-[34px] md:text-[56px]">
               오늘의 순간을
               <span
                 className="block bg-clip-text text-transparent"
@@ -51,7 +51,7 @@ export default function LandingPage() {
               오늘 하루 기록을 가볍게 남길 수 있어요.
             </p>
 
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <div className="mt-6 grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:flex-wrap">
               <Link
                 href="/login"
                 className="hc-button-hero inline-flex w-full items-center justify-center rounded-full px-5 py-3 text-sm font-semibold transition-all duration-300 ease-out sm:w-auto"


### PR DESCRIPTION
## 작업 내용
- 모바일 프레임 미리보기의 밝은 테마 배경, 테두리, 그림자 대비 보정
- 모바일 공통 스크롤 화면 상단 여백 보정
- 웹 홈/랜딩 문구와 CTA 모바일 배치 보정

## 영향
- 앱 프레임 선택/저장 미리보기 가독성 개선
- 웹 첫 화면 문구와 버튼 영역의 모바일 표시 안정화

## 검증
- `pnpm typecheck:mobile`
- `pnpm lint:mobile`
- `pnpm build:web`

Closes #206