### PR TITLE
feat(web): 랜딩페이지 STUDIO 재구성 + 그린 4컷 로고 (#336)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,106 +1,10 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import Image from "next/image";
-import { GuestTrialStartButton } from "@/components/guest/GuestTrialStartButton";
-import { BrandMark } from "@/components/layout/BrandMark";
+import { LandingView } from "@/components/landing/LandingView";
 
 export const metadata: Metadata = {
   alternates: { canonical: "/" },
 };
 
 export default function LandingPage() {
-  return (
-    <main className="hc-page-landing relative isolate min-h-dvh overflow-hidden text-[color:var(--hc-text)]">
-      <div className="hc-page-landing-overlay pointer-events-none absolute inset-0" />
-      <div className="mx-auto flex min-h-dvh w-full max-w-6xl flex-col px-4 py-4 sm:px-5 sm:py-5">
-        <header className="flex items-center justify-between gap-3">
-          <BrandMark href="/" tone="light" />
-
-          <div className="flex shrink-0 items-center gap-2">
-            <Link
-              href="/login"
-              className="hc-button-secondary rounded-full border px-3 py-2 text-[10px] transition-all duration-300 ease-out sm:px-4 sm:text-[11px]"
-            >
-              로그인
-            </Link>
-            <Link
-              href="/signup"
-              className="hc-button-hero rounded-full px-3 py-2 text-[10px] font-semibold transition-all duration-300 ease-out sm:px-4 sm:text-[11px]"
-            >
-              회원가입
-            </Link>
-          </div>
-        </header>
-
-        <section className="grid flex-1 items-center gap-8 py-6 lg:grid-cols-[minmax(0,1fr)_400px]">
-          <div className="max-w-2xl">
-            <div className="hc-accent-chip inline-flex rounded-full border px-3 py-1 text-[11px] font-medium">
-              오늘 하루를 네 컷으로 남겨보세요
-            </div>
-
-            <h1 className="mt-5 text-[30px] font-semibold leading-[1.2] tracking-[-0.04em] text-[color:var(--hc-text)] sm:text-[34px] md:text-[56px]">
-              오늘의 순간을
-              <span
-                className="block bg-clip-text text-transparent"
-                style={{
-                  backgroundImage:
-                    "linear-gradient(90deg, var(--hc-primary-strong), var(--hc-primary), var(--hc-hero-gradient-end))",
-                }}
-              >
-                다시 보고 싶은 네 컷으로
-              </span>
-            </h1>
-
-            <p className="mt-4 max-w-xl text-sm leading-6 text-[color:var(--hc-muted)] sm:text-[15px] sm:leading-7 md:text-base">
-              어디에서나 촬영하고, 꾸미고, 기록을 남겨보세요.
-            </p>
-
-            <div className="mt-6 grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:flex-wrap">
-              <Link
-                href="/login"
-                className="hc-button-hero inline-flex w-full items-center justify-center rounded-full px-5 py-3 text-sm font-semibold transition-all duration-300 ease-out sm:w-auto"
-              >
-                시작하기
-              </Link>
-              <GuestTrialStartButton />
-            </div>
-
-          </div>
-
-          <div className="mx-auto w-full max-w-[340px] sm:max-w-[360px]">
-            <div className="hc-surface-hero rounded-[30px] border p-4 backdrop-blur-xl">
-              <div className="hc-surface-inset overflow-hidden rounded-[24px] border">
-                <div className="relative aspect-[3/4] w-full">
-                  <Image
-                    src="/hero-image.png"
-                    alt="다양한 친구들이 야외에서 셀카를 찍는 네 컷 프레임 예시"
-                    fill
-                    sizes="(max-width: 1024px) 80vw, 360px"
-                    className="object-cover"
-                    priority
-                  />
-                </div>
-              </div>
-
-              <div className="mt-4">
-                <p className="text-[12px] leading-6 text-[color:var(--hc-muted)]">
-                  완성된 네컷은 기록에서 다시 보고 공유할 수 있어요.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <footer className="flex items-center justify-center gap-4 py-3 text-[11px] text-[color:var(--hc-muted)]">
-          <Link href="/terms" className="underline-offset-4 hover:underline">
-            서비스 이용약관
-          </Link>
-          <span aria-hidden>·</span>
-          <Link href="/privacy" className="underline-offset-4 hover:underline">
-            개인정보 처리방침
-          </Link>
-        </footer>
-      </div>
-    </main>
-  );
+  return <LandingView />;
 }

--- a/apps/web/components/guest/GuestTrialStartButton.tsx
+++ b/apps/web/components/guest/GuestTrialStartButton.tsx
@@ -1,17 +1,27 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useGuestTrialStore } from "@/lib/guestTrialStore";
 
-export function GuestTrialStartButton() {
+const DEFAULT_CLASS =
+  "hc-button-secondary inline-flex w-full items-center justify-center rounded-full border px-5 py-3 text-sm font-semibold transition-all duration-300 ease-out sm:w-auto";
+
+export function GuestTrialStartButton({
+  className,
+  children,
+}: {
+  className?: string;
+  children?: ReactNode;
+}) {
   const showGuestTrialNotice = useGuestTrialStore((state) => state.showGuestTrialNotice);
 
   return (
     <button
       type="button"
       onClick={showGuestTrialNotice}
-      className="hc-button-secondary inline-flex w-full items-center justify-center rounded-full border px-5 py-3 text-sm font-semibold transition-all duration-300 ease-out sm:w-auto"
+      className={className ?? DEFAULT_CLASS}
     >
-      체험하기
+      {children ?? "체험하기"}
     </button>
   );
 }

--- a/apps/web/components/landing/LandingView.tsx
+++ b/apps/web/components/landing/LandingView.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowRight, Plus } from "lucide-react";
+import { BrandMark } from "@/components/layout/BrandMark";
+import { FramePreview } from "@/components/frame/FramePreview";
+import type { FrameId } from "@/constants/frames";
+
+// STUDIO 마케팅 스테이지는 딥다크 고정(핸드오프 디자인 그대로).
+const GREEN = "#1ED760";
+
+const HERO_IMAGES = Array.from({ length: 4 }, () => "/hero-image.png");
+
+const STEPS = [
+  { n: "01", k: "SHOOT", t: "촬영하기", d: "카메라로 8장을 찍거나, 갤러리에서 골라요." },
+  { n: "02", k: "DECORATE", t: "꾸미기", d: "프레임·텍스트·스티커로 나만의 네 컷을 완성해요." },
+  { n: "03", k: "KEEP", t: "기록하기", d: "사진과 영상으로 저장하고, 기록에 차곡차곡 모아요." },
+] as const;
+
+const FRAMES: { id: FrameId; name: string; border: string }[] = [
+  { id: "classic-4", name: "클래식", border: "#000000" },
+  { id: "wide-4", name: "와이드", border: "#18181A" },
+  { id: "grid-4", name: "2×2 그리드", border: GREEN },
+  { id: "polaroid-4", name: "폴라로이드", border: "#FAFAF7" },
+];
+
+type Plan = {
+  id: "basic" | "plus" | "pro";
+  name: string;
+  price: string;
+  sub: string;
+  tagline: string;
+  feats: string[];
+  hot?: boolean;
+};
+
+const PLANS: Plan[] = [
+  {
+    id: "basic",
+    name: "BASIC",
+    price: "₩0",
+    sub: "/월",
+    tagline: "처음 시작하는 분께",
+    feats: ["기본 프레임 4종", "사진 + 영상 월 5회", "기록 보관", "링크 공유"],
+  },
+  {
+    id: "plus",
+    name: "PLUS",
+    price: "₩4,900",
+    sub: "/월",
+    tagline: "자주 남기는 분께",
+    feats: ["영상 월 30회", "워터마크 없이 저장", "원본 화질", "프레임 직접 꾸미기"],
+    hot: true,
+  },
+  {
+    id: "pro",
+    name: "PRO",
+    price: "₩9,900",
+    sub: "/월",
+    tagline: "무제한으로 누리고 싶다면",
+    feats: ["영상 무제한", "워터마크 없이 저장", "모든 프레임·편집 기능", "우선 지원"],
+  },
+];
+
+const FAQ_ITEMS: [string, string][] = [
+  [
+    "비회원도 사용할 수 있나요?",
+    "네, 가입 없이도 촬영은 바로 가능해요. 다운로드·저장·영상 생성·기록 보관은 가입(무료 BASIC) 후 이용할 수 있어요.",
+  ],
+  [
+    "사진 말고 영상도 만들어지나요?",
+    "네. 네 컷을 만들면 사진과 함께 영상 버전도 만들어져요. 영상 횟수는 플랜에 따라 달라요 (BASIC 월 5회 · PLUS 월 30회 · PRO 무제한).",
+  ],
+  [
+    "내 사진은 안전하게 보관되나요?",
+    "내 기록은 기본적으로 비공개예요. 공개되는 피드는 없고, 공유는 내가 링크를 보낼 때만 이뤄져요.",
+  ],
+  [
+    "워터마크 없이 저장할 수 있나요?",
+    "PLUS·PRO 플랜에서 워터마크 없이 원본 화질로 저장할 수 있어요.",
+  ],
+  [
+    "프레임은 직접 꾸밀 수 있나요?",
+    "네. 프레임 색·배경 이미지·텍스트·스티커를 더하고, 위치·회전까지 직접 편집할 수 있어요.",
+  ],
+];
+
+function WebNav() {
+  const [scrolled, setScrolled] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 10);
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <header
+      className="sticky top-0 z-40 transition-all duration-300"
+      style={{
+        background: scrolled ? "rgba(11,11,12,.82)" : "transparent",
+        backdropFilter: scrolled ? "saturate(1.2) blur(14px)" : "none",
+        borderBottom: `1px solid ${scrolled ? "rgba(255,255,255,.1)" : "transparent"}`,
+      }}
+    >
+      <div className="mx-auto flex h-[72px] max-w-[1160px] items-center justify-between px-7">
+        <BrandMark href="/" />
+        <nav className="hidden items-center gap-8 md:flex">
+          <a href="#how" className="text-sm font-semibold text-[#B3B3B3] hover:text-white">
+            서비스
+          </a>
+          <a href="#frames" className="text-sm font-semibold text-[#B3B3B3] hover:text-white">
+            프레임
+          </a>
+        </nav>
+        <div className="flex items-center gap-2.5">
+          <Link
+            href="/login"
+            className="rounded-full px-4 py-2 text-[13px] font-semibold text-white hover:bg-white/5"
+          >
+            로그인
+          </Link>
+          <Link
+            href="/signup"
+            className="rounded-full px-4 py-2 text-[13px] font-bold"
+            style={{ background: GREEN, color: "#06140A" }}
+          >
+            무료로 시작하기
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function ShowcaseFrame({
+  id,
+  className = "",
+}: {
+  id: FrameId;
+  className?: string;
+}) {
+  return (
+    <FramePreview
+      frameId={id}
+      images={HERO_IMAGES}
+      borderColor="#0B0B0C"
+      className={className}
+    />
+  );
+}
+
+function FaqList() {
+  const [open, setOpen] = useState(0);
+  return (
+    <div className="flex flex-col">
+      {FAQ_ITEMS.map(([q, a], i) => {
+        const on = open === i;
+        return (
+          <div key={q} className="border-t border-white/10">
+            <button
+              type="button"
+              onClick={() => setOpen(on ? -1 : i)}
+              className="flex w-full items-center justify-between gap-4 px-1 py-5 text-left"
+            >
+              <span className="text-[17px] font-bold tracking-tight text-white">{q}</span>
+              <span
+                className="grid h-6 w-6 shrink-0 place-items-center rounded-full border border-white/20 text-[#B3B3B3] transition-transform"
+                style={{ transform: on ? "rotate(45deg)" : "none" }}
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </span>
+            </button>
+            {on ? (
+              <p className="mb-5 mt-0 max-w-[680px] px-1 text-[15px] leading-[1.65] text-[#B3B3B3]">
+                {a}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+      <div className="border-t border-white/10" />
+    </div>
+  );
+}
+
+export function LandingView() {
+  return (
+    <div className="min-h-dvh bg-[#0B0B0C] text-white">
+      <WebNav />
+
+      {/* HERO */}
+      <section className="mx-auto grid max-w-[1160px] items-center gap-10 px-7 pb-16 pt-10 lg:grid-cols-[1.05fr_.95fr]">
+        <div>
+          <h1 className="mt-2 text-[40px] font-extrabold leading-[1.12] tracking-[-2px] sm:text-[58px]">
+            어디서든,
+            <br />
+            <span style={{ color: GREEN }}>오늘의 네&nbsp;컷</span>
+          </h1>
+          <p className="mb-7 mt-5 max-w-[430px] text-[17px] leading-[1.65] text-[#B3B3B3]">
+            특별한 하루를 사진으로 남겨보세요.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/signup"
+              className="inline-flex items-center gap-2 rounded-full px-7 py-3.5 text-[16px] font-bold"
+              style={{ background: GREEN, color: "#06140A" }}
+            >
+              무료로 시작하기 <ArrowRight className="h-[19px] w-[19px]" />
+            </Link>
+            <Link
+              href="/shoot"
+              className="inline-flex items-center rounded-full border border-white/20 px-6 py-3.5 text-[16px] font-bold text-white hover:border-white"
+            >
+              체험하기
+            </Link>
+          </div>
+        </div>
+
+        {/* 프레임 콜라주 — 우리 프로그래매틱 프레임 */}
+        <div className="relative flex h-[480px] items-center justify-center">
+          <div
+            className="h-[260px] -mr-6 drop-shadow-2xl"
+            style={{ transform: "rotate(-8deg) translateY(8px)", zIndex: 1 }}
+          >
+            <ShowcaseFrame id="classic-4" className="!h-full !w-auto" />
+          </div>
+          <div
+            className="h-[320px] drop-shadow-2xl"
+            style={{ transform: "rotate(3deg)", zIndex: 3 }}
+          >
+            <ShowcaseFrame id="grid-4" className="!h-full !w-auto" />
+          </div>
+          <div
+            className="h-[260px] -ml-6 drop-shadow-2xl"
+            style={{ transform: "rotate(9deg) translateY(8px)", zIndex: 2 }}
+          >
+            <ShowcaseFrame id="polaroid-4" className="!h-full !w-auto" />
+          </div>
+        </div>
+      </section>
+
+      {/* HOW */}
+      <section id="how" className="border-y border-white/10 bg-black">
+        <div className="mx-auto max-w-[1160px] px-7 py-[76px]">
+          <div className="mb-10 flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <span className="font-mono text-xs tracking-[3px]" style={{ color: GREEN }}>
+                ● REC · 사용법
+              </span>
+              <h2 className="mt-3.5 text-[40px] font-extrabold leading-[1.05] tracking-[-1.4px]">
+                찍고 — 꾸미고 — 남기고.
+                <br />네 컷이면 끝.
+              </h2>
+            </div>
+            <span className="font-mono text-xs text-white/40">00:03 / 00:08</span>
+          </div>
+
+          <div className="overflow-hidden rounded-[10px] border border-white/[0.08] bg-[#0E0E0F]">
+            <div className="h-[18px] border-b border-white/[0.06] bg-[repeating-linear-gradient(90deg,transparent_0_12px,rgba(255,255,255,.07)_12px_22px)]" />
+            <div className="grid md:grid-cols-3">
+              {STEPS.map((s, i) => (
+                <div
+                  key={s.n}
+                  className="relative px-[30px] pb-[38px] pt-[34px]"
+                  style={{ borderLeft: i ? "1px dashed rgba(255,255,255,.12)" : "none" }}
+                >
+                  <div className="mb-[18px] flex items-baseline gap-3">
+                    <span
+                      className="font-mono text-[58px] font-extrabold leading-[.8] tracking-[-3px]"
+                      style={{ color: i === 0 ? GREEN : "rgba(255,255,255,.16)" }}
+                    >
+                      {s.n}
+                    </span>
+                    <span
+                      className="font-mono text-[11px] tracking-[2px]"
+                      style={{ color: i === 0 ? GREEN : "rgba(255,255,255,.45)" }}
+                    >
+                      {s.k}
+                    </span>
+                  </div>
+                  <h3 className="mb-2 text-[22px] font-extrabold tracking-[-.4px] text-white">
+                    {s.t}
+                  </h3>
+                  <p className="text-[14.5px] leading-[1.65] text-white/60">{s.d}</p>
+                </div>
+              ))}
+            </div>
+            <div className="h-[18px] border-t border-white/[0.06] bg-[repeating-linear-gradient(90deg,transparent_0_12px,rgba(255,255,255,.07)_12px_22px)]" />
+          </div>
+        </div>
+      </section>
+
+      {/* FRAMES */}
+      <section id="frames" className="mx-auto max-w-[1160px] px-7 py-20">
+        <div className="mb-11">
+          <span className="font-mono text-xs tracking-[3px]" style={{ color: GREEN }}>
+            FRAMES · 프레임
+          </span>
+          <h2 className="mt-3 text-[38px] font-extrabold tracking-[-1.2px]">
+            오늘의 기분대로, <span style={{ color: GREEN }}>네 가지 프레임</span>
+          </h2>
+        </div>
+        <div className="flex flex-wrap items-end justify-center gap-9">
+          {FRAMES.map((f, i) => (
+            <div key={f.id} className="text-center">
+              <div
+                className="inline-block drop-shadow-2xl"
+                style={{ transform: `rotate(${(i - 1.5) * 2}deg)` }}
+              >
+                <div className={f.id === "wide-4" ? "w-[240px]" : "h-[210px]"}>
+                  <ShowcaseFrame
+                    id={f.id}
+                    className={f.id === "wide-4" ? "!w-full" : "!h-full !w-auto"}
+                  />
+                </div>
+              </div>
+              <h4 className="mb-1 mt-5 text-[17px] font-extrabold">{f.name}</h4>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* PRICING */}
+      <section className="border-y border-white/10 bg-[#18181A]">
+        <div className="mx-auto max-w-[1160px] px-7 py-20">
+          <div className="mb-9">
+            <span className="font-mono text-xs tracking-[3px]" style={{ color: GREEN }}>
+              PRICING · 요금제
+            </span>
+            <h2 className="mt-3 text-[38px] font-extrabold tracking-[-1.2px]">
+              비회원도 촬영은 무료
+            </h2>
+          </div>
+          <div className="grid items-stretch gap-[18px] md:grid-cols-3">
+            {PLANS.map((p) => {
+              const hot = p.hot;
+              const label =
+                p.id === "basic" ? "무료로 시작하기" : p.id === "pro" ? "PRO 시작하기" : "PLUS 시작하기";
+              return (
+                <div
+                  key={p.id}
+                  className="flex flex-col rounded-[18px] px-[26px] py-7"
+                  style={{
+                    background: hot ? GREEN : "transparent",
+                    border: hot ? "none" : "1px solid rgba(255,255,255,.1)",
+                    boxShadow: hot ? "0 24px 50px -24px rgba(30,215,96,.5)" : "none",
+                  }}
+                >
+                  <div className="flex min-h-[22px] items-center justify-between">
+                    <span
+                      className="text-[15px] font-extrabold tracking-[.4px]"
+                      style={{ color: hot ? "#06140A" : "#fff" }}
+                    >
+                      {p.name}
+                    </span>
+                    {hot ? (
+                      <span
+                        className="rounded-full px-2.5 py-1 text-[11px] font-extrabold"
+                        style={{ background: "#06140A", color: GREEN }}
+                      >
+                        인기
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mb-2.5 mt-[18px] flex items-baseline gap-1.5">
+                    <span
+                      className="text-[42px] font-extrabold leading-[.9] tracking-[-1.6px]"
+                      style={{ color: hot ? "#06140A" : "#fff" }}
+                    >
+                      {p.price}
+                    </span>
+                    <span
+                      className="font-mono text-[13px]"
+                      style={{ color: hot ? "rgba(6,20,10,.62)" : "#6F6F73" }}
+                    >
+                      {p.sub}
+                    </span>
+                  </div>
+                  <p
+                    className="mb-6 text-[13.5px]"
+                    style={{ color: hot ? "rgba(6,20,10,.7)" : "#B3B3B3" }}
+                  >
+                    {p.tagline}
+                  </p>
+                  <div className="mb-[26px] flex flex-col gap-3.5">
+                    {p.feats.map((feat) => (
+                      <div key={feat} className="flex items-start gap-2.5">
+                        <span
+                          className="mt-0.5 grid h-[19px] w-[19px] shrink-0 place-items-center rounded-full text-[11px] font-bold"
+                          style={{
+                            background: hot ? "rgba(6,20,10,.12)" : "rgba(30,215,96,.16)",
+                            color: hot ? "#06140A" : GREEN,
+                          }}
+                        >
+                          ✓
+                        </span>
+                        <span
+                          className="text-[13.5px] leading-[1.4]"
+                          style={{ color: hot ? "#06140A" : "#fff" }}
+                        >
+                          {feat}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                  <Link
+                    href={p.id === "basic" ? "/signup" : "/login"}
+                    className="mt-auto flex h-[50px] w-full items-center justify-center rounded-full text-[14.5px] font-extrabold transition-transform hover:scale-[1.025]"
+                    style={{
+                      background: hot ? "#06140A" : "transparent",
+                      color: hot ? GREEN : "#fff",
+                      border: hot ? "none" : "1px solid rgba(255,255,255,.18)",
+                    }}
+                  >
+                    {label}
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="mx-auto max-w-[820px] px-7 py-20">
+        <h2 className="mb-8 text-[36px] font-extrabold tracking-[-1px]">
+          자주 묻는 <span style={{ color: GREEN }}>질문들</span>
+        </h2>
+        <FaqList />
+      </section>
+
+      {/* CTA */}
+      <section className="mx-auto max-w-[1160px] px-7 pb-[90px] pt-5">
+        <div
+          className="flex flex-wrap items-center justify-between gap-5 rounded-3xl px-10 py-9"
+          style={{ background: GREEN }}
+        >
+          <h2 className="text-[30px] font-extrabold tracking-[-1px]" style={{ color: "#06140A" }}>
+            오늘 하루, 네 컷으로 남겨볼까요?
+          </h2>
+          <Link
+            href="/signup"
+            className="inline-flex shrink-0 items-center gap-2 rounded-full bg-white px-[30px] py-3.5 text-[16px] font-bold text-[#0B0B0C] hover:bg-zinc-100"
+          >
+            무료로 시작하기 <ArrowRight className="h-[19px] w-[19px]" />
+          </Link>
+        </div>
+      </section>
+
+      {/* FOOTER */}
+      <footer className="border-t border-white/10 bg-[#161617]">
+        <div className="mx-auto flex max-w-[1160px] flex-wrap justify-between gap-8 px-7 pb-10 pt-12">
+          <div className="max-w-[280px]">
+            <BrandMark href="/" />
+            <p className="mt-3.5 text-[13px] leading-[1.6] text-[#6F6F73]">
+              온라인 인생네컷 서비스.
+              <br />
+              오늘 하루를 네 컷으로 남기세요.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-14">
+            {[
+              ["서비스", ["촬영", "프레임", "기록"]],
+              ["정책", ["이용약관", "개인정보"]],
+            ].map(([h, items]) => (
+              <div key={h as string}>
+                <h6 className="mb-3.5 text-[13px] font-extrabold tracking-[.3px]">{h}</h6>
+                {(items as string[]).map((it) => (
+                  <span key={it} className="mb-2.5 block text-[13.5px] text-[#B3B3B3]">
+                    {it}
+                  </span>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="border-t border-white/10">
+          <div className="mx-auto flex max-w-[1160px] justify-between px-7 py-[18px]">
+            <span className="font-mono text-[11px] text-[#6F6F73]">© 2026 Harucut</span>
+            <span className="font-mono text-[11px] text-[#6F6F73]">harucut.com</span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/components/landing/LandingView.tsx
+++ b/apps/web/components/landing/LandingView.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowRight, Plus } from "lucide-react";
 import { BrandMark } from "@/components/layout/BrandMark";
 import { FramePreview } from "@/components/frame/FramePreview";
+import { GuestTrialStartButton } from "@/components/guest/GuestTrialStartButton";
 import type { FrameId } from "@/constants/frames";
 
 // STUDIO 마케팅 스테이지는 딥다크 고정(핸드오프 디자인 그대로).
@@ -86,6 +87,17 @@ const FAQ_ITEMS: [string, string][] = [
   ],
 ];
 
+const FOOTER_COLS: { title: string; items: { label: string; href?: string }[] }[] = [
+  { title: "서비스", items: [{ label: "촬영" }, { label: "프레임" }, { label: "기록" }] },
+  {
+    title: "정책",
+    items: [
+      { label: "이용약관", href: "/terms" },
+      { label: "개인정보", href: "/privacy" },
+    ],
+  },
+];
+
 function WebNav() {
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
@@ -104,7 +116,7 @@ function WebNav() {
       }}
     >
       <div className="mx-auto flex h-[72px] max-w-[1160px] items-center justify-between px-7">
-        <BrandMark href="/" />
+        <BrandMark href="/" tone="light" />
         <nav className="hidden items-center gap-8 md:flex">
           <a href="#how" className="text-sm font-semibold text-[#B3B3B3] hover:text-white">
             서비스
@@ -208,12 +220,9 @@ export function LandingView() {
             >
               무료로 시작하기 <ArrowRight className="h-[19px] w-[19px]" />
             </Link>
-            <Link
-              href="/shoot"
-              className="inline-flex items-center rounded-full border border-white/20 px-6 py-3.5 text-[16px] font-bold text-white hover:border-white"
-            >
+            <GuestTrialStartButton className="inline-flex items-center rounded-full border border-white/20 px-6 py-3.5 text-[16px] font-bold text-white transition-colors hover:border-white">
               체험하기
-            </Link>
+            </GuestTrialStartButton>
           </div>
         </div>
 
@@ -452,7 +461,7 @@ export function LandingView() {
       <footer className="border-t border-white/10 bg-[#161617]">
         <div className="mx-auto flex max-w-[1160px] flex-wrap justify-between gap-8 px-7 pb-10 pt-12">
           <div className="max-w-[280px]">
-            <BrandMark href="/" />
+            <BrandMark href="/" tone="light" />
             <p className="mt-3.5 text-[13px] leading-[1.6] text-[#6F6F73]">
               온라인 인생네컷 서비스.
               <br />
@@ -460,17 +469,24 @@ export function LandingView() {
             </p>
           </div>
           <div className="flex flex-wrap gap-14">
-            {[
-              ["서비스", ["촬영", "프레임", "기록"]],
-              ["정책", ["이용약관", "개인정보"]],
-            ].map(([h, items]) => (
-              <div key={h as string}>
-                <h6 className="mb-3.5 text-[13px] font-extrabold tracking-[.3px]">{h}</h6>
-                {(items as string[]).map((it) => (
-                  <span key={it} className="mb-2.5 block text-[13.5px] text-[#B3B3B3]">
-                    {it}
-                  </span>
-                ))}
+            {FOOTER_COLS.map((col) => (
+              <div key={col.title}>
+                <h6 className="mb-3.5 text-[13px] font-extrabold tracking-[.3px]">{col.title}</h6>
+                {col.items.map((it) =>
+                  it.href ? (
+                    <Link
+                      key={it.label}
+                      href={it.href}
+                      className="mb-2.5 block text-[13.5px] text-[#B3B3B3] hover:text-white"
+                    >
+                      {it.label}
+                    </Link>
+                  ) : (
+                    <span key={it.label} className="mb-2.5 block text-[13.5px] text-[#B3B3B3]">
+                      {it.label}
+                    </span>
+                  ),
+                )}
               </div>
             ))}
           </div>

--- a/apps/web/components/landing/LandingView.tsx
+++ b/apps/web/components/landing/LandingView.tsx
@@ -227,21 +227,21 @@ export function LandingView() {
         </div>
 
         {/* 프레임 콜라주 — 우리 프로그래매틱 프레임 */}
-        <div className="relative flex h-[480px] items-center justify-center">
+        <div className="relative flex h-[340px] items-center justify-center overflow-hidden sm:h-[480px]">
           <div
-            className="h-[260px] -mr-6 drop-shadow-2xl"
+            className="-mr-5 h-[180px] drop-shadow-2xl sm:-mr-6 sm:h-[260px]"
             style={{ transform: "rotate(-8deg) translateY(8px)", zIndex: 1 }}
           >
             <ShowcaseFrame id="classic-4" className="!h-full !w-auto" />
           </div>
           <div
-            className="h-[320px] drop-shadow-2xl"
+            className="h-[220px] drop-shadow-2xl sm:h-[320px]"
             style={{ transform: "rotate(3deg)", zIndex: 3 }}
           >
             <ShowcaseFrame id="grid-4" className="!h-full !w-auto" />
           </div>
           <div
-            className="h-[260px] -ml-6 drop-shadow-2xl"
+            className="-ml-5 h-[180px] drop-shadow-2xl sm:-ml-6 sm:h-[260px]"
             style={{ transform: "rotate(9deg) translateY(8px)", zIndex: 2 }}
           >
             <ShowcaseFrame id="polaroid-4" className="!h-full !w-auto" />

--- a/apps/web/components/layout/BrandMark.tsx
+++ b/apps/web/components/layout/BrandMark.tsx
@@ -44,7 +44,11 @@ export function BrandMark({
   label = "하루컷",
   compact = false,
   className = "",
+  tone,
 }: BrandMarkProps) {
+  // tone=light/dark는 고정 배경(예: 다크 랜딩) 위에서 테마와 무관하게 글자색을 강제한다.
+  const labelColor =
+    tone === "light" ? "#FFFFFF" : tone === "dark" ? "#0B0B0C" : "var(--hc-text)";
   return (
     <Link
       href={href}
@@ -52,7 +56,10 @@ export function BrandMark({
       className={`inline-flex items-center gap-2.5 transition-opacity hover:opacity-90 ${className}`.trim()}
     >
       <FourCutMark size={compact ? 26 : 30} />
-      <span className="text-lg font-extrabold tracking-tight text-[color:var(--hc-text)]">
+      <span
+        className="text-lg font-extrabold tracking-tight"
+        style={{ color: labelColor }}
+      >
         {label}
       </span>
     </Link>

--- a/apps/web/components/layout/BrandMark.tsx
+++ b/apps/web/components/layout/BrandMark.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { Sparkles } from "lucide-react";
 
 type BrandMarkProps = {
   href: string;
@@ -10,6 +9,35 @@ type BrandMarkProps = {
   className?: string;
   tone?: "dark" | "light";
 };
+
+// STUDIO 로고 — 딥다크 라운드 + 그린 4컷 그라데이션 스트립(A안).
+const MARK_SHADES = ["#7BEAA6", "#4FDD86", "#2FD06B", "#17B551"];
+
+function FourCutMark({ size = 30 }: { size?: number }) {
+  const width = Math.round(size * 0.74);
+  return (
+    <svg
+      width={width}
+      height={size}
+      viewBox="0 0 24 32"
+      aria-hidden
+      style={{ display: "block" }}
+    >
+      <rect width="24" height="32" rx="6" fill="#0B0B0C" />
+      {MARK_SHADES.map((color, i) => (
+        <rect
+          key={color}
+          x="5"
+          y={4 + i * 6.35}
+          width="14"
+          height="5"
+          rx="1.6"
+          fill={color}
+        />
+      ))}
+    </svg>
+  );
+}
 
 export function BrandMark({
   href,
@@ -21,34 +49,12 @@ export function BrandMark({
     <Link
       href={href}
       aria-label="Harucut home"
-      className={`inline-flex items-center gap-3 transition-opacity hover:opacity-100 ${className}`.trim()}
+      className={`inline-flex items-center gap-2.5 transition-opacity hover:opacity-90 ${className}`.trim()}
     >
-      <span
-        className="grid h-10 w-10 place-items-center rounded-2xl border border-[color:var(--hc-border)]"
-        style={{
-          background: "var(--hc-brand-badge-bg)",
-          color: "var(--hc-brand-badge-text)",
-          boxShadow: "var(--hc-brand-badge-shadow)",
-        }}
-      >
-        <Sparkles className="h-4 w-4" />
+      <FourCutMark size={compact ? 26 : 30} />
+      <span className="text-lg font-extrabold tracking-tight text-[color:var(--hc-text)]">
+        {label}
       </span>
-      {!compact ? (
-        <span className="flex min-w-0 flex-col">
-          <span className="text-[10px] uppercase tracking-[0.26em] text-[color:var(--hc-brand-overline)]">
-            Record your four cuts
-          </span>
-          <span
-            className="text-base font-semibold tracking-tight text-[color:var(--hc-text)]"
-          >
-            {label}
-          </span>
-        </span>
-      ) : (
-        <span className="text-sm font-semibold tracking-tight text-[color:var(--hc-text)]">
-          {label}
-        </span>
-      )}
     </Link>
   );
 }


### PR DESCRIPTION
핸드오프 디자인대로 웹 랜딩 재구성 + 로고 교체.

- BrandMark: Sparkles+영문 오버라인 → 그린 4컷 스트립 마크 + 하루컷 (기존 로고가 안 바뀌던 문제).
- 랜딩: nav/히어로/HOW 3스텝/프레임/요금제/FAQ/CTA/푸터, 딥다크 스테이지.
- 프레임 비주얼은 PNG 테마 대신 우리 프로그래매틱 FramePreview 사용(프레임은 기존 것 유지 방침).

웹 tsc 통과.

> 머지: 코드오너 승인 필요. CI + Codex 리뷰 확인 후 진행.