### PR TITLE
fix: dependabot workspace 업데이트 정리

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,22 +16,6 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  - package-ecosystem: "npm"
-    directory: "/apps/mobile"
-    target-branch: "develop"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:15"
-      timezone: "Asia/Seoul"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "mobile"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "develop"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - edited
       - reopened
       - synchronize
       - ready_for_review


### PR DESCRIPTION
## 변경
- pnpm workspace 기준 Dependabot 업데이트를 루트 설정으로 일원화
- `/apps/mobile` 개별 npm 업데이트 블록 제거
- Dependabot PR base 변경(`edited`) 시에도 auto-merge 워크플로가 동작하도록 이벤트 추가

## 이유
- `/apps/mobile` 블록에서 생성된 PR은 `apps/mobile/package.json`만 바꾸고 루트 `pnpm-lock.yaml`을 갱신하지 않아 `pnpm install --frozen-lockfile`에서 실패
- 루트 npm 블록은 workspace package와 lockfile을 함께 갱신하므로 해당 경로로 통일

## 검증
- `git diff --check`