### PR TITLE
feat(mobile): 소셜 로그인 콜백 딥링크 처리 완결

### DIFF
--- a/apps/mobile/app/oauth2/callback.tsx
+++ b/apps/mobile/app/oauth2/callback.tsx
@@ -1,0 +1,87 @@
+import { useRouter } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+
+import { useHarucutTheme } from '@/hooks/use-harucut-theme';
+import { getApiErrorMessage } from '@/lib/api-client';
+import { completeSocialLoginSession } from '@/lib/social-login';
+import { useHarucutStore } from '@/store/use-harucut-store';
+
+// 소셜 로그인 후 harucut://oauth2/callback 딥링크로 복귀할 때의 진입점.
+// 인앱 브라우저(openAuthSessionAsync)가 결과를 돌려주지 못하는 경우
+// (외부 브라우저 복귀, 콜드 스타트 등)에도 이 라우트가 세션을 확정한다.
+export default function OAuthCallbackScreen() {
+  const router = useRouter();
+  const { colors } = useHarucutTheme();
+  const showNotice = useHarucutStore((state) => state.showNotice);
+  const isHandlingRef = useRef(false);
+
+  useEffect(() => {
+    if (isHandlingRef.current) {
+      return;
+    }
+    isHandlingRef.current = true;
+
+    let cancelled = false;
+
+    const finishLogin = async () => {
+      try {
+        await completeSocialLoginSession();
+
+        if (!cancelled) {
+          router.replace('/home' as never);
+        }
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        showNotice({
+          actions: [{ id: 'dismiss', label: '닫기', variant: 'secondary' }],
+          eyebrow: 'SOCIAL LOGIN',
+          icon: 'warning-outline',
+          message: getApiErrorMessage(
+            error,
+            '소셜 로그인을 완료하지 못했어요. 잠시 후 다시 시도해 주세요.',
+          ),
+          title: '소셜 로그인 실패',
+        });
+        router.replace('/login' as never);
+      }
+    };
+
+    void finishLogin();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, showNotice]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <ActivityIndicator color={colors.primary} size="large" />
+      <Text style={[styles.title, { color: colors.text }]}>로그인 처리 중</Text>
+      <Text style={[styles.description, { color: colors.textSoft }]}>
+        소셜 로그인 상태를 확인하는 중이에요.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flex: 1,
+    gap: 12,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  description: {
+    fontSize: 13,
+    textAlign: 'center',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/lib/social-login.ts
+++ b/apps/mobile/lib/social-login.ts
@@ -1,0 +1,25 @@
+import { getAuthStatus, reactivateAccount } from '@/lib/auth-api';
+import { useHarucutStore } from '@/store/use-harucut-store';
+
+// 소셜 로그인 복귀 후 세션 확정 절차(상태 확인 → 필요 시 재활성화 → 멤버 세션 부트스트랩).
+// openAuthSessionAsync 성공 경로와 harucut://oauth2/callback 딥링크 경로가
+// 같은 로그인에 대해 동시에 도달할 수 있어 단일 in-flight 프라미스로 중복 실행을 막는다.
+let inFlight: Promise<void> | null = null;
+
+export function completeSocialLoginSession(): Promise<void> {
+  if (!inFlight) {
+    inFlight = (async () => {
+      const status = await getAuthStatus();
+
+      if (status?.userStatus === 'DELETED_REQUESTED') {
+        await reactivateAccount();
+      }
+
+      await useHarucutStore.getState().bootstrapMemberSession();
+    })().finally(() => {
+      inFlight = null;
+    });
+  }
+
+  return inFlight;
+}

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -12,7 +12,6 @@ import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { getApiConfig, getApiErrorMessage } from '@/lib/api-client';
 import { validateEmail, validatePassword, validateUsername } from '@/lib/auth-validation';
 import {
-  getAuthStatus,
   loginWithEmail,
   reactivateAccount,
   requestPasswordResetCode,
@@ -22,6 +21,7 @@ import {
   verifyEmailAuthCode,
   verifyPasswordResetCode,
 } from '@/lib/auth-api';
+import { completeSocialLoginSession } from '@/lib/social-login';
 import { useHarucutStore } from '@/store/use-harucut-store';
 
 type HarucutThemeColors = ReturnType<typeof useHarucutTheme>['colors'];
@@ -69,14 +69,14 @@ function AuthShell({
 function SocialButtons() {
   const { styles } = usePublicScreenTheme();
   const router = useRouter();
-  const bootstrapMemberSession = useHarucutStore((state) => state.bootstrapMemberSession);
   const showNotice = useHarucutStore((state) => state.showNotice);
   const [pending, setPending] = useState<SocialProvider | null>(null);
 
   // 웹은 `${backend}/oauth2/authorization/{provider}`로 이동 후 쿠키 세션을 받습니다.
   // 모바일은 시스템 인증 세션(expo-web-browser)으로 동일 엔드포인트를 열고,
   // `harucut://oauth2/callback` 딥링크로 복귀한 뒤 세션 상태를 확인합니다.
-  // 백엔드가 해당 리다이렉트 스킴과 앱 쿠키/토큰 핸드오프를 지원해야 완결됩니다.
+  // 인증 세션이 결과를 돌려주지 못하는 경로(외부 브라우저 복귀, 콜드 스타트)는
+  // app/oauth2/callback.tsx 라우트가 같은 절차로 세션을 확정합니다.
   const handleSocialLogin = async (provider: SocialProvider) => {
     if (pending) {
       return;
@@ -94,13 +94,7 @@ function SocialButtons() {
         return;
       }
 
-      const status = await getAuthStatus();
-
-      if (status?.userStatus === 'DELETED_REQUESTED') {
-        await reactivateAccount();
-      }
-
-      await bootstrapMemberSession();
+      await completeSocialLoginSession();
       router.replace('/home' as never);
     } catch (error) {
       showNotice({


### PR DESCRIPTION
## Summary
- app/oauth2/callback.tsx 라우트 추가 — openAuthSessionAsync가 결과를 돌려주지 못하는 복귀 경로(외부 브라우저 복귀, 콜드 스타트)에서도 harucut://oauth2/callback 딥링크로 세션을 확정
- lib/social-login.ts의 completeSocialLoginSession(): 상태 확인 → DELETED_REQUESTED 재활성화 → 멤버 세션 부트스트랩 절차를 단일 in-flight 프라미스로 공유, 인증 세션 경로와 딥링크 경로가 동시에 도달해도 1회만 실행
- SocialButtons 인라인 로직을 공용 헬퍼 호출로 정리

## Note
- 리뷰에서 지적됐던 media-download.ts 확장자 추론은 직접 확인 결과 (?:[?#]|$) 가드가 이미 있어 쿼리스트링 문제가 없음 → 수정 대상에서 제외
- 백엔드가 모바일 딥링크 리다이렉트(harucut://oauth2/callback)를 OAuth redirect 대상으로 허용해야 end-to-end가 완결됩니다 (앱 측 처리는 본 PR로 완료)

## Verification
- pnpm typecheck:mobile, pnpm lint:mobile 통과

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)