### PR TITLE
feat(web): 검색엔진 색인 메타데이터 정비

### DIFF
--- a/apps/web/app/forgot-password/layout.tsx
+++ b/apps/web/app/forgot-password/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+// 인증 페이지는 redirectTo 쿼리 변형으로 중복 수집되므로 검색 색인에서 제외한다
+export const metadata: Metadata = {
+  title: "비밀번호 찾기 | 하루컷",
+  robots: { index: false, follow: true },
+};
+
+export default function ForgotPasswordLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css";
 import { ExternalBrowserGate } from "./ExternalBrowserGate";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://www.harucut.com"),
   title: "하루컷",
   description: "오늘의 인생 네컷을 기록하는 사진 서비스",
 };

--- a/apps/web/app/login/layout.tsx
+++ b/apps/web/app/login/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+// 인증 페이지는 redirectTo 쿼리 변형으로 중복 수집되므로 검색 색인에서 제외한다
+export const metadata: Metadata = {
+  title: "로그인 | 하루컷",
+  robots: { index: false, follow: true },
+};
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import { GuestTrialStartButton } from "@/components/guest/GuestTrialStartButton";
 import { BrandMark } from "@/components/layout/BrandMark";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
 
 export default function LandingPage() {
   return (

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -5,6 +5,7 @@ import { LegalDocumentView } from "@/components/legal/LegalDocumentView";
 export const metadata: Metadata = {
   title: "개인정보 처리방침 | 하루컷",
   description: "하루컷 개인정보 처리방침",
+  alternates: { canonical: "/privacy" },
 };
 
 export default function PrivacyPage() {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { PROTECTED_PATHS } from "@/lib/protectedPaths";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [...PROTECTED_PATHS, "/api/", "/oauth2/"],
+    },
+    sitemap: "https://www.harucut.com/sitemap.xml",
+  };
+}

--- a/apps/web/app/signup/layout.tsx
+++ b/apps/web/app/signup/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+// 인증 페이지는 redirectTo 쿼리 변형으로 중복 수집되므로 검색 색인에서 제외한다
+export const metadata: Metadata = {
+  title: "회원가입 | 하루컷",
+  robots: { index: false, follow: true },
+};
+
+export default function SignupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://www.harucut.com";
+
+// 로그인 없이 접근 가능한 공개 페이지만 등록한다 (인증 페이지는 noindex)
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: `${BASE_URL}/`, priority: 1 },
+    { url: `${BASE_URL}/terms`, priority: 0.3 },
+    { url: `${BASE_URL}/privacy`, priority: 0.3 },
+  ];
+}

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -5,6 +5,7 @@ import { LegalDocumentView } from "@/components/legal/LegalDocumentView";
 export const metadata: Metadata = {
   title: "서비스 이용약관 | 하루컷",
   description: "하루컷 서비스 이용약관",
+  alternates: { canonical: "/terms" },
 };
 
 export default function TermsPage() {


### PR DESCRIPTION
Closes #319

## 변경 사항
- 루트 레이아웃에 metadataBase(https://www.harucut.com) 추가
- 랜딩(/), /terms, /privacy 페이지에 canonical 명시
- 인증 페이지(login/signup/forgot-password)에 noindex, follow 메타 추가 — Search Console의 /login?redirectTo=/home 중복 페이지 보고 해소
- app/robots.ts 추가: 보호 경로(home/shoot/upload/history/theme/mypage), /api/, /oauth2/ 크롤링 차단 + sitemap 위치 명시
- app/sitemap.ts 추가: 공개 페이지(/, /terms, /privacy) 등록

## 검증
- next build 성공, /robots.txt·/sitemap.xml 라우트 생성 및 출력 내용 확인
- 빌드 산출물에서 canonical 링크와 noindex 메타 태그 출력 확인
- jest 71/71 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)