### PR TITLE
feat(mobile): 모바일-웹 기능 동등성 작업 (결과 톤 필터, 인증 검증, 소셜 로그인)

### DIFF
--- a/apps/mobile/components/harucut/frame.tsx
+++ b/apps/mobile/components/harucut/frame.tsx
@@ -20,6 +20,7 @@ import {
   FRAME_CATALOG,
   type FrameId,
   type MediaAsset,
+  type OutputTone,
   type SavedFrame,
   type ThemeEditorComponent,
 } from '@/constants/harucut-data';
@@ -114,6 +115,23 @@ function toPercent(value: number, total: number): DimensionValue {
   return `${(value / total) * 100}%`;
 }
 
+type RnFilter = NonNullable<ViewStyle['filter']>;
+
+// 웹 FOURCUT_FILTERS의 CSS 필터를 React Native filter 스타일로 옮긴 값입니다.
+// (RN 0.76+ New Architecture에서 brightness/contrast/saturate/grayscale/blur 지원)
+function getOutputToneFilter(tone: OutputTone | undefined): RnFilter | undefined {
+  switch (tone) {
+    case 'B&W':
+      return [{ grayscale: 1 }];
+    case 'BRIGHT':
+      return [{ brightness: 1.14 }, { saturate: 1.04 }, { contrast: 1.02 }];
+    case 'SOFT':
+      return [{ brightness: 1.08 }, { contrast: 0.94 }, { saturate: 0.92 }, { blur: 0.45 }];
+    default:
+      return undefined;
+  }
+}
+
 function useFrameStyles() {
   const { colors, isDark } = useHarucutTheme();
 
@@ -133,6 +151,7 @@ export function FramePreview({
   onTransformComponent,
   slotColor,
   style,
+  tone,
 }: {
   accentColor?: string;
   activeComponentId?: string | null;
@@ -146,6 +165,7 @@ export function FramePreview({
   onTransformComponent?: (id: string, transform: ThemeComponentTransform) => void;
   slotColor?: string;
   style?: StyleProp<ViewStyle>;
+  tone?: OutputTone;
 }) {
   const { colors, isDark } = useHarucutTheme();
   const styles = useFrameStyles();
@@ -157,6 +177,7 @@ export function FramePreview({
   const resolvedAccent = accentColor ?? colors.primary;
   const resolvedBackground = backgroundColor ?? accentColor ?? pickerPreviewColors.outer;
   const resolvedSlotColor = slotColor ?? pickerPreviewColors.slot;
+  const toneFilter = getOutputToneFilter(tone);
 
   return (
     <View
@@ -191,6 +212,7 @@ export function FramePreview({
                 top: toPercent(slot.y, layout.totalHeight),
                 width: toPercent(slot.width, layout.totalWidth),
               },
+              toneFilter ? { filter: toneFilter } : null,
             ]}>
             {currentMedia ? (
               <>

--- a/apps/mobile/constants/harucut-data.ts
+++ b/apps/mobile/constants/harucut-data.ts
@@ -1,6 +1,7 @@
 export type FrameId = 'classic-4' | 'grid-4' | 'polaroid-4' | 'wide-4';
 export type MediaKind = 'image' | 'video';
-export type OutputTone = '기본' | '선명한 블루' | '소프트';
+// 웹 lib/frameFilters.ts와 동일한 4종 필터 (기본/흑백/밝게/뽀샤시)
+export type OutputTone = 'NONE' | 'B&W' | 'BRIGHT' | 'SOFT';
 
 export type MediaAsset = {
   id: string;
@@ -211,7 +212,19 @@ export const FRAME_BORDER_OPTIONS = [
   { label: '아이스 블루', value: '#C7DCFF' },
 ] as const;
 
-export const OUTPUT_TONE_OPTIONS: OutputTone[] = ['기본', '선명한 블루', '소프트'];
+export type OutputToneOption = {
+  description: string;
+  id: OutputTone;
+  label: string;
+};
+
+// 웹 FOURCUT_FILTERS와 라벨/설명/순서를 동일하게 맞춥니다.
+export const OUTPUT_TONE_OPTIONS: OutputToneOption[] = [
+  { description: '원본 톤 그대로', id: 'NONE', label: '기본' },
+  { description: '차분한 필름 톤', id: 'B&W', label: '흑백' },
+  { description: '밝고 또렷하게', id: 'BRIGHT', label: '밝게' },
+  { description: '은은하고 부드럽게', id: 'SOFT', label: '뽀샤시' },
+];
 
 export const BACKGROUND_SWATCHES = [
   { label: '화이트', value: '#FFFFFF' },

--- a/apps/mobile/lib/auth-validation.ts
+++ b/apps/mobile/lib/auth-validation.ts
@@ -1,0 +1,35 @@
+// 웹 apps/web/lib/authValidation.ts와 동일한 규칙/문구를 모바일로 옮긴 검증 유틸.
+
+// 이메일 형식(기본)
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// 비밀번호 규칙: 8~16자, 영문/숫자/일부 특수문자
+const PASSWORD_REGEX = /^[A-Za-z0-9!@#$%^&*()\-_=+\[\]{};:,.?]{8,16}$/;
+
+// 닉네임 규칙: 2~20자, 한글/영문/숫자/공백/_/-
+const USERNAME_REGEX = /^[\p{L}\p{N}_\- ]{2,20}$/u;
+
+export function validateEmail(email: string): string | null {
+  const value = email.trim();
+  if (!value) return '이메일을 입력해 주세요.';
+  if (!EMAIL_REGEX.test(value)) return '이메일 형식이 올바르지 않습니다.';
+  return null;
+}
+
+export function validatePassword(password: string): string | null {
+  if (!password) return '비밀번호를 입력해 주세요.';
+  if (password.length < 8) return '비밀번호는 최소 8자 이상이어야 합니다.';
+  if (!PASSWORD_REGEX.test(password)) {
+    return '영문, 숫자, 일부 특수문자(!@#$%^&* 등)만 사용할 수 있습니다.';
+  }
+  return null;
+}
+
+export function validateUsername(username: string): string | null {
+  const value = username.trim();
+  if (!value) return '닉네임을 입력해 주세요.';
+  if (!USERNAME_REGEX.test(value)) {
+    return '닉네임은 2~20자의 한글/영문/숫자, 공백, _, - 만 사용할 수 있습니다.';
+  }
+  return null;
+}

--- a/apps/mobile/lib/media-download.ts
+++ b/apps/mobile/lib/media-download.ts
@@ -1,0 +1,64 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import * as MediaLibrary from 'expo-media-library';
+import { Share } from 'react-native';
+
+// 웹의 다운로드(원격 download-url → 파일 저장)와 공유(링크 공유)를 모바일로 옮긴 유틸.
+// - 다운로드: 원격 URL을 캐시에 받은 뒤 기기 사진 보관함에 저장
+// - 공유: 시스템 공유 시트로 링크 전달
+
+export type MediaDownloadResult =
+  | { ok: true }
+  | { ok: false; reason: 'failed' | 'no-url' | 'permission-denied' };
+
+function inferExtension(url: string, kind: 'image' | 'photo' | 'video') {
+  const match = /\.([a-zA-Z0-9]{2,4})(?:[?#]|$)/.exec(url);
+  if (match) {
+    return match[1].toLowerCase();
+  }
+
+  return kind === 'video' ? 'mp4' : 'jpg';
+}
+
+function sanitizeFilename(value: string) {
+  const cleaned = value
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return cleaned || '하루컷';
+}
+
+export async function saveRemoteMediaToLibrary(
+  url: string | undefined,
+  title: string,
+  kind: 'image' | 'photo' | 'video' = 'photo',
+): Promise<MediaDownloadResult> {
+  if (!url) {
+    return { ok: false, reason: 'no-url' };
+  }
+
+  const permission = await MediaLibrary.requestPermissionsAsync();
+
+  if (!permission.granted) {
+    return { ok: false, reason: 'permission-denied' };
+  }
+
+  try {
+    const extension = inferExtension(url, kind);
+    const target = `${FileSystem.cacheDirectory ?? ''}${sanitizeFilename(title)}.${extension}`;
+    const { uri } = await FileSystem.downloadAsync(url, target);
+    await MediaLibrary.saveToLibraryAsync(uri);
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: 'failed' };
+  }
+}
+
+export async function shareMediaLink(title: string, url: string | undefined) {
+  if (!url) {
+    return;
+  }
+
+  await Share.share({ message: `${title}\n${url}`, url });
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "expo-camera": "~55.0.17",
     "expo-constants": "~55.0.15",
     "expo-dev-client": "~55.0.32",
+    "expo-file-system": "~55.0.22",
     "expo-font": "~55.0.6",
     "expo-haptics": "~55.0.14",
     "expo-image": "~55.0.9",

--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -11,6 +11,7 @@ import type { HarucutThemePreference } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { changePassword, exitAccount, logout } from '@/lib/auth-api';
 import { getApiErrorMessage } from '@/lib/api-client';
+import { validatePassword } from '@/lib/auth-validation';
 import { uploadLocalFileWithPresigned } from '@/lib/file-storage-api';
 import { saveRemoteMediaToLibrary, shareMediaLink } from '@/lib/media-download';
 import { updateProfileImage, updateUsername } from '@/lib/user-api';
@@ -577,8 +578,19 @@ export function MyPageScreen() {
   };
 
   const handleChangePassword = async () => {
-    if (!oldPassword || !newPassword || newPassword !== confirmPassword) {
-      showError('비밀번호 변경 실패', '현재 비밀번호와 새 비밀번호 확인 값을 다시 확인해 주세요.');
+    if (!oldPassword) {
+      showError('비밀번호 변경 실패', '현재 비밀번호를 입력해 주세요.');
+      return;
+    }
+
+    const passwordError = validatePassword(newPassword);
+    if (passwordError) {
+      showError('비밀번호 변경 실패', passwordError);
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      showError('비밀번호 변경 실패', '새 비밀번호 확인 값이 일치하지 않아요.');
       return;
     }
 

--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -2,7 +2,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
-import { Image, Pressable, Share, StyleSheet, Text, View } from 'react-native';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { FramePreview } from '@/components/harucut/frame';
 import { ActionButton, AppScrollView, FormField, PageHeader, Pill, SurfaceCard } from '@/components/harucut/ui';
@@ -12,7 +12,9 @@ import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { changePassword, exitAccount, logout } from '@/lib/auth-api';
 import { getApiErrorMessage } from '@/lib/api-client';
 import { uploadLocalFileWithPresigned } from '@/lib/file-storage-api';
+import { saveRemoteMediaToLibrary, shareMediaLink } from '@/lib/media-download';
 import { updateProfileImage, updateUsername } from '@/lib/user-api';
+import { getMediaDownloadUrl } from '@/lib/user-media-api';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 type HarucutThemeColors = ReturnType<typeof useHarucutTheme>['colors'];
@@ -65,16 +67,16 @@ function formatDate(value: string) {
   });
 }
 
-async function sharePreview(item: HistoryItem) {
-  const uri = historyPreviewUri(item);
-  if (!uri) {
-    return;
+async function resolveHistoryMediaUrl(item: HistoryItem) {
+  if (item.mediaId) {
+    try {
+      return await getMediaDownloadUrl(item.mediaId);
+    } catch {
+      // 서명 URL 재발급 실패 시 미리보기 URL로 대체합니다.
+    }
   }
 
-  await Share.share({
-    message: `${item.title}\n${uri}`,
-    url: uri,
-  });
+  return historyPreviewUri(item);
 }
 
 function formatCurrentDate() {
@@ -299,6 +301,63 @@ export function HistoryScreen() {
   const [search, setSearch] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const handleDownloadItem = async (item: HistoryItem) => {
+    setBusyId(item.id);
+
+    try {
+      const url = await resolveHistoryMediaUrl(item);
+      const result = await saveRemoteMediaToLibrary(url, item.title, item.kind);
+
+      if (result.ok) {
+        showNotice({
+          actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+          eyebrow: 'DOWNLOAD',
+          icon: 'checkmark-circle-outline',
+          message: '사진 보관함에 저장했어요.',
+          title: '다운로드 완료',
+        });
+        return;
+      }
+
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'DOWNLOAD ERROR',
+        icon: 'warning-outline',
+        message:
+          result.reason === 'permission-denied'
+            ? '사진 보관함 권한이 필요해요. 권한을 허용한 뒤 다시 시도해 주세요.'
+            : '파일을 내려받지 못했어요. 잠시 후 다시 시도해 주세요.',
+        title: '다운로드 실패',
+      });
+    } catch (error) {
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'DOWNLOAD ERROR',
+        icon: 'warning-outline',
+        message: getApiErrorMessage(error, '파일을 내려받지 못했어요.'),
+        title: '다운로드 실패',
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleShareItem = async (item: HistoryItem) => {
+    try {
+      const url = await resolveHistoryMediaUrl(item);
+      await shareMediaLink(item.title, url);
+    } catch (error) {
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'SHARE ERROR',
+        icon: 'warning-outline',
+        message: getApiErrorMessage(error, '공유 링크를 준비하지 못했어요.'),
+        title: '공유 실패',
+      });
+    }
+  };
 
   const filteredItems = useMemo(() => {
     return historyItems.filter((item) => {
@@ -397,14 +456,14 @@ export function HistoryScreen() {
                 <View style={styles.actionWrap}>
                   <ActionButton
                     icon={<Ionicons color="#FFFFFF" name="download-outline" size={15} />}
-                    label="다운로드"
-                    onPress={() => sharePreview(item)}
+                    label={busyId === item.id ? '다운로드 중...' : '다운로드'}
+                    onPress={() => void handleDownloadItem(item)}
                     style={{ flex: 1, minHeight: 42 }}
                   />
                   <ActionButton
                     icon={<Ionicons color={colors.text} name="share-social-outline" size={15} />}
                     label="공유하기"
-                    onPress={() => sharePreview(item)}
+                    onPress={() => void handleShareItem(item)}
                     style={{ flex: 1, minHeight: 42 }}
                     variant="secondary"
                   />

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -8,6 +8,7 @@ import { HERO_IMAGE_SOURCE, LOGIN_FIELDS, SIGNUP_FIELDS } from '@/constants/haru
 import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, SurfaceCard } from '@/components/harucut/ui';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { getApiErrorMessage } from '@/lib/api-client';
+import { validateEmail, validatePassword, validateUsername } from '@/lib/auth-validation';
 import {
   loginWithEmail,
   reactivateAccount,
@@ -195,8 +196,14 @@ export function LoginScreen() {
   const [remember, setRemember] = useState(true);
 
   const handleLogin = async () => {
-    if (!form.email.trim() || !form.password) {
-      setError('이메일과 비밀번호를 입력해 주세요.');
+    const emailError = validateEmail(form.email);
+    if (emailError) {
+      setError(emailError);
+      return;
+    }
+
+    if (!form.password) {
+      setError('비밀번호를 입력해 주세요.');
       return;
     }
 
@@ -301,8 +308,9 @@ export function SignupScreen() {
   }, [codeExpiresAt, verified]);
 
   const handleSendCode = async () => {
-    if (!email.trim()) {
-      setError('이메일을 입력해 주세요.');
+    const emailError = validateEmail(email);
+    if (emailError) {
+      setError(emailError);
       return;
     }
 
@@ -344,8 +352,15 @@ export function SignupScreen() {
       return;
     }
 
-    if (!form.username.trim() || !form.password) {
-      setError('닉네임과 비밀번호를 입력해 주세요.');
+    const usernameError = validateUsername(form.username);
+    if (usernameError) {
+      setError(usernameError);
+      return;
+    }
+
+    const passwordError = validatePassword(form.password);
+    if (passwordError) {
+      setError(passwordError);
       return;
     }
 
@@ -392,6 +407,8 @@ export function SignupScreen() {
           onChangeText={(value) => {
             setEmail(value);
             setVerified(false);
+            setCode('');
+            setCodeExpiresAt(null);
           }}
           placeholder="example@harucut.com"
           value={email}
@@ -468,10 +485,12 @@ export function ForgotPasswordScreen() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [resetToken, setResetToken] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [codeRequested, setCodeRequested] = useState(false);
 
   const handleRequestCode = async () => {
-    if (!email.trim()) {
-      setError('이메일을 입력해 주세요.');
+    const emailError = validateEmail(email);
+    if (emailError) {
+      setError(emailError);
       return;
     }
 
@@ -480,6 +499,7 @@ export function ForgotPasswordScreen() {
 
     try {
       await requestPasswordResetCode(email.trim());
+      setCodeRequested(true);
     } catch (requestError) {
       setError(getApiErrorMessage(requestError, '인증 코드를 보내지 못했어요.'));
     } finally {
@@ -514,7 +534,13 @@ export function ForgotPasswordScreen() {
       return;
     }
 
-    if (!newPassword.trim() || newPassword !== confirmPassword) {
+    const passwordError = validatePassword(newPassword);
+    if (passwordError) {
+      setError(passwordError);
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
       setError('새 비밀번호와 확인 값이 일치하지 않아요.');
       return;
     }
@@ -538,7 +564,13 @@ export function ForgotPasswordScreen() {
       title="비밀번호 재설정">
       {step === 'VERIFY_CODE' ? (
         <SurfaceCard style={{ gap: 14 }}>
-          <FormField label="이메일" onChangeText={setEmail} placeholder="example@harucut.com" value={email} />
+          <FormField
+            editable={!codeRequested}
+            label="이메일"
+            onChangeText={setEmail}
+            placeholder="example@harucut.com"
+            value={email}
+          />
           <FormField label="인증 코드" onChangeText={setCode} placeholder="인증 코드 입력" value={code} />
           <View style={styles.heroActions}>
             <ActionButton

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -1,5 +1,7 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import * as Linking from 'expo-linking';
 import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import { useEffect, useMemo, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,9 +9,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { HERO_IMAGE_SOURCE, LOGIN_FIELDS, SIGNUP_FIELDS } from '@/constants/harucut-data';
 import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, SurfaceCard } from '@/components/harucut/ui';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
-import { getApiErrorMessage } from '@/lib/api-client';
+import { getApiConfig, getApiErrorMessage } from '@/lib/api-client';
 import { validateEmail, validatePassword, validateUsername } from '@/lib/auth-validation';
 import {
+  getAuthStatus,
   loginWithEmail,
   reactivateAccount,
   requestPasswordResetCode,
@@ -22,6 +25,7 @@ import {
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 type HarucutThemeColors = ReturnType<typeof useHarucutTheme>['colors'];
+type SocialProvider = 'kakao' | 'naver';
 
 function usePublicScreenTheme() {
   const { colors, isDark } = useHarucutTheme();
@@ -64,6 +68,52 @@ function AuthShell({
 
 function SocialButtons() {
   const { styles } = usePublicScreenTheme();
+  const router = useRouter();
+  const bootstrapMemberSession = useHarucutStore((state) => state.bootstrapMemberSession);
+  const showNotice = useHarucutStore((state) => state.showNotice);
+  const [pending, setPending] = useState<SocialProvider | null>(null);
+
+  // 웹은 `${backend}/oauth2/authorization/{provider}`로 이동 후 쿠키 세션을 받습니다.
+  // 모바일은 시스템 인증 세션(expo-web-browser)으로 동일 엔드포인트를 열고,
+  // `harucut://oauth2/callback` 딥링크로 복귀한 뒤 세션 상태를 확인합니다.
+  // 백엔드가 해당 리다이렉트 스킴과 앱 쿠키/토큰 핸드오프를 지원해야 완결됩니다.
+  const handleSocialLogin = async (provider: SocialProvider) => {
+    if (pending) {
+      return;
+    }
+
+    setPending(provider);
+
+    try {
+      const { baseUrl } = getApiConfig();
+      const returnUrl = Linking.createURL('oauth2/callback');
+      const authUrl = `${baseUrl}/oauth2/authorization/${provider}`;
+      const result = await WebBrowser.openAuthSessionAsync(authUrl, returnUrl);
+
+      if (result.type !== 'success') {
+        return;
+      }
+
+      const status = await getAuthStatus();
+
+      if (status?.userStatus === 'DELETED_REQUESTED') {
+        await reactivateAccount();
+      }
+
+      await bootstrapMemberSession();
+      router.replace('/home' as never);
+    } catch (error) {
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'SOCIAL LOGIN',
+        icon: 'warning-outline',
+        message: getApiErrorMessage(error, '소셜 로그인을 완료하지 못했어요. 잠시 후 다시 시도해 주세요.'),
+        title: '소셜 로그인 실패',
+      });
+    } finally {
+      setPending(null);
+    }
+  };
 
   return (
     <View style={{ gap: 10 }}>
@@ -72,8 +122,16 @@ function SocialButtons() {
         <Text style={styles.socialText}>또는 소셜 계정으로 계속하기</Text>
         <View style={styles.socialLine} />
       </View>
-      <SocialBrandButton label="카카오 로그인" onPress={() => undefined} provider="kakao" />
-      <SocialBrandButton label="네이버 로그인" onPress={() => undefined} provider="naver" />
+      <SocialBrandButton
+        label={pending === 'kakao' ? '카카오 로그인 중...' : '카카오 로그인'}
+        onPress={() => void handleSocialLogin('kakao')}
+        provider="kakao"
+      />
+      <SocialBrandButton
+        label={pending === 'naver' ? '네이버 로그인 중...' : '네이버 로그인'}
+        onPress={() => void handleSocialLogin('naver')}
+        provider="naver"
+      />
     </View>
   );
 }

--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -310,7 +310,7 @@ export function ShootSelectScreen() {
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.sectionTitle}>프레임 미리보기</Text>
         <View style={{ alignItems: 'center' }}>
-          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} />
+          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} tone={shoot.tone} />
         </View>
       </SurfaceCard>
 
@@ -353,10 +353,10 @@ export function ShootSelectScreen() {
         <View style={styles.filterWrap}>
           {OUTPUT_TONE_OPTIONS.map((option) => (
             <Pill
-              key={option}
-              active={shoot.tone === option}
-              onPress={() => setShootOption('tone', option)}>
-              {option}
+              key={option.id}
+              active={shoot.tone === option.id}
+              onPress={() => setShootOption('tone', option.id)}>
+              {option.label}
             </Pill>
           ))}
         </View>
@@ -516,10 +516,10 @@ export function ShootResultScreen() {
 
       <SurfaceCard style={{ gap: 14 }}>
         <View collapsable={false} ref={previewRef}>
-          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} />
+          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} tone={shoot.tone} />
         </View>
         {!isGuest && shoot.includeVideo ? (
-          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} />
+          <FramePreview accentColor={shoot.borderColor} frameId={selectedFrameId} media={previewMedia} tone={shoot.tone} />
         ) : null}
       </SurfaceCard>
 

--- a/apps/mobile/screens/upload-screens.tsx
+++ b/apps/mobile/screens/upload-screens.tsx
@@ -2,20 +2,29 @@ import * as ImagePicker from 'expo-image-picker';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useRouter } from 'expo-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Image, Pressable, Share, StyleSheet, Text, View } from 'react-native';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { captureRef } from 'react-native-view-shot';
 
 import { FramePickerSection, FramePreview, SavedFramesPanel } from '@/components/harucut/frame';
 import { ActionButton, AppScrollView, FormField, PageHeader, Pill, StepProgress, SurfaceCard } from '@/components/harucut/ui';
-import { FRAME_BORDER_OPTIONS, OUTPUT_TONE_OPTIONS, type MediaAsset } from '@/constants/harucut-data';
+import { FRAME_BORDER_OPTIONS, OUTPUT_TONE_OPTIONS, type HistoryItem, type MediaAsset } from '@/constants/harucut-data';
 import type { HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { getApiErrorMessage } from '@/lib/api-client';
+import { saveRemoteMediaToLibrary, shareMediaLink } from '@/lib/media-download';
+import { getMediaDownloadUrl } from '@/lib/user-media-api';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
-async function shareMedia(title: string, uri: string | undefined) {
-  if (!uri) return;
-  await Share.share({ message: `${title}\n${uri}`, url: uri });
+async function resolveHistoryMediaUrl(item: HistoryItem) {
+  if (item.mediaId) {
+    try {
+      return await getMediaDownloadUrl(item.mediaId);
+    } catch {
+      // 서명 URL 재발급 실패 시 미리보기 URL로 대체합니다.
+    }
+  }
+
+  return item.previewMedia[0]?.uri;
 }
 
 function useUploadStyles() {
@@ -130,7 +139,7 @@ export function UploadSelectScreen() {
       <SurfaceCard style={{ gap: 14 }}>
         <Text style={styles.sectionTitle}>프레임 미리보기</Text>
         <View style={{ alignItems: 'center' }}>
-          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
+          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} tone={upload.tone} />
         </View>
       </SurfaceCard>
 
@@ -178,10 +187,10 @@ export function UploadSelectScreen() {
         <View style={styles.filterWrap}>
           {OUTPUT_TONE_OPTIONS.map((option) => (
             <Pill
-              key={option}
-              active={upload.tone === option}
-              onPress={() => setUploadOption('tone', option)}>
-              {option}
+              key={option.id}
+              active={upload.tone === option.id}
+              onPress={() => setUploadOption('tone', option.id)}>
+              {option.label}
             </Pill>
           ))}
         </View>
@@ -216,6 +225,7 @@ export function UploadResultScreen() {
   const showNotice = useHarucutStore((state) => state.showNotice);
   const [draftName, setDraftName] = useState('');
   const [saveStatus, setSaveStatus] = useState<'error' | 'idle' | 'saving' | 'saved'>('idle');
+  const [downloading, setDownloading] = useState(false);
   const previewRef = useRef<View | null>(null);
 
   useEffect(() => {
@@ -278,6 +288,66 @@ export function UploadResultScreen() {
     setDraftName(currentHistory?.title ?? '');
   }, [currentHistory?.title]);
 
+  const handleDownload = async () => {
+    if (!currentHistory) return;
+
+    setDownloading(true);
+
+    try {
+      const url = await resolveHistoryMediaUrl(currentHistory);
+      const result = await saveRemoteMediaToLibrary(url, currentHistory.title, currentHistory.kind);
+
+      if (result.ok) {
+        showNotice({
+          actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+          eyebrow: 'DOWNLOAD',
+          icon: 'checkmark-circle-outline',
+          message: '사진 보관함에 저장했어요.',
+          title: '다운로드 완료',
+        });
+        return;
+      }
+
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'DOWNLOAD ERROR',
+        icon: 'warning-outline',
+        message:
+          result.reason === 'permission-denied'
+            ? '사진 보관함 권한이 필요해요. 권한을 허용한 뒤 다시 시도해 주세요.'
+            : '파일을 내려받지 못했어요. 잠시 후 다시 시도해 주세요.',
+        title: '다운로드 실패',
+      });
+    } catch (error) {
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'DOWNLOAD ERROR',
+        icon: 'warning-outline',
+        message: getApiErrorMessage(error, '파일을 내려받지 못했어요.'),
+        title: '다운로드 실패',
+      });
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const handleShare = async () => {
+    if (!currentHistory) return;
+
+    try {
+      const url = await resolveHistoryMediaUrl(currentHistory);
+      await shareMediaLink(currentHistory.title, url);
+    } catch (error) {
+      showNotice({
+        actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+        eyebrow: 'SHARE ERROR',
+        icon: 'warning-outline',
+        message: getApiErrorMessage(error, '공유 링크를 준비하지 못했어요.'),
+        title: '공유 실패',
+      });
+    }
+  };
+
   return (
     <AppScrollView>
       <PageHeader title="업로드 결과" />
@@ -295,10 +365,10 @@ export function UploadResultScreen() {
 
       <SurfaceCard style={{ gap: 14 }}>
         <View collapsable={false} ref={previewRef}>
-          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
+          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} tone={upload.tone} />
         </View>
         {upload.includeVideo ? (
-          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} />
+          <FramePreview accentColor={upload.borderColor} frameId={upload.frameId} media={previewMedia} tone={upload.tone} />
         ) : null}
       </SurfaceCard>
 
@@ -331,14 +401,14 @@ export function UploadResultScreen() {
           <View style={styles.rowButtons}>
             <ActionButton
               icon={<Ionicons color="#FFFFFF" name="download-outline" size={16} />}
-              label="다운로드"
-              onPress={() => shareMedia(currentHistory.title, currentHistory.previewMedia[0]?.uri)}
+              label={downloading ? '다운로드 중...' : '다운로드'}
+              onPress={() => void handleDownload()}
               style={{ flex: 1 }}
             />
             <ActionButton
               icon={<Ionicons color={colors.text} name="share-social-outline" size={16} />}
               label="공유하기"
-              onPress={() => shareMedia(currentHistory.title, currentHistory.previewMedia[0]?.uri)}
+              onPress={() => void handleShare()}
               style={{ flex: 1 }}
               variant="secondary"
             />

--- a/apps/mobile/store/use-harucut-store.ts
+++ b/apps/mobile/store/use-harucut-store.ts
@@ -242,7 +242,7 @@ function defaultShootSession(): ShootSession {
     selectedSavedFrameId: null,
     selectedShotIds: [],
     shots: [],
-    tone: '기본',
+    tone: 'NONE',
   };
 }
 
@@ -255,7 +255,7 @@ function defaultUploadSession(): UploadSession {
     persistedHistoryId: null,
     selectedAssetIds: [],
     selectedSavedFrameId: null,
-    tone: '기본',
+    tone: 'NONE',
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       expo-dev-client:
         specifier: ~55.0.32
         version: 55.0.32(expo@55.0.20)
+      expo-file-system:
+        specifier: ~55.0.22
+        version: 55.0.22(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))
       expo-font:
         specifier: ~55.0.6
         version: 55.0.6(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
@@ -3757,8 +3760,8 @@ packages:
     peerDependencies:
       expo: '*'
 
-  expo-file-system@55.0.17:
-    resolution: {integrity: sha512-d27K1cagUOt2BwxwPka9KW8Znu5kN1tnairozCzzCRZviZFtWnBxwFuJ3KU6MAbav/9UhSMkp5Ve/oZ+SR0UgQ==}
+  expo-file-system@55.0.22:
+    resolution: {integrity: sha512-T5Rfv3vqcFyhVrl/tEEeglc/J8LJbcZQgC3TMT5jxzIgUgWmIgJEgncGYqB/YNXFgUTL2LiuCvqrU51Dzp83NQ==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -10580,7 +10583,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -10603,7 +10606,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10633,14 +10636,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10675,7 +10678,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11006,7 +11009,7 @@ snapshots:
       expo: 55.0.20(@babel/core@7.28.5)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native-worklets@0.8.3(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       expo-dev-menu-interface: 55.0.2(expo@55.0.20)
 
-  expo-file-system@55.0.17(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5)):
+  expo-file-system@55.0.22(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5)):
     dependencies:
       expo: 55.0.20(@babel/core@7.28.5)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.5))(react-native-webview@13.16.1(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native-worklets@0.8.3(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5))(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react-native: 0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5)
@@ -11211,7 +11214,7 @@ snapshots:
       babel-preset-expo: 55.0.20(@babel/core@7.28.5)(@babel/runtime@7.29.2)(expo@55.0.20)(react-refresh@0.14.2)
       expo-asset: 55.0.16(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       expo-constants: 55.0.15(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))
-      expo-file-system: 55.0.17(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))
+      expo-file-system: 55.0.22(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))
       expo-font: 55.0.6(expo@55.0.20)(react-native@0.85.2(@babel/core@7.28.5)(@react-native/metro-config@0.85.2(@babel/core@7.28.5))(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       expo-keep-awake: 55.0.7(expo@55.0.20)(react@19.2.5)
       expo-modules-autolinking: 55.0.19(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- 결과 화면 톤 필터 적용 및 다운로드/공유 동작 분리
- 인증 입력 검증 로직을 웹과 동일하게 정렬
- 소셜 로그인(Kakao/Naver) 시작 흐름 구현

🤖 Generated with [Claude Code](https://claude.com/claude-code)