### PR TITLE
feat: 촬영 프레임 선택 흐름과 홈 UI 정리

### DIFF
--- a/apps/mobile/components/harucut/frame.tsx
+++ b/apps/mobile/components/harucut/frame.tsx
@@ -401,7 +401,7 @@ export function FramePickerSection({
   confirmLabel: string;
   onConfirm: () => void;
   onSelect: (frameId: FrameId) => void;
-  selectedFrameId: FrameId;
+  selectedFrameId: FrameId | null;
 }) {
   const styles = useFrameStyles();
   const { width } = useWindowDimensions();
@@ -473,7 +473,7 @@ export function FramePickerSection({
           </View>
         </View>
       )}
-      <ActionButton label={confirmLabel} onPress={onConfirm} />
+      <ActionButton disabled={!selectedFrameId} label={confirmLabel} onPress={onConfirm} />
     </>
   );
 }
@@ -583,13 +583,15 @@ export function SavedFramesPanel({
   onAction?: (frame: SavedFrame) => void;
   onRefresh: () => void;
   onSelect: (frame: SavedFrame) => void;
-  selectedFrameId: FrameId;
+  selectedFrameId: FrameId | null;
   selectedSavedFrameId: string | null;
   title: string;
 }) {
   const { colors } = useHarucutTheme();
   const styles = useFrameStyles();
-  const matchingFrames = frames.filter((frame) => frame.frameId === selectedFrameId);
+  const matchingFrames = selectedFrameId
+    ? frames.filter((frame) => frame.frameId === selectedFrameId)
+    : frames;
 
   return (
     <SurfaceCard>

--- a/apps/mobile/components/harucut/global-theme-toggle.tsx
+++ b/apps/mobile/components/harucut/global-theme-toggle.tsx
@@ -22,7 +22,7 @@ const THEME_OPTIONS: {
 }[] = [
   {
     icon: 'phone-portrait-outline',
-    label: '시스템',
+    label: '기본값',
     value: 'system',
   },
   {
@@ -42,7 +42,7 @@ function currentThemeChipLabel(
   scheme: 'light' | 'dark',
 ) {
   if (preference === 'system') {
-    return '시스템';
+    return '기본값';
   }
 
   return scheme === 'dark' ? '다크' : '라이트';

--- a/apps/mobile/components/harucut/ui.tsx
+++ b/apps/mobile/components/harucut/ui.tsx
@@ -198,6 +198,7 @@ export function Pill({
 }
 
 type ActionButtonProps = {
+  disabled?: boolean;
   icon?: ReactNode;
   label: string;
   onPress: () => void;
@@ -206,6 +207,7 @@ type ActionButtonProps = {
 };
 
 export function ActionButton({
+  disabled = false,
   icon,
   label,
   onPress,
@@ -234,11 +236,14 @@ export function ActionButton({
     <Pressable
       accessibilityLabel={label}
       accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
       onPress={onPress}
       style={({ pressed }) => [
         styles.button,
         variantStyle,
-        pressed ? styles.buttonPressed : null,
+        pressed && !disabled ? styles.buttonPressed : null,
+        disabled ? styles.buttonDisabled : null,
         style,
       ]}>
       <View style={styles.buttonContent}>
@@ -396,6 +401,9 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     },
     buttonLabelOnSolid: {
       color: '#FFFFFF',
+    },
+    buttonDisabled: {
+      opacity: 0.55,
     },
     buttonPressed: {
       opacity: 0.88,

--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -24,7 +24,7 @@ const THEME_OPTIONS: Array<{
 }> = [
   {
     description: '기기 설정에 맞춰 자동으로 전환해요.',
-    label: '시스템',
+    label: '기본값',
     value: 'system',
   },
   {
@@ -77,6 +77,41 @@ async function sharePreview(item: HistoryItem) {
   });
 }
 
+function formatCurrentDate() {
+  return new Date().toLocaleDateString('ko-KR', {
+    day: 'numeric',
+    month: 'long',
+    weekday: 'short',
+  });
+}
+
+function getNextDateRefreshDelay() {
+  const now = new Date();
+  const nextMidnight = new Date(now);
+  nextMidnight.setHours(24, 0, 1, 0);
+
+  return Math.max(nextMidnight.getTime() - now.getTime(), 1000);
+}
+
+function useCurrentDateLabel() {
+  const [dateLabel, setDateLabel] = useState(formatCurrentDate);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const refresh = () => {
+      setDateLabel(formatCurrentDate());
+      timeoutId = setTimeout(refresh, getNextDateRefreshDelay());
+    };
+
+    timeoutId = setTimeout(refresh, getNextDateRefreshDelay());
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return dateLabel;
+}
+
 function useAppScreenTheme() {
   const { colors, isDark } = useHarucutTheme();
   const styles = useMemo(() => createStyles(colors, isDark), [colors, isDark]);
@@ -97,11 +132,7 @@ export function HomeScreen() {
   const savedFrames = useHarucutStore((state) => state.savedFrames);
   const user = useHarucutStore((state) => state.user);
 
-  const todayMoment = new Date().toLocaleDateString('ko-KR', {
-    day: 'numeric',
-    month: 'long',
-    weekday: 'short',
-  });
+  const todayMoment = useCurrentDateLabel();
   const recentItems = historyItems.slice(0, 4);
   const isHistoryLoading =
     historyStatus === 'loading' ||
@@ -537,7 +568,6 @@ export function MyPageScreen() {
   return (
     <AppScrollView>
       <PageHeader
-        description="계정 정보와 보안 설정을 관리할 수 있어요."
         onPressRight={() => void refreshUserProfile().catch((error) =>
           showError('계정 정보 새로고침 실패', getApiErrorMessage(error, '계정 정보를 불러오지 못했어요.')),
         )}
@@ -571,8 +601,7 @@ export function MyPageScreen() {
         </View>
 
         <ActionButton
-          icon={<Ionicons color={colors.text} name="image-outline" size={16} />}
-          label={submitting ? '처리 중...' : '프로필 이미지 업로드'}
+          label={submitting ? '업로드 중' : '업로드'}
           onPress={handlePickProfile}
           variant="secondary"
         />
@@ -616,11 +645,6 @@ export function MyPageScreen() {
 
       <SurfaceCard style={{ gap: 12 }}>
         <Text style={styles.sectionTitle}>앱 테마</Text>
-        <Text style={styles.bodyCopy}>
-          {isDark
-            ? '현재 다크 모드가 적용되어 있어요. 기기 설정을 따르거나 원하는 테마로 바로 바꿀 수 있어요.'
-            : '현재 라이트 모드가 적용되어 있어요. 기기 설정을 따르거나 원하는 테마로 바로 바꿀 수 있어요.'}
-        </Text>
         <View style={styles.themeOptionList}>
           {THEME_OPTIONS.map((option) => {
             const active = themePreference === option.value;
@@ -670,7 +694,7 @@ export function MyPageScreen() {
 
       <SurfaceCard style={[styles.exitCard, { gap: 12 }]}>
         <Text style={styles.exitTitle}>회원 탈퇴 요청</Text>
-        <Text style={styles.bodyCopy}>
+        <Text style={styles.exitBody}>
           탈퇴를 요청하면 계정이 비활성화돼요. 다시 로그인하면 탈퇴를 취소하고 계정을 다시 사용할 수 있어요.
         </Text>
         <ActionButton
@@ -707,6 +731,11 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       color: colors.danger,
       fontSize: 18,
       fontWeight: '700',
+    },
+    exitBody: {
+      color: isDark ? '#FECACA' : '#7F1D1D',
+      fontSize: 12,
+      lineHeight: 18,
     },
     filterRow: {
       flexDirection: 'row',

--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -66,15 +66,14 @@ export function ShootFrameScreen() {
     }
   }, [accessMode, loadRemoteFrames]);
 
+  useEffect(() => {
+    setShootFrame(null);
+  }, [setShootFrame]);
+
   return (
     <AppScrollView>
       <PageHeader
         backLabel={accessMode === 'guest' ? '처음으로' : '홈으로'}
-        description={
-          accessMode === 'guest'
-            ? '비회원 체험에서는 촬영과 이미지 다운로드만 할 수 있어요.'
-            : '촬영할 프레임을 먼저 골라 주세요.'
-        }
         onPressBack={() => {
           if (accessMode === 'guest') {
             enterAnonymousMode();
@@ -87,8 +86,12 @@ export function ShootFrameScreen() {
       />
       <StepProgress current={1} label="프레임 선택" total={4} />
       <FramePickerSection
-        confirmLabel="촬영 시작하기"
-        onConfirm={() => push('/shoot/capture')}
+        confirmLabel={shoot.frameId ? '촬영 시작하기' : '촬영할 프레임을 선택해주세요'}
+        onConfirm={() => {
+          if (!shoot.frameId) return;
+
+          push('/shoot/capture');
+        }}
         onSelect={setShootFrame}
         selectedFrameId={shoot.frameId}
       />
@@ -128,8 +131,6 @@ export function ShootCaptureScreen() {
       router.replace('/shoot' as never);
     }
   }, [router, shoot.frameId]);
-
-  const remainingShots = Math.max(8 - shoot.shots.length, 0);
 
   const handleStartAutoCapture = async () => {
     if (!permission?.granted) {
@@ -198,17 +199,21 @@ export function ShootCaptureScreen() {
       <PageHeader
         backLabel="프레임 다시 선택"
         onPressBack={() => push('/shoot')}
-        title="사진 촬영 · 8장 자동 촬영"
       />
+      <StepProgress current={2} label="사진 촬영" total={4} />
 
       <SurfaceCard style={{ gap: 14 }}>
         <View style={styles.statusRow}>
-          <Text style={styles.statusText}>2단계 · 카메라 촬영 {isShooting ? '· 자동 촬영 중' : ''}</Text>
+          <Text style={styles.statusText}>사진과 영상을 함께 촬영해요</Text>
           <Pill>{shoot.shots.length} / 8장 촬영됨</Pill>
         </View>
 
         <View style={styles.cameraFrame}>
-          {permission?.granted ? (
+          {permission === null ? (
+            <View style={styles.cameraPlaceholder}>
+              <Text style={styles.bodyText}>카메라 권한 상태를 확인하는 중이에요.</Text>
+            </View>
+          ) : permission.granted ? (
             <CameraView
               facing={facing}
               onCameraReady={() => setIsCameraReady(true)}
@@ -227,15 +232,16 @@ export function ShootCaptureScreen() {
               <View style={styles.countdownCircle}>
                 <Text style={styles.countdownText}>{countdown}</Text>
               </View>
-              <Text style={styles.overlayCaption}>다음 촬영까지 남은 시간</Text>
-              <Text style={styles.overlayCaption}>남은 사진 {remainingShots}장</Text>
+              <Text style={styles.overlayCaption}>{shoot.shots.length}/8</Text>
             </View>
           ) : null}
         </View>
 
         <View style={{ gap: 8 }}>
           <Text style={styles.bodyText}>
-            카메라를 켜고 &quot;8장 자동 촬영 시작&quot; 버튼을 누르면 3초 간격으로 사진을 촬영해요.
+            {permission?.granted
+              ? '"촬영 시작" 버튼을 누르면 3초 간격으로 사진을 촬영해요.'
+              : '카메라 권한을 허용하면 8장 자동 촬영을 시작할 수 있어요.'}
           </Text>
           <Text style={styles.statusText}>카메라 {isCameraReady ? '준비 완료' : '아직 켜져 있지 않아요'}</Text>
         </View>
@@ -249,7 +255,7 @@ export function ShootCaptureScreen() {
           />
           <ActionButton
             icon={<Ionicons color="#FFFFFF" name="camera-outline" size={16} />}
-            label={isShooting ? '촬영 중...' : '8장 자동 촬영 시작'}
+            label={isShooting ? '촬영 중...' : '촬영 시작'}
             onPress={() => void handleStartAutoCapture()}
           />
           {shoot.shots.length >= 4 ? (
@@ -267,11 +273,12 @@ export function ShootSelectScreen() {
   const styles = useShootStyles();
   const accessMode = useHarucutStore((state) => state.accessMode);
   const shoot = useHarucutStore((state) => state.shoot);
+  const selectedFrameId = shoot.frameId;
   const toggleShootSelection = useHarucutStore((state) => state.toggleShootSelection);
   const setShootOption = useHarucutStore((state) => state.setShootOption);
 
   useEffect(() => {
-    if (!shoot.frameId) {
+    if (!selectedFrameId) {
       router.replace('/shoot' as never);
       return;
     }
@@ -279,7 +286,7 @@ export function ShootSelectScreen() {
     if (shoot.shots.length === 0) {
       router.replace('/shoot/capture' as never);
     }
-  }, [router, shoot.frameId, shoot.shots.length]);
+  }, [router, selectedFrameId, shoot.shots.length]);
 
   const selectedCount = shoot.selectedShotIds.length;
   const previewMedia = useMemo(
@@ -290,26 +297,27 @@ export function ShootSelectScreen() {
     [shoot.selectedShotIds, shoot.shots],
   );
 
+  if (!selectedFrameId) return null;
+
   return (
     <AppScrollView>
       <PageHeader
         backLabel="다시 촬영"
-        description="마음에 드는 사진 4장을 고르고 출력 옵션을 정해 주세요."
         onPressBack={() => push('/shoot/capture')}
-        title="사진 선택"
       />
+      <StepProgress current={3} label="사진 선택" total={4} />
 
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.sectionTitle}>프레임 미리보기</Text>
         <View style={{ alignItems: 'center' }}>
-          <FramePreview accentColor={shoot.borderColor} frameId={shoot.frameId} media={previewMedia} />
+          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} />
         </View>
       </SurfaceCard>
 
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.bodyText}>방금 촬영한 사진 {shoot.shots.length}장 중에서 4장을 골라 주세요.</Text>
         <View style={styles.mediaGrid}>
-          {shoot.shots.map((item) => {
+          {shoot.shots.map((item, index) => {
             const selected = shoot.selectedShotIds.includes(item.id);
             return (
               <Pressable
@@ -321,7 +329,7 @@ export function ShootSelectScreen() {
                 style={[styles.mediaCard, selected ? styles.mediaCardSelected : null]}>
                 <Image accessibilityLabel={item.label} accessibilityRole="image" source={{ uri: item.uri }} style={styles.mediaImage} />
                 <View style={styles.mediaBadge}>
-                  <Text style={styles.mediaBadgeText}>{selected ? '선택됨' : item.label}</Text>
+                  <Text style={styles.mediaBadgeText}>#{index + 1}</Text>
                 </View>
               </Pressable>
             );
@@ -359,11 +367,10 @@ export function ShootSelectScreen() {
             </Pill>
             <Text style={styles.bodyText}>촬영 플로우에서는 이미지 중심 결과를 우선 제공합니다.</Text>
           </>
-        ) : (
-          <Text style={styles.bodyText}>비회원 체험에서는 이미지 결과만 다운로드할 수 있어요.</Text>
-        )}
+        ) : null}
         <ActionButton
-          label={`다음 단계로 (${selectedCount}/4)`}
+          disabled={selectedCount !== 4}
+          label={selectedCount === 4 ? '다음 단계로' : '4장을 골라주세요'}
           onPress={() => {
             if (selectedCount === 4) {
               push('/shoot/result');
@@ -382,6 +389,7 @@ export function ShootResultScreen() {
   const styles = useShootStyles();
   const accessMode = useHarucutStore((state) => state.accessMode);
   const shoot = useHarucutStore((state) => state.shoot);
+  const selectedFrameId = shoot.frameId;
   const persistShootResult = useHarucutStore((state) => state.persistShootResult);
   const historyItems = useHarucutStore((state) => state.historyItems);
   const renameHistoryItem = useHarucutStore((state) => state.renameHistoryItem);
@@ -393,7 +401,7 @@ export function ShootResultScreen() {
   const isGuest = accessMode === 'guest';
 
   useEffect(() => {
-    if (!shoot.frameId) {
+    if (!selectedFrameId) {
       router.replace('/shoot' as never);
       return;
     }
@@ -439,7 +447,7 @@ export function ShootResultScreen() {
     persistShootResult,
     router,
     saveStatus,
-    shoot.frameId,
+    selectedFrameId,
     shoot.persistedHistoryId,
     shoot.selectedShotIds.length,
     showNotice,
@@ -485,6 +493,8 @@ export function ShootResultScreen() {
     }
   };
 
+  if (!selectedFrameId) return null;
+
   return (
     <AppScrollView>
       <PageHeader title="촬영 결과" />
@@ -506,10 +516,10 @@ export function ShootResultScreen() {
 
       <SurfaceCard style={{ gap: 14 }}>
         <View collapsable={false} ref={previewRef}>
-          <FramePreview accentColor={shoot.borderColor} frameId={shoot.frameId} media={previewMedia} />
+          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} />
         </View>
         {!isGuest && shoot.includeVideo ? (
-          <FramePreview accentColor={shoot.borderColor} frameId={shoot.frameId} media={previewMedia} />
+          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} />
         ) : null}
       </SurfaceCard>
 
@@ -653,8 +663,10 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       gap: 8,
     },
     mediaBadge: {
-      backgroundColor: colors.overlayStrong,
+      backgroundColor: '#FFFFFF',
+      borderColor: 'rgba(17, 24, 39, 0.14)',
       borderRadius: 999,
+      borderWidth: 1,
       bottom: 8,
       left: 8,
       paddingHorizontal: 8,
@@ -662,9 +674,9 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       position: 'absolute',
     },
     mediaBadgeText: {
-      color: '#FFFFFF',
+      color: '#000000',
       fontSize: 10,
-      fontWeight: '700',
+      fontWeight: '800',
     },
     mediaCard: {
       aspectRatio: 0.75,

--- a/apps/mobile/store/use-harucut-store.ts
+++ b/apps/mobile/store/use-harucut-store.ts
@@ -51,7 +51,7 @@ type NoticeState = {
 
 type ShootSession = {
   borderColor: string;
-  frameId: FrameId;
+  frameId: FrameId | null;
   includeVideo: boolean;
   persistedHistoryId: string | null;
   selectedSavedFrameId: string | null;
@@ -131,7 +131,7 @@ type HarucutStore = {
   selectSavedFrameForShoot: (frame: SavedFrame) => void;
   selectSavedFrameForTheme: (frame: SavedFrame) => void;
   selectSavedFrameForUpload: (frame: SavedFrame) => void;
-  setShootFrame: (frameId: FrameId) => void;
+  setShootFrame: (frameId: FrameId | null) => void;
   setShootOption: (key: keyof Pick<ShootSession, 'borderColor' | 'includeVideo' | 'tone'>, value: string | boolean) => void;
   setThemeAccentColor: (value: string) => void;
   setThemeActiveComponent: (id: string | null) => void;
@@ -236,7 +236,7 @@ const frameNames: Record<FrameId, string> = {
 function defaultShootSession(): ShootSession {
   return {
     borderColor: defaultBorderColor,
-    frameId: 'classic-4',
+    frameId: null,
     includeVideo: false,
     persistedHistoryId: null,
     selectedSavedFrameId: null,
@@ -464,9 +464,15 @@ export const useHarucutStore = create<HarucutStore>((set, get) => ({
       throw new Error('저장할 결과 이미지를 만들지 못했어요.');
     }
 
+    if (!state.shoot.frameId) {
+      throw new Error('촬영할 프레임을 선택해 주세요.');
+    }
+
+    const frameId = state.shoot.frameId;
+
     const nextItem = await uploadFourcutResult({
-      displayName: `${frameName(state.shoot.frameId)} 촬영 결과`,
-      frameId: state.shoot.frameId,
+      displayName: `${frameName(frameId)} 촬영 결과`,
+      frameId,
       source: 'shoot',
       uri: previewUri,
     });

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Camera,
   ChevronRight,
@@ -18,17 +18,49 @@ import type { UserMedia, RemoteFrame } from "@/lib/api-types";
 import { frameIdFromFrameType } from "@/lib/frameApi";
 import { getUserMediaPreview, getUserMediaTitle } from "@/lib/userMediaPreview";
 
-function getRecentMoment(items: UserMedia[]) {
-  if (items.length === 0) return "첫 기록을 남겨보세요";
-
-  const latest = items[0].createdAt ? new Date(items[0].createdAt) : null;
-  if (!latest || Number.isNaN(latest.getTime())) return "최근 기록 확인";
-
-  return latest.toLocaleDateString("ko-KR", {
+function formatCurrentDate() {
+  return new Date().toLocaleDateString("ko-KR", {
     month: "long",
     day: "numeric",
     weekday: "short",
   });
+}
+
+function getNextDateRefreshDelay() {
+  const now = new Date();
+  const nextMidnight = new Date(now);
+  nextMidnight.setHours(24, 0, 1, 0);
+
+  return Math.max(nextMidnight.getTime() - now.getTime(), 1000);
+}
+
+function useCurrentDateLabel() {
+  const [dateLabel, setDateLabel] = useState(formatCurrentDate);
+
+  useEffect(() => {
+    let timeoutId: number;
+
+    const refresh = () => {
+      setDateLabel(formatCurrentDate());
+      timeoutId = window.setTimeout(refresh, getNextDateRefreshDelay());
+    };
+
+    const refreshOnVisible = () => {
+      if (!document.hidden) {
+        setDateLabel(formatCurrentDate());
+      }
+    };
+
+    timeoutId = window.setTimeout(refresh, getNextDateRefreshDelay());
+    document.addEventListener("visibilitychange", refreshOnVisible);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      document.removeEventListener("visibilitychange", refreshOnVisible);
+    };
+  }, []);
+
+  return dateLabel;
 }
 
 export default function HomePage() {
@@ -77,10 +109,7 @@ export default function HomePage() {
     };
   }, []);
 
-  const recentMoment = useMemo(
-    () => getRecentMoment(recentMedia),
-    [recentMedia],
-  );
+  const currentDateLabel = useCurrentDateLabel();
   const savedFrame = savedFrames[0] ?? null;
 
   return (
@@ -106,7 +135,7 @@ export default function HomePage() {
 
         <section className="hc-surface-card-xl rounded-[28px] border p-5 backdrop-blur sm:p-6">
           <div className="hc-accent-chip inline-flex rounded-full border px-3 py-1 text-[11px]">
-            {recentMoment}
+            {currentDateLabel}
           </div>
 
           <div className="mt-4 space-y-3">

--- a/apps/web/app/mypage/page.tsx
+++ b/apps/web/app/mypage/page.tsx
@@ -211,13 +211,9 @@ export default function MyPage() {
             </button>
           }
           description={
-            <span
-              className={`text-[11px] ${
-                errors.common ? "text-red-400" : "text-zinc-400"
-              }`}
-            >
-              {errors.common ?? "계정 정보와 보안 설정을 관리할 수 있어요."}
-            </span>
+            errors.common ? (
+              <span className="text-[11px] text-red-400">{errors.common}</span>
+            ) : undefined
           }
         />
 
@@ -284,9 +280,9 @@ export default function MyPage() {
                   type="button"
                   onClick={handleUploadProfileImage}
                   disabled={isUploadingProfile || !profileFile}
-                  className="hc-button-primary h-9 whitespace-nowrap rounded-full px-4 text-[11px] font-semibold disabled:opacity-50"
+                  className="hc-button-primary h-9 shrink-0 whitespace-nowrap rounded-full px-4 text-[11px] font-semibold disabled:opacity-50"
                 >
-                  {isUploadingProfile ? "업로드 중..." : "프로필 업로드"}
+                  {isUploadingProfile ? "업로드 중" : "업로드"}
                 </button>
               </div>
             </section>
@@ -388,10 +384,10 @@ export default function MyPage() {
             </section>
 
             <section className="rounded-2xl border border-red-900/40 bg-red-950/10 p-4">
-              <h2 className="text-sm font-semibold text-red-200">
+              <h2 className="text-sm font-semibold text-red-700 dark:text-red-200">
                 회원 탈퇴 요청
               </h2>
-              <p className="mt-1 text-[11px] text-red-200/80">
+              <p className="mt-1 text-[11px] text-red-900/80 dark:text-red-200/80">
                 탈퇴를 요청하면 계정이 비활성화돼요. 다시 로그인하면 탈퇴를
                 취소하고 계정을 다시 사용할 수 있어요.
               </p>

--- a/apps/web/app/shoot/capture/_hooks/useCaptureFlow.ts
+++ b/apps/web/app/shoot/capture/_hooks/useCaptureFlow.ts
@@ -26,6 +26,8 @@ export function useCaptureFlow() {
     useShootSession();
 
   const [isCameraReady, setIsCameraReady] = useState(false);
+  const [isCheckingCameraPermission, setIsCheckingCameraPermission] =
+    useState(true);
   const [shooting, setShooting] = useState<ShootingState>({
     isShooting: false,
     countdown: null,
@@ -38,6 +40,7 @@ export function useCaptureFlow() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const shutterAudioRef = useRef<HTMLAudioElement | null>(null);
+  const autoStartAttemptedRef = useRef(false);
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const recordedChunksRef = useRef<Blob[]>([]);
@@ -113,6 +116,43 @@ export function useCaptureFlow() {
       });
     }
   }, [cameraFacingMode, setNotice, stopStream]);
+
+  useEffect(() => {
+    if (!frameId || isCameraReady || autoStartAttemptedRef.current) {
+      setIsCheckingCameraPermission(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const startIfCameraAlreadyAllowed = async () => {
+      if (typeof navigator === "undefined" || !navigator.permissions?.query) {
+        if (!cancelled) setIsCheckingCameraPermission(false);
+        return;
+      }
+
+      try {
+        const permission = await navigator.permissions.query({
+          name: "camera" as PermissionName,
+        });
+
+        if (!cancelled && permission.state === "granted") {
+          autoStartAttemptedRef.current = true;
+          await startCamera();
+        }
+      } catch {
+        // 권한 API가 카메라 조회를 지원하지 않는 브라우저에서는 수동 버튼 흐름 유지
+      } finally {
+        if (!cancelled) setIsCheckingCameraPermission(false);
+      }
+    };
+
+    void startIfCameraAlreadyAllowed();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [frameId, isCameraReady, startCamera]);
 
   // 언마운트 시 정리
   useEffect(() => {
@@ -306,6 +346,7 @@ export function useCaptureFlow() {
     shutterAudioRef,
 
     isCameraReady,
+    isCheckingCameraPermission,
     isShooting: shooting.isShooting,
     countdown: shooting.countdown,
     shotCount,

--- a/apps/web/app/shoot/capture/page.tsx
+++ b/apps/web/app/shoot/capture/page.tsx
@@ -3,6 +3,7 @@
 import { RefreshCw } from "lucide-react";
 import { ThemeOverlaySvg } from "@/components/theme/editor/ThemeOverlaySvg";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { StepProgress } from "@/components/layout/StepProgress";
 import { FRAME_LAYOUTS } from "@/constants/frameLayouts";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
 import { useGuestTrialStore } from "@/lib/guestTrialStore";
@@ -15,17 +16,16 @@ export default function CapturePage() {
     canvasRef,
     shutterAudioRef,
     isCameraReady,
+    isCheckingCameraPermission,
     isShooting,
     countdown,
     shotCount,
-    remainingShots,
     startCamera,
     startShooting,
     handleShootNow,
     switchCamera,
     canFlipCamera,
     MAX_SHOTS,
-    MAX_COUNT,
   } = useCaptureFlow();
 
   const { frameId, remoteFrameId } = useShootSession();
@@ -48,20 +48,15 @@ export default function CapturePage() {
       />
       <div className="mx-auto flex w-full max-w-md flex-col gap-5">
         <PageHeader
-          title="사진 촬영 · 8장 자동 촬영"
           backHref="/shoot"
           backLabel="프레임 다시 선택"
           brandHref={accessMode === "guest" ? "/shoot" : "/home"}
-          description={
-            accessMode === "guest"
-              ? "비회원 체험에서는 촬영 후 이미지 다운로드까지만 바로 이용할 수 있어요."
-              : undefined
-          }
         />
+        <StepProgress current={2} total={4} label="사진 촬영" />
 
         <section className="flex flex-col gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-3">
           <div className="flex items-center justify-between text-[11px] text-zinc-400">
-            <span>2단계 · 카메라 촬영 {isShooting && "· 자동 촬영 중"}</span>
+            <span>사진과 영상을 함께 촬영해요</span>
             <span className="rounded-full border border-zinc-700 px-2 py-0.5">
               {shotCount} / {MAX_SHOTS}장 촬영됨
             </span>
@@ -108,30 +103,23 @@ export default function CapturePage() {
             {isShooting && countdown !== null ? (
               <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/40">
                 <div className="pointer-events-auto flex flex-col items-center gap-2">
-                  <div className="flex h-16 w-16 items-center justify-center rounded-full border border-[color:var(--hc-primary)] text-2xl font-semibold">
+                  <div className="flex h-16 w-16 items-center justify-center rounded-full border border-white text-2xl font-semibold text-white">
                     {countdown}
                   </div>
-                  <span className="text-xs text-zinc-200">다음 촬영까지 남은 시간</span>
-                  <span className="text-[11px] text-zinc-400">남은 사진 {remainingShots}장</span>
+                  <span className="text-[11px] font-semibold text-white">
+                    {shotCount}/{MAX_SHOTS}
+                  </span>
                   <button
                     type="button"
                     onClick={handleShootNow}
-                    className="hc-button-primary mt-2 rounded-full px-3 py-1 text-[11px] font-semibold"
+                    className="mt-2 rounded-full bg-white px-3 py-1 text-[11px] font-semibold text-[color:var(--hc-primary)] hover:bg-zinc-100"
                   >
-                    지금 촬영
+                    바로 촬영
                   </button>
                 </div>
               </div>
             ) : null}
 
-            {!isShooting ? (
-              <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-black/40">
-                <p className="px-4 text-center text-[11px] text-zinc-200">
-                  카메라를 켜고 <span className="font-semibold">&quot;8장 자동 촬영 시작&quot;</span>{" "}
-                  버튼을 누르면 {MAX_COUNT}초 간격으로 사진과 영상을 함께 촬영해요.
-                </p>
-              </div>
-            ) : null}
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2">
@@ -156,20 +144,22 @@ export default function CapturePage() {
                   </span>
                 </button>
               ) : null}
-              <button
-                type="button"
-                onClick={() => void startCamera()}
-                className="rounded-full border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-zinc-800"
-              >
-                카메라 켜기
-              </button>
+              {!isCameraReady && !isCheckingCameraPermission ? (
+                <button
+                  type="button"
+                  onClick={() => void startCamera()}
+                  className="rounded-full border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-[11px] text-zinc-200 hover:bg-zinc-800"
+                >
+                  카메라 켜기
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={startShooting}
                 disabled={!isCameraReady || isShooting}
                 className="hc-button-primary rounded-full px-3 py-1.5 text-[11px] font-semibold disabled:cursor-not-allowed disabled:opacity-40"
               >
-                {isShooting ? "촬영 중..." : "8장 자동 촬영 시작"}
+                {isShooting ? "촬영 중..." : "촬영 시작"}
               </button>
             </div>
           </div>

--- a/apps/web/app/shoot/page.tsx
+++ b/apps/web/app/shoot/page.tsx
@@ -22,8 +22,8 @@ function ShootPageContent() {
   const { frames, isLoading, error, refresh } = useMyFrames();
   const accessMode = useGuestTrialStore((state) => state.accessMode);
 
-  const [manualSelectedFrameId, setManualSelectedFrameId] = useState<FrameId>(
-    queriedFrameId ?? "classic-4",
+  const [manualSelectedFrameId, setManualSelectedFrameId] = useState<FrameId | null>(
+    queriedFrameId ?? null,
   );
   const [selectedRemoteFrameId, setSelectedRemoteFrameId] = useState<number | null>(
     Number.isFinite(queriedRemoteFrameId) && queriedRemoteFrameId > 0
@@ -48,6 +48,8 @@ function ShootPageContent() {
     : manualSelectedFrameId;
 
   const handleConfirmFrame = () => {
+    if (!selectedFrameId) return;
+
     setFrameId(selectedFrameId);
     setRemoteFrameId(selectedRemoteFrameId);
     router.push("/shoot/capture");
@@ -60,11 +62,6 @@ function ShootPageContent() {
           backHref={accessMode === "guest" ? "/" : "/home"}
           backLabel={accessMode === "guest" ? "처음으로" : "홈으로"}
           brandHref={accessMode === "guest" ? "/shoot" : "/home"}
-          description={
-            accessMode === "guest"
-              ? "비회원 체험에서는 촬영과 이미지 다운로드만 할 수 있어요."
-              : "촬영할 프레임을 먼저 골라 주세요."
-          }
         />
         <StepProgress current={1} total={4} label="프레임 선택" />
 
@@ -75,7 +72,8 @@ function ShootPageContent() {
             setSelectedRemoteFrameId(null);
           }}
           onConfirm={handleConfirmFrame}
-          confirmLabel="촬영 시작하기"
+          confirmDisabled={!selectedFrameId}
+          confirmLabel={selectedFrameId ? "촬영 시작하기" : "촬영할 프레임을 선택해주세요"}
         />
 
         {accessMode === "member" ? (

--- a/apps/web/app/shoot/select/page.tsx
+++ b/apps/web/app/shoot/select/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { FrameOutputOptionsPanel } from "@/components/frame/FrameOutputOptionsPanel";
 import { FrameSelectPanel } from "@/components/frame/FrameSelectPanel";
 import { PageHeader } from "@/components/layout/PageHeader";
+import { StepProgress } from "@/components/layout/StepProgress";
 import { useGuestTrialStore } from "@/lib/guestTrialStore";
 import { useRemoteFrameTheme } from "@/hooks/useRemoteFrameTheme";
 import { useShootSession } from "@/lib/shootSessionStore";
@@ -75,16 +76,11 @@ export default function ShootSelectPage() {
     <main className="hc-page-app min-h-dvh px-4 py-6 text-[color:var(--hc-text)]">
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
         <PageHeader
-          title="사진 선택"
           backHref="/shoot/capture"
           backLabel="다시 촬영"
           brandHref={guestMode ? "/shoot" : "/home"}
-          description={
-            guestMode
-              ? "마음에 드는 사진 4장을 고르고 다운로드용 이미지를 준비해 보세요."
-              : "마음에 드는 사진 4장을 고르고 출력 옵션을 정해 주세요."
-          }
         />
+        <StepProgress current={3} total={4} label="사진 선택" />
 
         <FrameSelectPanel
           frameId={frameId ?? null}
@@ -92,6 +88,7 @@ export default function ShootSelectPage() {
           selectedIndexes={selectedIndexes}
           maxSelect={4}
           emptyStateText="촬영한 사진이 없어요. 다시 촬영해 주세요."
+          incompleteButtonLabel="4장을 골라주세요"
           nextButtonLabel="다음 단계로"
           onToggleSelect={toggleSelect}
           onReset={reset}

--- a/apps/web/components/frame/FrameOutputOptionsPanel.tsx
+++ b/apps/web/components/frame/FrameOutputOptionsPanel.tsx
@@ -40,9 +40,6 @@ export function FrameOutputOptionsPanel({
         <div className="flex flex-col gap-2">
           <div>
             <h2 className="text-xs font-medium text-zinc-200">출력 옵션</h2>
-            <p className="mt-1 text-[11px] text-zinc-500">
-              다음 단계에서 이미지와 동영상을 준비할 때 이 설정이 그대로 반영돼요.
-            </p>
           </div>
 
           {hasCustomFrame ? (
@@ -123,11 +120,7 @@ export function FrameOutputOptionsPanel({
           </div>
         </div>
 
-        {guestMode ? (
-          <div className="hc-feedback rounded-xl border px-3 py-2 text-[11px]">
-            비회원 체험에서는 이미지 결과만 다운로드할 수 있어요.
-          </div>
-        ) : (
+        {guestMode ? null : (
           <div className="flex flex-col gap-2">
             <label className="inline-flex items-start gap-2 text-[11px] text-zinc-200">
               <input

--- a/apps/web/components/frame/FramePicker.tsx
+++ b/apps/web/components/frame/FramePicker.tsx
@@ -13,9 +13,10 @@ const PREVIEW_BORDER_COLOR = "var(--hc-frame-picker-preview-outer)";
 const PREVIEW_SLOT_COLOR = "var(--hc-frame-picker-preview-inner)";
 
 type FramePickerProps = {
-  selectedFrameId: FrameId;
+  selectedFrameId: FrameId | null;
   onChangeSelected: (id: FrameId) => void;
   onConfirm: () => void;
+  confirmDisabled?: boolean;
   confirmLabel?: string;
 };
 
@@ -23,6 +24,7 @@ export function FramePicker({
   selectedFrameId,
   onChangeSelected,
   onConfirm,
+  confirmDisabled = false,
   confirmLabel = "선택한 프레임으로 진행하기",
 }: FramePickerProps) {
   return (
@@ -73,8 +75,9 @@ export function FramePicker({
       <div className="mt-2 flex justify-end">
         <button
           type="button"
+          disabled={confirmDisabled}
           onClick={onConfirm}
-          className="hc-button-primary rounded-full px-5 py-2.5 text-xs font-semibold"
+          className="hc-button-primary rounded-full px-5 py-2.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
         >
           {confirmLabel}
         </button>

--- a/apps/web/components/frame/FrameSelectPanel.tsx
+++ b/apps/web/components/frame/FrameSelectPanel.tsx
@@ -15,6 +15,7 @@ type FrameSelectPanelProps = {
   selectedIndexes: (number | null)[];
   maxSelect: number;
   emptyStateText?: string;
+  incompleteButtonLabel?: string;
   nextButtonLabel: string;
   onToggleSelect: (index: number) => void;
   onReset: () => void;
@@ -32,6 +33,7 @@ export function FrameSelectPanel({
   selectedIndexes,
   maxSelect,
   emptyStateText = "선택 가능한 사진이나 영상이 아직 없어요.",
+  incompleteButtonLabel,
   nextButtonLabel,
   onToggleSelect,
   onReset,
@@ -121,7 +123,7 @@ export function FrameSelectPanel({
                       />
                     )}
 
-                    <span className="pointer-events-none absolute left-1 top-1 rounded-full bg-black/70 px-1.5 py-0.5 text-[9px] text-zinc-200">
+                    <span className="pointer-events-none absolute left-1 top-1 rounded-full border border-black/10 bg-white px-1.5 py-0.5 text-[9px] font-bold text-black shadow-sm">
                       #{index + 1}
                     </span>
 
@@ -153,7 +155,7 @@ export function FrameSelectPanel({
             onClick={onNext}
             className="hc-button-primary rounded-full px-3 py-1.5 text-[11px] font-semibold disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {nextButtonLabel}
+            {canProceed ? nextButtonLabel : incompleteButtonLabel ?? nextButtonLabel}
           </button>
         </section>
       </section>

--- a/apps/web/components/frame/SavedFramesSection.tsx
+++ b/apps/web/components/frame/SavedFramesSection.tsx
@@ -11,7 +11,7 @@ type SavedFramesSectionProps = {
   title: string;
   description?: string;
   emptyText: string;
-  selectedFrameId: FrameId;
+  selectedFrameId: FrameId | null;
   frames: RemoteFrame[];
   isLoading: boolean;
   error: string | null;
@@ -41,7 +41,10 @@ export function SavedFramesSection({
   idleStatusText = "클릭해서 선택",
 }: SavedFramesSectionProps) {
   const matchingFrames = useMemo(
-    () => frames.filter((frame) => matchesFrameType(selectedFrameId, frame.frameType)),
+    () =>
+      selectedFrameId
+        ? frames.filter((frame) => matchesFrameType(selectedFrameId, frame.frameType))
+        : frames,
     [frames, selectedFrameId],
   );
 

--- a/apps/web/components/theme/ColorThemePreferencePanel.tsx
+++ b/apps/web/components/theme/ColorThemePreferencePanel.tsx
@@ -8,7 +8,6 @@ import {
   persistColorThemePreference,
   readStoredColorThemePreference,
   subscribeSystemColorTheme,
-  type ColorTheme,
   type ColorThemePreference,
 } from "@/lib/colorTheme";
 
@@ -23,7 +22,7 @@ const THEME_META: Record<
   system: {
     description: "기기 설정이 바뀌면 하루컷 화면도 함께 바뀌어요.",
     icon: Monitor,
-    label: "시스템",
+    label: "기본값",
   },
   light: {
     description: "밝은 화면으로 고정해요.",
@@ -40,15 +39,13 @@ const THEME_META: Record<
 export function ColorThemePreferencePanel() {
   const [preference, setPreference] =
     useState<ColorThemePreference>("system");
-  const [effectiveTheme, setEffectiveTheme] = useState<ColorTheme>("light");
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     const storedPreference = readStoredColorThemePreference();
-    const nextTheme = applyPreferredColorTheme(storedPreference);
+    applyPreferredColorTheme(storedPreference);
     const frame = window.requestAnimationFrame(() => {
       setPreference(storedPreference);
-      setEffectiveTheme(nextTheme);
       setMounted(true);
     });
 
@@ -60,18 +57,16 @@ export function ColorThemePreferencePanel() {
       return;
     }
 
-    return subscribeSystemColorTheme((nextTheme) => {
+    return subscribeSystemColorTheme(() => {
       applyPreferredColorTheme("system");
-      setEffectiveTheme(nextTheme);
     });
   }, [preference]);
 
   const handlePreferenceChange = (nextPreference: ColorThemePreference) => {
     persistColorThemePreference(nextPreference);
-    const nextTheme = applyPreferredColorTheme(nextPreference);
+    applyPreferredColorTheme(nextPreference);
 
     setPreference(nextPreference);
-    setEffectiveTheme(nextTheme);
   };
 
   return (
@@ -81,9 +76,6 @@ export function ColorThemePreferencePanel() {
           Display
         </p>
         <h2 className="mt-2 text-sm font-semibold">화면 모드</h2>
-        <p className="mt-1 text-[11px] leading-5 text-[color:var(--hc-muted)]">
-          기본값은 시스템 설정을 따르고, 여기에서 원하는 모드로 고정할 수 있어요.
-        </p>
       </div>
 
       <div className="mt-3 grid gap-2">
@@ -116,9 +108,6 @@ export function ColorThemePreferencePanel() {
                 <span className="min-w-0">
                   <span className="block text-[12px] font-semibold">
                     {meta.label}
-                    {item === "system" && mounted
-                      ? ` · 현재 ${effectiveTheme === "dark" ? "다크" : "라이트"}`
-                      : ""}
                   </span>
                   <span className="mt-0.5 block text-[11px] leading-4 text-[color:var(--hc-muted)]">
                     {meta.description}


### PR DESCRIPTION
## 요약
- 촬영 진입 시 기본 프레임 자동 선택 제거 및 프레임 선택 필수화
- 카메라 권한 확인, 촬영 단계, 사진 선택 단계의 버튼 상태와 문구 정리
- 홈 현재 날짜 표시와 자정 갱신 처리 추가
- 마이페이지/테마 설정 문구와 라벨 정리

## 커밋
- feat: 촬영 프레임 선택 흐름 구현
- feat: 홈 계정 테마 화면 정리

## 검증
- `pnpm test:web`
- `pnpm build:web`
- `pnpm lint:mobile`
- `pnpm typecheck:mobile`

Closes #286