### PR TITLE
chore: dependabot 충돌 업데이트 정리

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -42,7 +42,7 @@
     "react-native-reanimated": "~4.3.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.16.0",
-    "react-native-view-shot": "^5.0.0",
+    "react-native-view-shot": "^5.1.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.8.1",
     "zustand": "^5.0.12"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@imgly/background-removal": "1.7.0",
     "axios": "^1.16.0",
-    "jose": "^6.1.3",
+    "jose": "^6.2.3",
     "konva": "^10.0.12",
     "lucide-react": "^0.562.0",
     "next": "16.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ~4.16.0
         version: 4.16.0(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-view-shot:
-        specifier: ^5.0.0
-        version: 5.0.1(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ^5.1.0
+        version: 5.1.0(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -146,8 +146,8 @@ importers:
         specifier: ^1.16.0
         version: 1.16.0
       jose:
-        specifier: ^6.1.3
-        version: 6.1.3
+        specifier: ^6.2.3
+        version: 6.2.3
       konva:
         specifier: ^10.0.12
         version: 10.0.12
@@ -5221,8 +5221,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -6347,8 +6347,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-view-shot@5.0.1:
-    resolution: {integrity: sha512-iGLeli0OcqrYL9iz/faSn0iQdqStQ5+EbS0QlUNN8klPenVXl/HJtV8yHbYiECfse20U56hv3E5puVShTJwBDg==}
+  react-native-view-shot@5.1.0:
+    resolution: {integrity: sha512-JZgElCD82aO+hejIF/leUzI7JufL9mgJ6ChzGWIcdZ2ajpaEvvSnvIcw0qD32XWkrbId8wfSbyz/4u/ulTQzQA==}
     engines: {node: '>=20', npm: '>=10'}
     peerDependencies:
       react: '>=18.0.0'
@@ -12037,7 +12037,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12068,7 +12068,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13765,7 +13765,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@6.1.3: {}
+  jose@6.2.3: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -15162,7 +15162,7 @@ snapshots:
       react-native-is-edge-to-edge: 1.3.1(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       warn-once: 0.1.1
 
-  react-native-view-shot@5.0.1(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+  react-native-view-shot@5.1.0(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       html2canvas: 1.4.1
       react: 19.2.3


### PR DESCRIPTION
## 변경
- `jose`를 `^6.2.3`으로 업데이트
- `react-native-view-shot`을 `^5.1.0`으로 업데이트
- 루트 `pnpm-lock.yaml`을 workspace 기준으로 정리

## 이유
- 기존 Dependabot PR 10개는 base가 `main`이던 시점의 `release-guard` 실패 체크와 lockfile 충돌이 남아 자동 머지가 막힘
- 이미 `develop`에 반영된 중복 업데이트는 닫고, 아직 빠진 업데이트만 깨끗한 PR로 재구성
- `typescript@6.0.3`은 현재 `build:web`에서 CSS side-effect import 타입 오류를 내므로 이번 자동 머지 대상에서 제외

## 검증
- `pnpm install --frozen-lockfile`
- `pnpm lint:mobile`
- `pnpm typecheck:mobile`
- `pnpm test:web`
- `pnpm build:web`
- `git diff --check`