### PR TITLE
웹 촬영·업로드 플로우 페이지 반응형 재구성

### DIFF
--- a/apps/web/app/shoot/page.tsx
+++ b/apps/web/app/shoot/page.tsx
@@ -56,12 +56,14 @@ function ShootPageContent() {
   };
 
   return (
-    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-4">
+    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)] sm:px-4 lg:px-8 lg:py-10">
+      <div className="mx-auto flex w-full max-w-md flex-col gap-4 lg:max-w-5xl lg:gap-6">
         <PageHeader
           backHref={accessMode === "guest" ? "/" : "/home"}
           backLabel={accessMode === "guest" ? "처음으로" : "홈으로"}
           brandHref={accessMode === "guest" ? "/shoot" : "/home"}
+          title="프레임 선택"
+          description="촬영할 4컷 프레임을 골라주세요."
         />
         <StepProgress current={1} total={4} label="프레임 선택" />
 

--- a/apps/web/app/shoot/result/page.tsx
+++ b/apps/web/app/shoot/result/page.tsx
@@ -637,8 +637,8 @@ export default function ShootResultPage() {
   };
 
   return (
-    <main className="hc-page-app min-h-dvh px-4 py-6 text-[color:var(--hc-text)]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-6">
+    <main className="hc-page-app min-h-dvh px-4 py-6 text-[color:var(--hc-text)] lg:px-8 lg:py-10">
+      <div className="mx-auto flex w-full max-w-md flex-col gap-6 lg:max-w-3xl">
         <PageHeader
           title="촬영 결과"
           brandHref={guestMode ? "/shoot" : "/home"}
@@ -715,7 +715,13 @@ export default function ShootResultPage() {
           </section>
         ) : null}
 
-        <section className="space-y-3">
+        <section
+          className={
+            shouldPrepareVideo
+              ? "mx-auto grid w-full max-w-md gap-3 sm:max-w-none sm:grid-cols-2"
+              : "mx-auto w-full max-w-md"
+          }
+        >
           <FramePreview
             frameId={frameId}
             media={previewImage}

--- a/apps/web/app/theme/page.tsx
+++ b/apps/web/app/theme/page.tsx
@@ -60,9 +60,14 @@ function ThemePageContent() {
   };
 
   return (
-    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-4">
-        <PageHeader backHref="/home" backLabel="처음으로" />
+    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)] sm:px-4 lg:px-8 lg:py-10">
+      <div className="mx-auto flex w-full max-w-md flex-col gap-4 lg:max-w-5xl lg:gap-6">
+        <PageHeader
+          backHref="/home"
+          backLabel="처음으로"
+          title="프레임 꾸미기"
+          description="새 프레임을 만들거나 저장한 프레임을 이어서 꾸며보세요."
+        />
         <StepProgress current={1} total={2} label="프레임 선택" />
 
         <FramePicker

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -52,11 +52,12 @@ function UploadFramePageContent() {
   };
 
   return (
-    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-4">
+    <main className="hc-page-app min-h-dvh px-2 py-6 text-[color:var(--hc-text)] sm:px-4 lg:px-8 lg:py-10">
+      <div className="mx-auto flex w-full max-w-md flex-col gap-4 lg:max-w-5xl lg:gap-6">
         <PageHeader
           backHref="/home"
           backLabel="홈으로"
+          title="프레임 선택"
           description="업로드로 만들 프레임을 먼저 골라 주세요."
         />
         <StepProgress current={1} total={3} label="프레임 선택" />

--- a/apps/web/app/upload/result/page.tsx
+++ b/apps/web/app/upload/result/page.tsx
@@ -564,8 +564,8 @@ export default function UploadResultPage() {
   };
 
   return (
-    <main className="hc-page-app min-h-dvh px-4 py-6 text-[color:var(--hc-text)]">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-6">
+    <main className="hc-page-app min-h-dvh px-4 py-6 text-[color:var(--hc-text)] lg:px-8 lg:py-10">
+      <div className="mx-auto flex w-full max-w-md flex-col gap-6 lg:max-w-3xl">
         <PageHeader title="업로드 결과" />
         <StepProgress current={3} total={3} label="결과 확인" />
 
@@ -630,7 +630,13 @@ export default function UploadResultPage() {
           </section>
         ) : null}
 
-        <section className="space-y-3">
+        <section
+          className={
+            shouldPrepareVideo
+              ? "mx-auto grid w-full max-w-md gap-3 sm:max-w-none sm:grid-cols-2"
+              : "mx-auto w-full max-w-md"
+          }
+        >
           <FramePreview
             frameId={frameId}
             media={previewImage}

--- a/apps/web/components/frame/FramePicker.tsx
+++ b/apps/web/components/frame/FramePicker.tsx
@@ -30,7 +30,7 @@ export function FramePicker({
   return (
     <>
       <section className="flex flex-col gap-3">
-        <div className="grid grid-cols-2 gap-4 max-md:hidden">
+        <div className="grid grid-cols-2 gap-4 max-md:hidden lg:grid-cols-3 xl:grid-cols-4">
           {FRAME_CONFIGS.map((frame) => (
             <FramePickerCard
               key={frame.id}
@@ -72,12 +72,12 @@ export function FramePicker({
         </div>
       </section>
 
-      <div className="mt-2 flex justify-end">
+      <div className="mt-2 flex justify-stretch md:justify-end">
         <button
           type="button"
           disabled={confirmDisabled}
           onClick={onConfirm}
-          className="hc-button-primary rounded-full px-5 py-2.5 text-xs font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+          className="hc-button-primary w-full rounded-full px-5 py-3.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50 md:w-auto md:py-2.5 md:text-xs"
         >
           {confirmLabel}
         </button>

--- a/apps/web/components/frame/FrameSelectPanel.tsx
+++ b/apps/web/components/frame/FrameSelectPanel.tsx
@@ -63,10 +63,10 @@ export function FrameSelectPanel({
   const canProceed = selectedCount === maxSelect;
 
   return (
-    <div className="flex flex-col gap-4 xl:grid xl:grid-cols-[minmax(0,1fr)_320px] xl:items-start">
+    <div className="flex flex-col gap-4 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start lg:gap-6">
       <section className="flex flex-col gap-3">
         {frameId ? (
-          <section className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3 xl:hidden">
+          <section className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3 lg:hidden">
             <p className="text-sm font-semibold text-zinc-100">프레임 미리보기</p>
             <div className="flex justify-center">
               <FramePreview
@@ -87,7 +87,7 @@ export function FrameSelectPanel({
               {emptyStateText}
             </div>
           ) : (
-            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 xl:grid-cols-4">
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-5">
               {baseItems.map((item, index) => {
                 const slotIndex = selectedIndexes.indexOf(index);
                 const isSelected = slotIndex !== -1;
@@ -166,9 +166,9 @@ export function FrameSelectPanel({
         </section>
       </section>
 
-      <aside className="flex flex-col gap-3 xl:sticky xl:top-6">
+      <aside className="flex flex-col gap-3 lg:sticky lg:top-6">
         {frameId ? (
-          <section className="hidden flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3 xl:flex">
+          <section className="hidden flex-col gap-2 rounded-2xl border border-white/10 bg-white/[0.04] p-3 lg:flex">
             <p className="text-sm font-semibold text-zinc-100">프레임 미리보기</p>
             <div className="flex justify-center">
               <FramePreview


### PR DESCRIPTION
## 개요
handoff 디자인 기준으로 웹 촬영/업로드 플로우 페이지들을 반응형으로 재구성했습니다. 데스크톱(>=lg)은 handoff web 처럼 와이드 레이아웃, 폰/태블릿(<lg)은 앱 느낌(풀폭 버튼, 가로 스크롤 없음)으로 정리했습니다.

## 변경 페이지/컴포넌트
- app/shoot/page.tsx, app/theme/page.tsx, app/upload/page.tsx (프레임 선택): 컨테이너 lg max-w-5xl 확장, 헤더 타이틀/설명 보강
- app/shoot/result/page.tsx, app/upload/result/page.tsx (결과): 컨테이너 lg max-w-3xl, 이미지+영상 동시 출력 시 2열, 단독 출력 시 중앙 정렬
- components/frame/FramePicker.tsx: 데스크톱 그리드 lg 3열 / xl 4열, 확인 버튼 모바일 풀폭 + 데스크톱 자동폭 (이 변경으로 shoot/select, upload/select 도 함께 개선됨)
- components/frame/FrameSelectPanel.tsx: 2단 레이아웃 분기를 xl -> lg 로 앞당기고 썸네일 그리드 lg 5열, 모바일 가로 스크롤 방지

## 제약 준수
- 로직/상태/API 호출/훅 시그니처 변경 없음. className/JSX 래퍼만 조정
- 색은 기존 토큰 유지(하드코딩 hex 추가 없음)
- tsc --noEmit 통과, jest app/shoot app/upload 5 tests 통과