### PR TITLE
chore(mobile): Android applicationId를 com.harucut.app으로 변경

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "android": {
-      "package": "com.harucut.mobile",
+      "package": "com.harucut.app",
       "adaptiveIcon": {
         "backgroundColor": "#F6E8E0",
         "foregroundImage": "./assets/images/android-icon-foreground.png",


### PR DESCRIPTION
## Summary
- Play Console 등록용 패키지명을 com.harucut.app으로 확정 (app.json android.package)
- android/ 디렉토리는 prebuild 산출물(gitignore)이라 app.json만 변경하면 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)