### PR TITLE
feat(theme): 웹 꾸미기 배경 이미지 + Codex 리뷰 P2 수정 (#336 후속)

### DIFF
--- a/apps/mobile/screens/theme-screens.tsx
+++ b/apps/mobile/screens/theme-screens.tsx
@@ -11,7 +11,7 @@ import { BACKGROUND_SWATCHES, THEME_STICKERS, type ThemeAsset, type ThemeCompone
 import type { HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 import { getApiErrorMessage } from '@/lib/api-client';
-import { resolveUploadContentType, uploadLocalFileWithPresigned } from '@/lib/file-storage-api';
+import { getPresignedImageUrl, resolveUploadContentType, uploadLocalFileWithPresigned } from '@/lib/file-storage-api';
 import { useLibraryStore } from '@/store/use-library-store';
 import { useSessionStore } from '@/store/use-session-store';
 import { useThemeEditorStore } from '@/store/use-theme-editor-store';
@@ -74,6 +74,7 @@ export function ThemeStickerScreen() {
   const setThemeDescription = useThemeEditorStore((state) => state.setThemeDescription);
   const setThemeBackgroundColor = useThemeEditorStore((state) => state.setThemeBackgroundColor);
   const setThemeBackgroundImage = useThemeEditorStore((state) => state.setThemeBackgroundImage);
+  const setThemeBackgroundPreview = useThemeEditorStore((state) => state.setThemeBackgroundPreview);
   const clearThemeBackgroundImage = useThemeEditorStore((state) => state.clearThemeBackgroundImage);
   const setThemeActiveComponent = useThemeEditorStore((state) => state.setThemeActiveComponent);
   const setThemeTab = useThemeEditorStore((state) => state.setThemeTab);
@@ -109,6 +110,28 @@ export function ThemeStickerScreen() {
       router.replace('/theme' as never);
     }
   }, [router, themeEditor.frameId]);
+
+  // 저장된 IMAGE 배경 프레임을 다시 열면 key를 URL로 해석해 미리보기에 복원한다.
+  // (수정 저장 시 배경 이미지가 빠진 단색 썸네일로 저장되는 문제 방지)
+  useEffect(() => {
+    const background = themeEditor.background;
+    if (background.type !== 'IMAGE' || !background.key || themeEditor.backgroundImageUri) {
+      return;
+    }
+
+    let cancelled = false;
+    void getPresignedImageUrl(background.key)
+      .then((url) => {
+        if (!cancelled && url) {
+          setThemeBackgroundPreview(url);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [themeEditor.background, themeEditor.backgroundImageUri, setThemeBackgroundPreview]);
 
   const showError = (title: string, error: unknown, fallback: string) => {
     showNotice({

--- a/apps/mobile/store/use-shoot-store.ts
+++ b/apps/mobile/store/use-shoot-store.ts
@@ -107,7 +107,11 @@ export const useShootStore = create<ShootStore>((set, get) => ({
   resetShootSession: () =>
     set((state) => ({
       ...defaultShootSession(),
+      // 촬영 시작 시 세션(촬영본/선택)만 초기화하고 고른 프레임(저장 프레임 포함)은 유지한다.
+      // 그래야 촬영 중에도 카메라 위 프레임 오버레이의 데코가 그대로 보인다.
+      borderColor: state.borderColor,
       frameId: state.frameId,
+      selectedSavedFrameId: state.selectedSavedFrameId,
     })),
   selectSavedFrameForShoot: (frame) =>
     set({

--- a/apps/mobile/store/use-theme-editor-store.ts
+++ b/apps/mobile/store/use-theme-editor-store.ts
@@ -31,6 +31,9 @@ type ThemeEditorSessionState = {
   background: ThemeBackground;
   backgroundColor: string;
   backgroundImageUri: string | null;
+  // backgroundImageUri가 새로 고른 로컬 파일이라 저장 시 업로드해야 하는지 여부.
+  // 저장 프레임을 다시 열어 원격 배경을 미리보기만 할 때는 false(재업로드 금지, 기존 key 유지).
+  backgroundImagePending: boolean;
   caption: string;
   components: ThemeEditorComponent[];
   description: string;
@@ -67,6 +70,7 @@ type ThemeEditorStore = ThemeEditorSessionState & {
   setThemeActiveComponent: (id: string | null) => void;
   setThemeBackgroundColor: (value: string) => void;
   setThemeBackgroundImage: (uri: string) => void;
+  setThemeBackgroundPreview: (uri: string) => void;
   setThemeCaption: (value: string) => void;
   setThemeDescription: (value: string) => void;
   setThemeFrame: (frameId: FrameId) => void;
@@ -97,6 +101,7 @@ function defaultThemeEditor(): ThemeEditorSessionState {
     },
     backgroundColor,
     backgroundImageUri: null,
+    backgroundImagePending: false,
     caption: 'today archive',
     components: [],
     description: '하루컷에서 직접 꾸민 나만의 프레임',
@@ -287,9 +292,10 @@ export const useThemeEditorStore = create<ThemeEditorStore>((set, get) => ({
     const remoteFrameId =
       selectedFrame?.remoteFrameId ??
       (current.selectedSavedFrameId ? remoteFrameIdFromSavedId(current.selectedSavedFrameId) : null);
-    // 로컬 배경 이미지가 있으면 업로드해 IMAGE 배경 key를 채운다.
+    // 새로 고른 로컬 배경 이미지만 업로드해 IMAGE 배경 key를 채운다.
+    // (저장 프레임을 다시 열어 미리보기만 한 경우는 pending=false라 기존 key를 그대로 보존)
     let background = current.background;
-    if (current.backgroundImageUri) {
+    if (current.backgroundImagePending && current.backgroundImageUri) {
       const uploadedBackground = await uploadLocalFileWithPresigned({
         contentType: 'JPEG',
         filename: `${title}-bg.jpg`,
@@ -349,6 +355,7 @@ export const useThemeEditorStore = create<ThemeEditorStore>((set, get) => ({
       },
       backgroundColor: frame.backgroundColor,
       backgroundImageUri: null,
+      backgroundImagePending: false,
       caption: frame.caption,
       components: normalizeThemeZ(
         (frame.components ?? []).map((component) => ({
@@ -373,6 +380,7 @@ export const useThemeEditorStore = create<ThemeEditorStore>((set, get) => ({
         value: normalizeThemeColor(state.backgroundColor).replace(/^#/, ''),
       },
       backgroundImageUri: null,
+      backgroundImagePending: false,
     })),
   setThemeBackgroundColor: (value) => {
     const backgroundColor = normalizeThemeColor(value);
@@ -384,14 +392,19 @@ export const useThemeEditorStore = create<ThemeEditorStore>((set, get) => ({
       },
       backgroundColor,
       backgroundImageUri: null,
+      backgroundImagePending: false,
     });
   },
   setThemeBackgroundImage: (uri) =>
     set({
-      // key는 저장 시 업로드 후 채운다. 미리보기는 backgroundImageUri(local)를 사용.
+      // 새로 고른 로컬 이미지 — 저장 시 업로드해 key를 채운다(pending=true).
       background: { type: 'IMAGE' },
       backgroundImageUri: uri,
+      backgroundImagePending: true,
     }),
+  setThemeBackgroundPreview: (uri) =>
+    // 저장된 원격 IMAGE 배경을 편집용으로 미리보기만(기존 key 유지, 재업로드 금지).
+    set({ backgroundImageUri: uri, backgroundImagePending: false }),
   setThemeCaption: (value) => set({ caption: value }),
   setThemeDescription: (value) => set({ description: value }),
   setThemeFrame: (frameId) =>

--- a/apps/web/components/frame/FramePreview.tsx
+++ b/apps/web/components/frame/FramePreview.tsx
@@ -56,6 +56,17 @@ export function FramePreview({
         backgroundColor: borderColor || undefined,
       }}
     >
+      {theme?.background?.type === "IMAGE" && theme.background.url ? (
+        // 배경 이미지는 슬롯(사진)보다 아래 레이어로 깔린다.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={theme.background.url}
+          alt=""
+          aria-hidden
+          className="pointer-events-none absolute inset-0 h-full w-full object-cover"
+          style={{ opacity: theme.background.opacity ?? 1 }}
+        />
+      ) : null}
       {slots.map((slot, idx) => {
         const leftPct = (slot.x / totalWidth) * 100;
         const topPct = (slot.y / totalHeight) * 100;

--- a/apps/web/components/theme/editor/ThemeEditorPage.tsx
+++ b/apps/web/components/theme/editor/ThemeEditorPage.tsx
@@ -36,6 +36,8 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
   const background = useThemeEditorStore((s) => s.background);
   const backgroundColor = useThemeEditorStore((s) => s.backgroundColor);
   const setBackgroundColor = useThemeEditorStore((s) => s.setBackgroundColor);
+  const setBackgroundImage = useThemeEditorStore((s) => s.setBackgroundImage);
+  const clearBackgroundImage = useThemeEditorStore((s) => s.clearBackgroundImage);
   const addDraft = useThemeDraftStore((s) => s.addDraft);
   const { remoteFrameId } = useThemeSession();
   const [isSaving, setIsSaving] = useState(false);
@@ -49,7 +51,7 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
   const [draftDescription, setDraftDescription] = useState("");
   const [saveDialogError, setSaveDialogError] = useState<string | null>(null);
   const hasRemoteLoadFailure = Boolean(remoteFrameId && loadError);
-  const hasNonColorBackground = background.type !== "COLOR";
+  const hasVideoBackground = background.type === "VIDEO";
 
   useEffect(() => {
     setFrameId(frameId);
@@ -126,9 +128,6 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
       alert("숨겨진 레이어가 있어요.");
     }
 
-    const themeJson = exportJson();
-    if (!themeJson) return;
-
     const nextTitle = draftTitle.trim() || "테마 프레임";
     const nextDescription =
       draftDescription.trim() ||
@@ -137,6 +136,27 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
     setIsSaving(true);
     setSaveDialogError(null);
     try {
+      // 로컬 배경 이미지가 있으면 먼저 업로드해 IMAGE 배경 key를 채운다.
+      const editorState = useThemeEditorStore.getState();
+      if (
+        editorState.pendingBackgroundFile &&
+        editorState.background.type === "IMAGE" &&
+        !editorState.background.key
+      ) {
+        const { key } = await uploadToS3WithPresigned({
+          file: editorState.pendingBackgroundFile,
+          type: PRESIGNED_UPLOAD_TYPES.FRAME,
+          isTemp: false,
+        });
+        useThemeEditorStore.getState().setBackgroundImageKey(key);
+      }
+
+      const themeJson = exportJson();
+      if (!themeJson) {
+        setIsSaving(false);
+        return;
+      }
+
       const previewBlob = await renderThemePreviewPng(themeJson);
       const previewFile = new File(
         [previewBlob],
@@ -203,10 +223,10 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
             {loadError ? (
               <p className="mt-1 text-[11px] text-red-300">{loadError}</p>
             ) : null}
-            {remoteFrameId && hasNonColorBackground ? (
+            {remoteFrameId && hasVideoBackground ? (
               <p className="mt-1 text-[11px] text-amber-300">
-                이미지/비디오 배경은 미리보기에서 단색 배경으로 보이지만, 배경
-                색상을 바꾸지 않으면 기존 배경 정보는 그대로 보존됩니다.
+                비디오 배경은 미리보기에서 단색 배경으로 보이지만, 배경 색상을
+                바꾸지 않으면 기존 배경 정보는 그대로 보존됩니다.
               </p>
             ) : null}
           </div>
@@ -256,7 +276,7 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
 
           <div className="lg:col-start-2 lg:row-start-2">
             <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4 flex flex-col gap-3">
-              <p className="text-sm font-semibold">배경색</p>
+              <p className="text-sm font-semibold">배경</p>
               <div className="flex flex-wrap gap-2">
                 {BACKGROUND_COLORS.map((color) => {
                   const selected = backgroundColor === color.value;
@@ -291,6 +311,33 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
                   placeholder="ffffff"
                 />
               </div>
+              <div className="flex items-center gap-2">
+                <label className="inline-flex h-9 cursor-pointer items-center justify-center rounded-lg border border-[color:var(--hc-border)] px-3 text-[11px] font-semibold text-[color:var(--hc-text)] hover:border-[color:var(--hc-primary)]">
+                  {background.type === "IMAGE" ? "배경 이미지 변경" : "배경 이미지"}
+                  <input
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) setBackgroundImage(file);
+                      e.target.value = "";
+                    }}
+                  />
+                </label>
+                {background.type === "IMAGE" ? (
+                  <button
+                    type="button"
+                    onClick={clearBackgroundImage}
+                    className="h-9 rounded-lg border border-[color:var(--hc-border)] px-3 text-[11px] font-semibold text-[color:var(--hc-muted)] hover:border-[color:var(--hc-primary)]"
+                  >
+                    이미지 제거
+                  </button>
+                ) : null}
+              </div>
+              <p className="text-[11px] leading-4 text-[color:var(--hc-muted)]">
+                배경 이미지는 사진 칸 뒤에 깔려요.
+              </p>
             </section>
           </div>
 

--- a/apps/web/components/theme/editor/canvas/CanvasStage.tsx
+++ b/apps/web/components/theme/editor/canvas/CanvasStage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useLayoutEffect, useMemo, useRef } from "react";
-import { Stage, Layer, Rect, Transformer } from "react-konva";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Stage, Layer, Rect, Transformer, Image as KonvaImage } from "react-konva";
 import Konva from "konva";
 
 import { FRAME_LAYOUTS } from "@/constants/frameLayouts";
@@ -15,7 +15,33 @@ export function CanvasStage() {
   const components = useThemeEditorStore((s) => s.components);
   const activeId = useThemeEditorStore((s) => s.activeId);
   const backgroundColor = useThemeEditorStore((s) => s.backgroundColor);
+  const background = useThemeEditorStore((s) => s.background);
   const renderKey = useThemeEditorStore((s) => s.renderKey);
+
+  const backgroundImageUrl =
+    background.type === "IMAGE" ? background.url : undefined;
+  const [backgroundImage, setBackgroundImage] =
+    useState<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    if (!backgroundImageUrl) {
+      setBackgroundImage(null);
+      return;
+    }
+    const img = new window.Image();
+    img.crossOrigin = "anonymous";
+    let active = true;
+    img.onload = () => {
+      if (active) setBackgroundImage(img);
+    };
+    img.onerror = () => {
+      if (active) setBackgroundImage(null);
+    };
+    img.src = backgroundImageUrl;
+    return () => {
+      active = false;
+    };
+  }, [backgroundImageUrl]);
 
   const setActive = useThemeEditorStore((s) => s.setActive);
   const update = useThemeEditorStore((s) => s.updateComponent);
@@ -105,6 +131,47 @@ export function CanvasStage() {
               fill={`#${backgroundColor}`}
               cornerRadius={60}
             />
+
+            {backgroundImage
+              ? (() => {
+                  const iw =
+                    backgroundImage.naturalWidth || backgroundImage.width || 1;
+                  const ih =
+                    backgroundImage.naturalHeight || backgroundImage.height || 1;
+                  const fr = frameW / frameH;
+                  const ir = iw / ih;
+                  let cw = iw;
+                  let ch = ih;
+                  let cx = 0;
+                  let cy = 0;
+                  // cover crop
+                  if (ir > fr) {
+                    ch = ih;
+                    cw = ih * fr;
+                    cx = (iw - cw) / 2;
+                  } else {
+                    cw = iw;
+                    ch = iw / fr;
+                    cy = (ih - ch) / 2;
+                  }
+                  return (
+                    <KonvaImage
+                      image={backgroundImage}
+                      x={0}
+                      y={0}
+                      width={frameW}
+                      height={frameH}
+                      crop={{ x: cx, y: cy, width: cw, height: ch }}
+                      cornerRadius={60}
+                      opacity={
+                        background.type === "IMAGE"
+                          ? background.opacity ?? 1
+                          : 1
+                      }
+                    />
+                  );
+                })()
+              : null}
 
             {layout.slots.map((s, i) => (
               <Rect

--- a/apps/web/hooks/useRemoteFrameTheme.ts
+++ b/apps/web/hooks/useRemoteFrameTheme.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { FrameId } from "@/constants/frames";
 import { toThemeExportJson } from "@/lib/frameApi";
+import { getImageUrlByKey } from "@/lib/presignedUploadApi";
 import { getFrame } from "@/lib/remoteFrameApi";
 import type { ThemeExportJson } from "@/lib/types/themeEditor";
 
@@ -29,6 +30,19 @@ export function useRemoteFrameTheme(
         if (expectedFrameId && nextTheme.frameId !== expectedFrameId) {
           setThemeData(null);
           return;
+        }
+
+        // IMAGE 배경은 key만 오므로 렌더용 URL을 해석해 붙인다(실패 시 색 폴백).
+        if (
+          nextTheme.background?.type === "IMAGE" &&
+          nextTheme.background.key &&
+          !nextTheme.background.url
+        ) {
+          const url = await getImageUrlByKey(nextTheme.background.key);
+          if (cancelled) return;
+          if (url) {
+            nextTheme.background = { ...nextTheme.background, url };
+          }
         }
 
         setThemeData(nextTheme);

--- a/apps/web/lib/canvas/composeFrame.ts
+++ b/apps/web/lib/canvas/composeFrame.ts
@@ -192,6 +192,19 @@ async function loadOverlayImages(theme: ThemeExportJson | null) {
   return map;
 }
 
+// IMAGE 배경(슬롯 뒤에 깔리는 배경)을 로드한다. 실패 시 null → 색 배경만 사용.
+async function loadBackgroundImage(theme: ThemeExportJson | null) {
+  if (!theme || theme.background?.type !== "IMAGE") return null;
+  const url = theme.background.url;
+  if (!url) return null;
+
+  try {
+    return await loadImage(url);
+  } catch {
+    return null;
+  }
+}
+
 async function resolveVideoEncoderConfig(
   width: number,
   height: number,
@@ -342,12 +355,29 @@ function drawFrameOnce(
   outputFilter: FourcutFilterId,
   theme: ThemeExportJson | null,
   overlayImages: OverlayImageMap,
+  backgroundImage: HTMLImageElement | null,
 ) {
   const { totalWidth, totalHeight, slots } = layout;
   const slotFilter = getFourcutFilterCanvasValue(outputFilter);
 
   ctx.fillStyle = borderColor;
   ctx.fillRect(0, 0, totalWidth, totalHeight);
+
+  // 배경 이미지를 색 배경 위, 슬롯(사진) 아래에 cover로 깐다.
+  if (backgroundImage) {
+    const bgOpacity =
+      theme?.background?.type === "IMAGE" ? theme.background.opacity ?? 1 : 1;
+    ctx.save();
+    ctx.globalAlpha = Math.min(1, Math.max(0, bgOpacity));
+    drawCover(
+      ctx,
+      backgroundImage,
+      backgroundImage.naturalWidth || backgroundImage.width || 1,
+      backgroundImage.naturalHeight || backgroundImage.height || 1,
+      { x: 0, y: 0, width: totalWidth, height: totalHeight },
+    );
+    ctx.restore();
+  }
 
   slots.forEach((slot, index) => {
     const drawable = drawables[index];
@@ -400,6 +430,7 @@ export async function composeFramePng(opts: {
   const ctx = ensureCtx(canvas);
   const drawables = await loadDrawables(sources);
   const overlayImages = await loadOverlayImages(theme);
+  const backgroundImage = await loadBackgroundImage(theme);
 
   drawFrameOnce(
     ctx,
@@ -409,6 +440,7 @@ export async function composeFramePng(opts: {
     outputFilter,
     theme,
     overlayImages,
+    backgroundImage,
   );
 
   return toPngBlob(canvas);
@@ -446,6 +478,7 @@ export async function recordFrameWebm(opts: {
   const ctx = ensureCtx(canvas);
   const drawables = await loadDrawables(sources);
   const overlayImages = await loadOverlayImages(theme);
+  const backgroundImage = await loadBackgroundImage(theme);
   const videoDrawables = drawables.filter(
     (drawable): drawable is { kind: "video"; el: HTMLVideoElement } =>
       drawable.kind === "video",
@@ -488,6 +521,7 @@ export async function recordFrameWebm(opts: {
       outputFilter,
       theme,
       overlayImages,
+      backgroundImage,
     );
 
     const frame = new VideoFrame(canvas, {

--- a/apps/web/lib/canvas/renderThemePreview.ts
+++ b/apps/web/lib/canvas/renderThemePreview.ts
@@ -65,6 +65,36 @@ export async function renderThemePreviewPng(theme: ThemeExportJson) {
   drawRoundedRect(ctx, 0, 0, canvas.width, canvas.height, 60);
   ctx.fill();
 
+  // IMAGE 배경: 색 위, 슬롯 아래에 cover로 깐다.
+  if (theme.background?.type === "IMAGE" && theme.background.url) {
+    try {
+      const bgImg = await loadImage(theme.background.url);
+      const iw = bgImg.naturalWidth || bgImg.width || 1;
+      const ih = bgImg.naturalHeight || bgImg.height || 1;
+      const fr = canvas.width / canvas.height;
+      const ir = iw / ih;
+      let dw = canvas.width;
+      let dh = canvas.height;
+      let dx = 0;
+      let dy = 0;
+      if (ir > fr) {
+        dh = canvas.height;
+        dw = dh * ir;
+        dx = (canvas.width - dw) / 2;
+      } else {
+        dw = canvas.width;
+        dh = dw / ir;
+        dy = (canvas.height - dh) / 2;
+      }
+      ctx.save();
+      drawRoundedRect(ctx, 0, 0, canvas.width, canvas.height, 60);
+      ctx.clip();
+      ctx.globalAlpha = Math.min(1, Math.max(0, theme.background.opacity ?? 1));
+      ctx.drawImage(bgImg, dx, dy, dw, dh);
+      ctx.restore();
+    } catch {}
+  }
+
   // CanvasStage와 동일한 슬롯 음영 레이어
   ctx.fillStyle = "rgba(0,0,0,0.30)";
   layout.slots.forEach((slot) => {

--- a/apps/web/lib/presignedUploadApi.ts
+++ b/apps/web/lib/presignedUploadApi.ts
@@ -131,6 +131,21 @@ async function requestUploadedMediaInfo(
   return { objectUrl: fallbackUrl };
 }
 
+// 저장된 S3 key를 화면/합성용 다운로드 URL로 해석한다. 실패 시 null(호출부에서 색 폴백).
+export async function getImageUrlByKey(key: string): Promise<string | null> {
+  if (!key) return null;
+
+  try {
+    const res = await clientApi.get<ApiEnvelope<unknown>>(
+      `/api/client/user/files/presigned-img?key=${encodeURIComponent(key)}`,
+    );
+    const info = extractUploadedMediaInfo(res.data.data);
+    return info?.downloadUrl ?? info?.objectUrl ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function extractFilenameFromKey(key: string) {
   const filename = key.split("/").pop()?.trim();
   if (!filename) {

--- a/apps/web/lib/themeEditorStore.ts
+++ b/apps/web/lib/themeEditorStore.ts
@@ -86,10 +86,15 @@ type State = {
   activeId: string | null;
   background: ThemeBackground;
   backgroundColor: string;
+  // 저장 시 업로드할 로컬 배경 이미지 파일(있을 때만).
+  pendingBackgroundFile: File | null;
 
   setFrameId: (id: FrameId) => void;
   setTab: (t: ComponentType) => void;
   setBackgroundColor: (color: string) => void;
+  setBackgroundImage: (file: File) => void;
+  setBackgroundImageKey: (key: string) => void;
+  clearBackgroundImage: () => void;
 
   addPhotoAssets: (
     files: FileList,
@@ -144,6 +149,11 @@ function resetEditorState(get: () => State) {
       URL.revokeObjectURL(p.src);
     } catch {}
   }
+  if (state.background.type === "IMAGE" && state.background.url) {
+    try {
+      URL.revokeObjectURL(state.background.url);
+    } catch {}
+  }
 
   return {
     tab: "PHOTO" as ComponentType,
@@ -157,6 +167,7 @@ function resetEditorState(get: () => State) {
       type: "COLOR" as const,
       value: "111827",
     },
+    pendingBackgroundFile: null,
   };
 }
 
@@ -176,6 +187,7 @@ export const useThemeEditorStore = create<State>((set, get) => ({
     value: "111827",
   },
   backgroundColor: "111827",
+  pendingBackgroundFile: null,
 
   // 프레임 변경 시 에디터 상태 초기화
   setFrameId: (id) =>
@@ -196,7 +208,13 @@ export const useThemeEditorStore = create<State>((set, get) => ({
 
   setTab: (t) => set({ tab: t }),
   setBackgroundColor: (color) =>
-    set(() => {
+    set((s) => {
+      // 색을 고르면 배경 이미지는 해제한다.
+      if (s.background.type === "IMAGE" && s.background.url) {
+        try {
+          URL.revokeObjectURL(s.background.url);
+        } catch {}
+      }
       const normalized = normalizeHexColor(color);
       return {
         background: {
@@ -204,6 +222,37 @@ export const useThemeEditorStore = create<State>((set, get) => ({
           value: normalized,
         },
         backgroundColor: normalized,
+        pendingBackgroundFile: null,
+      };
+    }),
+  setBackgroundImage: (file) =>
+    set((s) => {
+      if (s.background.type === "IMAGE" && s.background.url) {
+        try {
+          URL.revokeObjectURL(s.background.url);
+        } catch {}
+      }
+      const url = URL.createObjectURL(file);
+      return {
+        background: { type: "IMAGE", url },
+        pendingBackgroundFile: file,
+      };
+    }),
+  setBackgroundImageKey: (key) =>
+    set((s) => {
+      if (s.background.type !== "IMAGE") return s;
+      return { background: { ...s.background, key } };
+    }),
+  clearBackgroundImage: () =>
+    set((s) => {
+      if (s.background.type === "IMAGE" && s.background.url) {
+        try {
+          URL.revokeObjectURL(s.background.url);
+        } catch {}
+      }
+      return {
+        background: { type: "COLOR", value: normalizeHexColor(s.backgroundColor) },
+        pendingBackgroundFile: null,
       };
     }),
 

--- a/apps/web/lib/types/themeEditor.ts
+++ b/apps/web/lib/types/themeEditor.ts
@@ -69,6 +69,8 @@ export type ThemeBackground =
       type: "IMAGE";
       key?: string;
       opacity?: number;
+      // 클라이언트에서 key를 해석해 채우는 렌더 전용 URL (서버 전송 X).
+      url?: string;
     }
   | {
       type: "VIDEO";


### PR DESCRIPTION
PR #337(머지됨) 이후 누락분 + Codex 리뷰 반영.

## 웹 꾸미기 배경 이미지 (Phase D 웹 — #337에 못 들어간 커밋)
- key→URL 해석(getImageUrlByKey) + useRemoteFrameTheme가 IMAGE 배경 url 주입.
- 웹 FramePreview·composeFrame(PNG/WebM)·Konva 에디터·썸네일이 배경 이미지를 슬롯 뒤 cover로 렌더.
- 에디터 배경 이미지 업로드/제거 UI + 저장 시 업로드.

## Codex 리뷰 P2 수정 (#337)
- 촬영 오버레이: resetShootSession이 selectedSavedFrameId/borderColor 보존 → 촬영 시작 후에도 저장 프레임 데코 유지.
- 배경 이미지 편집 복원: pending 분리 + getPresignedImageUrl로 미리보기 복원, 수정 저장 시 기존 key 보존.

모바일 typecheck, 웹 tsc 통과.

> 머지: 코드오너 승인 필요(작성자 셀프 승인 불가).