### PR TITLE
feat(web): auth 반응형 셸 + 소셜 3종 (#336 후속)

### DIFF
--- a/apps/web/components/auth/AuthPageShell.test.tsx
+++ b/apps/web/components/auth/AuthPageShell.test.tsx
@@ -1,32 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import { AuthPageShell } from "@/components/auth/AuthPageShell";
 
-const mockPageHeader = jest.fn();
-
-jest.mock("@/components/layout/PageHeader", () => ({
-  PageHeader: (props: unknown) => {
-    mockPageHeader(props);
-    return <div data-testid="page-header" />;
-  },
-}));
-
 describe("AuthPageShell", () => {
-  beforeEach(() => {
-    mockPageHeader.mockClear();
-  });
-
-  test("pins the auth-page brand link to the landing page", () => {
+  test("renders the title and pins the brand link to the landing page", () => {
     render(
       <AuthPageShell title="로그인" description="설명">
         <div>content</div>
       </AuthPageShell>,
     );
 
-    expect(screen.getByTestId("page-header")).toBeInTheDocument();
-    expect(mockPageHeader).toHaveBeenCalledWith(
-      expect.objectContaining({
-        brandHref: "/",
-      }),
-    );
+    expect(screen.getByRole("heading", { name: "로그인" })).toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+
+    const homeLinks = screen.getAllByRole("link", { name: /Harucut home/i });
+    expect(homeLinks.length).toBeGreaterThan(0);
+    homeLinks.forEach((link) => expect(link).toHaveAttribute("href", "/"));
   });
 });

--- a/apps/web/components/auth/AuthPageShell.tsx
+++ b/apps/web/components/auth/AuthPageShell.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { PageHeader } from "../layout/PageHeader";
+import { BrandMark } from "../layout/BrandMark";
+import { FramePreview } from "../frame/FramePreview";
 
 type Props = {
   title: string;
@@ -10,19 +11,67 @@ type Props = {
   footer?: ReactNode;
 };
 
+// 사진은 추후 교체될 placeholder.
+const COLLAGE = Array.from({ length: 4 }, () => "/hero-image.png");
+
 export function AuthPageShell({ title, description, children, footer }: Props) {
   return (
-    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-6">
-        <PageHeader
-          title={title}
-          description={<>{description}</>}
-          brandHref="/"
-        />
+    <main className="grid min-h-dvh lg:grid-cols-[1.05fr_1fr]">
+      {/* 브랜드 패널 — 데스크톱(lg+)에서만, handoff web 분할 레이아웃의 다크 스테이지 */}
+      <aside className="relative hidden overflow-hidden bg-[#0B0B0C] p-14 lg:flex lg:flex-col lg:justify-between">
+        <div className="relative z-10">
+          <BrandMark href="/" tone="light" />
+        </div>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 flex items-center justify-center"
+        >
+          <div
+            className="-mr-6 h-[300px] drop-shadow-2xl"
+            style={{ transform: "rotate(-7deg)" }}
+          >
+            <FramePreview
+              frameId="classic-4"
+              images={COLLAGE}
+              borderColor="#0B0B0C"
+              className="!h-full !w-auto"
+            />
+          </div>
+          <div className="h-[330px] drop-shadow-2xl" style={{ transform: "rotate(5deg)" }}>
+            <FramePreview
+              frameId="grid-4"
+              images={COLLAGE}
+              borderColor="#0B0B0C"
+              className="!h-full !w-auto"
+            />
+          </div>
+        </div>
+        <div className="relative z-10 mt-auto">
+          <p className="text-[34px] font-extrabold leading-[1.2] tracking-[-1px] text-white">
+            오늘 하루를
+            <br />네 컷으로.
+          </p>
+          <p className="mt-3.5 max-w-[300px] text-[15px] leading-[1.6] text-white/60">
+            찍고, 꾸미고, 기록하는 나만의 인생네컷. 하루컷에 오신 걸 환영해요.
+          </p>
+        </div>
+      </aside>
 
-        {children}
-
-        {footer ? <div className="pt-1">{footer}</div> : null}
+      {/* 폼 패널 — 테마(라이트/다크) 반응. 폰/태블릿에선 앱 스타일 단일 컬럼 */}
+      <div className="hc-page-app flex items-center justify-center px-5 py-10 text-[color:var(--hc-text)]">
+        <div className="w-full max-w-[380px]">
+          <div className="mb-8 lg:hidden">
+            <BrandMark href="/" />
+          </div>
+          <h1 className="text-[28px] font-extrabold tracking-tight text-[color:var(--hc-text)]">
+            {title}
+          </h1>
+          {description ? (
+            <p className="mt-2 text-sm leading-6 text-[color:var(--hc-muted)]">{description}</p>
+          ) : null}
+          <div className="mt-7">{children}</div>
+          {footer ? <div className="pt-5">{footer}</div> : null}
+        </div>
       </div>
     </main>
   );

--- a/apps/web/components/auth/SocialLoginSection.tsx
+++ b/apps/web/components/auth/SocialLoginSection.tsx
@@ -1,11 +1,27 @@
 "use client";
 
-import { loginKakao, loginNaver } from "@/lib/authLogin";
+import { loginGoogle, loginKakao, loginNaver } from "@/lib/authLogin";
 
 type Props = {
   mode?: "login" | "signup";
   redirectTo?: string | null;
 };
+
+function GoogleSymbol() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      className="h-[18px] w-[18px] shrink-0"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path fill="#4285F4" d="M21.6 12.2c0-.6 0-1.2-.2-1.8H12v3.5h5.4a4.6 4.6 0 0 1-2 3v2.5h3.2c1.9-1.7 3-4.3 3-7.2Z" />
+      <path fill="#34A853" d="M12 22c2.7 0 5-1 6.6-2.6l-3.2-2.5c-.9.6-2 1-3.4 1-2.6 0-4.8-1.7-5.6-4.1H3.1v2.6A10 10 0 0 0 12 22Z" />
+      <path fill="#FBBC05" d="M6.4 13.8a6 6 0 0 1 0-3.6V7.6H3.1a10 10 0 0 0 0 8.8l3.3-2.6Z" />
+      <path fill="#EA4335" d="M12 6.3c1.5 0 2.8.5 3.8 1.5l2.8-2.8A10 10 0 0 0 3.1 7.6l3.3 2.6C7.2 8 9.4 6.3 12 6.3Z" />
+    </svg>
+  );
+}
 
 function KakaoSymbol() {
   return (
@@ -88,6 +104,14 @@ export function SocialLoginSection({ mode = "login", redirectTo }: Props) {
       </div>
 
       <div className="flex flex-col gap-2">
+        <SocialButton
+          onClick={() => loginGoogle(redirectTo)}
+          icon={<GoogleSymbol />}
+          label="구글 로그인"
+          className="border border-[color:var(--hc-border)] bg-white text-[rgba(0,0,0,0.72)] shadow-[0_14px_32px_rgba(15,23,42,0.08)] hover:bg-zinc-50"
+          iconContainerClassName="border-r border-[color:var(--hc-border)] bg-white"
+        />
+
         <SocialButton
           onClick={() => loginKakao(redirectTo)}
           icon={<KakaoSymbol />}

--- a/apps/web/lib/authLogin.ts
+++ b/apps/web/lib/authLogin.ts
@@ -2,6 +2,13 @@ import { persistSocialLoginRedirect } from "@/lib/socialLoginRedirect";
 
 const backendBase = process.env.NEXT_PUBLIC_BASE_URL;
 
+// 백엔드 Google OAuth 등록 예정. 등록 전에는 콜백이 실패할 수 있음(프런트 버튼 선반영).
+export function loginGoogle(redirectTo?: string | null) {
+  persistSocialLoginRedirect(redirectTo);
+  const googleAuthUrl = `${backendBase}/oauth2/authorization/google`;
+  window.location.href = googleAuthUrl;
+}
+
 export function loginKakao(redirectTo?: string | null) {
   persistSocialLoginRedirect(redirectTo);
   const kakaoAuthUrl = `${backendBase}/oauth2/authorization/kakao`;


### PR DESCRIPTION
auth 그룹: 반응형(데스크톱=분할 브랜드패널, 폰/태블릿=앱 폼) + 소셜 3종(구글/카카오/네이버). Google은 백엔드 OAuth 등록 후 작동. tsc·auth 테스트 통과.