### PR TITLE
fix(web): 원격 IMAGE 배경 프레임 편집 시 배경 보존 (#338 Codex P2)

### DIFF
--- a/apps/web/components/theme/editor/ThemeEditorPage.tsx
+++ b/apps/web/components/theme/editor/ThemeEditorPage.tsx
@@ -81,9 +81,22 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
 
         // IMAGE 배경(key만 있음)은 url을 해석해 캔버스/썸네일에 렌더되도록 주입.
         // 그래야 수정 저장 시 배경이 빠진 단색 썸네일로 저장되지 않는다.
-        if (imported.background?.type === "IMAGE" && imported.background.key) {
-          const url = await getImageUrlByKey(imported.background.key);
-          if (!cancelled && url) setBackgroundImageUrl(url);
+        const importedKey =
+          imported.background?.type === "IMAGE" ? imported.background.key : undefined;
+        if (importedKey) {
+          const url = await getImageUrlByKey(importedKey);
+          // 해석을 기다리는 동안 사용자가 새 배경(로컬 파일/다른 key)을 골랐을 수 있다.
+          // 현재 배경이 여전히 같은 원격 key일 때만 적용해 stale URL 덮어쓰기를 막는다.
+          const current = useThemeEditorStore.getState();
+          if (
+            !cancelled &&
+            url &&
+            !current.pendingBackgroundFile &&
+            current.background.type === "IMAGE" &&
+            current.background.key === importedKey
+          ) {
+            setBackgroundImageUrl(url);
+          }
         }
       } catch (error) {
         console.error(error);

--- a/apps/web/components/theme/editor/ThemeEditorPage.tsx
+++ b/apps/web/components/theme/editor/ThemeEditorPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/remoteFrameApi";
 import {
   PRESIGNED_UPLOAD_TYPES,
+  getImageUrlByKey,
   uploadToS3WithPresigned,
 } from "@/lib/presignedUploadApi";
 import { renderThemePreviewPng } from "@/lib/canvas/renderThemePreview";
@@ -37,6 +38,7 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
   const backgroundColor = useThemeEditorStore((s) => s.backgroundColor);
   const setBackgroundColor = useThemeEditorStore((s) => s.setBackgroundColor);
   const setBackgroundImage = useThemeEditorStore((s) => s.setBackgroundImage);
+  const setBackgroundImageUrl = useThemeEditorStore((s) => s.setBackgroundImageUrl);
   const clearBackgroundImage = useThemeEditorStore((s) => s.clearBackgroundImage);
   const addDraft = useThemeDraftStore((s) => s.addDraft);
   const { remoteFrameId } = useThemeSession();
@@ -71,10 +73,17 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
 
       try {
         const remoteFrame = await getFrame(remoteFrameId);
-        if (!cancelled) {
-          importJson(toThemeExportJson(remoteFrame));
-          setTitle(remoteFrame.title || "");
-          setDescription(remoteFrame.description || "");
+        if (cancelled) return;
+        const imported = toThemeExportJson(remoteFrame);
+        importJson(imported);
+        setTitle(remoteFrame.title || "");
+        setDescription(remoteFrame.description || "");
+
+        // IMAGE 배경(key만 있음)은 url을 해석해 캔버스/썸네일에 렌더되도록 주입.
+        // 그래야 수정 저장 시 배경이 빠진 단색 썸네일로 저장되지 않는다.
+        if (imported.background?.type === "IMAGE" && imported.background.key) {
+          const url = await getImageUrlByKey(imported.background.key);
+          if (!cancelled && url) setBackgroundImageUrl(url);
         }
       } catch (error) {
         console.error(error);
@@ -93,7 +102,7 @@ export function ThemeEditorPage({ frameId }: { frameId: FrameId }) {
     return () => {
       cancelled = true;
     };
-  }, [importJson, remoteFrameId]);
+  }, [importJson, remoteFrameId, setBackgroundImageUrl]);
 
   useEffect(() => {
     if (remoteFrameId) return;

--- a/apps/web/lib/themeEditorStore.ts
+++ b/apps/web/lib/themeEditorStore.ts
@@ -94,6 +94,7 @@ type State = {
   setBackgroundColor: (color: string) => void;
   setBackgroundImage: (file: File) => void;
   setBackgroundImageKey: (key: string) => void;
+  setBackgroundImageUrl: (url: string) => void;
   clearBackgroundImage: () => void;
 
   addPhotoAssets: (
@@ -242,6 +243,13 @@ export const useThemeEditorStore = create<State>((set, get) => ({
     set((s) => {
       if (s.background.type !== "IMAGE") return s;
       return { background: { ...s.background, key } };
+    }),
+  // 저장된 원격 IMAGE 배경(key만 있음)을 편집/썸네일에 렌더하도록 해석된 url을 주입.
+  // 재업로드 대상이 아니므로 pendingBackgroundFile은 건드리지 않는다(기존 key 보존).
+  setBackgroundImageUrl: (url) =>
+    set((s) => {
+      if (s.background.type !== "IMAGE") return s;
+      return { background: { ...s.background, url } };
     }),
   clearBackgroundImage: () =>
     set((s) => {
@@ -640,6 +648,7 @@ export const useThemeEditorStore = create<State>((set, get) => ({
           data.background?.type === "COLOR"
             ? normalizeHexColor(data.background.value)
             : "111827",
+        pendingBackgroundFile: null,
         assets: {
           photos: [],
           stickers: s.assets.stickers,


### PR DESCRIPTION
#338 Codex P2 후속. 저장된 IMAGE 배경 프레임을 웹 에디터에서 열 때 key→url을 해석해 캔버스/썸네일에 배경을 렌더 → 수정 저장 시 단색 썸네일로 저장되던 문제 해결. 재업로드 없이 기존 key 보존.

웹 tsc 통과.

> 머지: 코드오너 승인 필요. CI/Codex 리뷰 확인 후 진행 예정.