### PR TITLE
fix: 웹 타입체크 오류 정리

### DIFF
--- a/apps/web/app/shoot/result/page.test.tsx
+++ b/apps/web/app/shoot/result/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from "@testing-library/react";
 import { create } from "zustand";
 import ShootResultPage from "@/app/shoot/result/page";
+import type { GeneratedFourcutAsset } from "@/lib/fourcutOutput";
 
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
@@ -11,7 +12,22 @@ const mockUploadGeneratedFourcutFile = jest.fn();
 const mockCreateObjectURL = jest.fn();
 const mockRevokeObjectURL = jest.fn();
 
-const mockUseShootSession = create(() => ({
+type MockShootSessionState = {
+  frameId: string | null;
+  remoteFrameId: number | null;
+  shots: Array<{ photo: string; video?: string }>;
+  selectedIndexes: Array<number | null>;
+  borderColor: string;
+  outputFilter: "NONE";
+  includeVideo: boolean;
+  imageResult: GeneratedFourcutAsset | null;
+  videoResult: GeneratedFourcutAsset | null;
+  setImageResult: (imageResult: GeneratedFourcutAsset | null) => void;
+  setVideoResult: (videoResult: GeneratedFourcutAsset | null) => void;
+  clearResults: () => void;
+};
+
+const mockUseShootSession = create<MockShootSessionState>((set) => ({
   frameId: "classic-4" as string | null,
   remoteFrameId: null as number | null,
   shots: [
@@ -24,15 +40,11 @@ const mockUseShootSession = create(() => ({
   borderColor: "#111827",
   outputFilter: "NONE",
   includeVideo: true,
-  imageResult: null as null | object,
-  videoResult: null as null | object,
-  setImageResult: (imageResult: unknown) =>
-    mockUseShootSession.setState({ imageResult }),
-  setVideoResult: (videoResult: unknown) =>
-    mockUseShootSession.setState({ videoResult }),
-  clearResults: jest.fn(() =>
-    mockUseShootSession.setState({ imageResult: null, videoResult: null }),
-  ),
+  imageResult: null,
+  videoResult: null,
+  setImageResult: (imageResult) => set({ imageResult }),
+  setVideoResult: (videoResult) => set({ videoResult }),
+  clearResults: jest.fn(() => set({ imageResult: null, videoResult: null })),
 }));
 
 jest.mock("next/navigation", () => ({

--- a/apps/web/app/upload/result/page.test.tsx
+++ b/apps/web/app/upload/result/page.test.tsx
@@ -1,6 +1,8 @@
 import { render, waitFor } from "@testing-library/react";
 import { create } from "zustand";
 import UploadResultPage from "@/app/upload/result/page";
+import type { FrameMedia } from "@/components/frame/FramePreview";
+import type { GeneratedFourcutAsset } from "@/lib/fourcutOutput";
 
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
@@ -11,7 +13,22 @@ const mockUploadGeneratedFourcutFile = jest.fn();
 const mockCreateObjectURL = jest.fn();
 const mockRevokeObjectURL = jest.fn();
 
-const mockUseUploadSession = create(() => ({
+type MockUploadSessionState = {
+  frameId: string | null;
+  remoteFrameId: number | null;
+  media: FrameMedia[];
+  selectedIndexes: Array<number | null>;
+  borderColor: string;
+  outputFilter: "NONE";
+  includeVideo: boolean;
+  imageResult: GeneratedFourcutAsset | null;
+  videoResult: GeneratedFourcutAsset | null;
+  setImageResult: (imageResult: GeneratedFourcutAsset | null) => void;
+  setVideoResult: (videoResult: GeneratedFourcutAsset | null) => void;
+  clearResults: () => void;
+};
+
+const mockUseUploadSession = create<MockUploadSessionState>((set) => ({
   frameId: "classic-4" as string | null,
   remoteFrameId: null as number | null,
   media: [
@@ -24,15 +41,11 @@ const mockUseUploadSession = create(() => ({
   borderColor: "#111827",
   outputFilter: "NONE",
   includeVideo: true,
-  imageResult: null as null | object,
-  videoResult: null as null | object,
-  setImageResult: (imageResult: unknown) =>
-    mockUseUploadSession.setState({ imageResult }),
-  setVideoResult: (videoResult: unknown) =>
-    mockUseUploadSession.setState({ videoResult }),
-  clearResults: jest.fn(() =>
-    mockUseUploadSession.setState({ imageResult: null, videoResult: null }),
-  ),
+  imageResult: null,
+  videoResult: null,
+  setImageResult: (imageResult) => set({ imageResult }),
+  setVideoResult: (videoResult) => set({ videoResult }),
+  clearResults: jest.fn(() => set({ imageResult: null, videoResult: null })),
 }));
 
 jest.mock("next/navigation", () => ({

--- a/apps/web/global.d.ts
+++ b/apps/web/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/apps/web/lib/api-types.ts
+++ b/apps/web/lib/api-types.ts
@@ -42,7 +42,7 @@ export type UserMedia = {
   s3Key: string;
   displayName?: string | null;
   displayname?: string | null;
-  downloadUrl?: string;
+  downloadUrl?: string | null;
   originalS3Key?: string;
   originalFileName?: string;
   transcodeJobId?: string;

--- a/apps/web/tests/e2e/accessibility.spec.ts
+++ b/apps/web/tests/e2e/accessibility.spec.ts
@@ -1,5 +1,6 @@
 import { AxeBuilder } from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 const baseURL =
   process.env.PLAYWRIGHT_BASE_URL ??
@@ -15,9 +16,7 @@ const authenticatedRoutes = [
   "/mypage",
 ] as const;
 
-async function enableAuthenticatedContext(
-  page: Parameters<typeof test>[0]["page"],
-) {
+async function enableAuthenticatedContext(page: Page) {
   await page.context().addCookies([
     {
       name: "accessToken",
@@ -27,9 +26,7 @@ async function enableAuthenticatedContext(
   ]);
 }
 
-async function expectNoAccessibilityViolations(
-  page: Parameters<typeof test>[0]["page"],
-) {
+async function expectNoAccessibilityViolations(page: Page) {
   await page.locator("body").waitFor({ state: "visible" });
 
   const accessibilityScanResults = await new AxeBuilder({ page })

--- a/apps/web/tests/e2e/guards.spec.ts
+++ b/apps/web/tests/e2e/guards.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 const baseURL =
   process.env.PLAYWRIGHT_BASE_URL ??
   `http://localhost:${Number(process.env.PORT ?? 3000)}`;
 
-async function enableAuthenticatedContext(page: Parameters<typeof test>[0]["page"]) {
+async function enableAuthenticatedContext(page: Page) {
   await page.context().addCookies([
     {
       name: "accessToken",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -26,6 +26,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
     "**/*.mts"


### PR DESCRIPTION
## 변경 내용
- Storybook preview CSS side-effect import를 처리할 수 있도록 CSS module 선언 추가
- Storybook 설정 파일을 웹 tsconfig 타입체크 범위에 포함
- Jest mock store 자기참조 타입 오류 수정
- Playwright E2E helper의 page 타입을 공식 Page 타입으로 교체
- UserMedia.downloadUrl의 null 응답 케이스 반영

## 원인
- CI 기본 verify 경로에는 직접 tsc 실행이 없어 에디터/tsconfig 기준 타입 오류가 남아 있었음
- CSS import 선언이 없어 preview.ts가 별도 TS 프로젝트로 해석될 때 module declaration 오류가 발생할 수 있었음

## 검증
- pnpm --dir apps/web exec tsc --noEmit --pretty false --noUncheckedSideEffectImports
- pnpm lint:web
- pnpm test:web
- pnpm build:web