### PR TITLE
feat(mobile): 인증/홈/마이 화면 handoff 톤 정비 및 구글 소셜 로그인 버튼 추가

### DIFF
--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -650,7 +650,11 @@ export function MyPageScreen() {
       <SurfaceCard style={{ gap: 14 }}>
         <View style={styles.profileRow}>
           <View style={styles.profileAvatar}>
-            {user.profileUrl ? <Image source={{ uri: user.profileUrl }} style={styles.avatarImage} /> : null}
+            {user.profileUrl ? (
+              <Image source={{ uri: user.profileUrl }} style={styles.avatarImage} />
+            ) : (
+              <Text style={styles.profileAvatarInitial}>{user.username?.trim().charAt(0) || '하'}</Text>
+            )}
           </View>
           <View style={{ flex: 1, gap: 4 }}>
             <Text style={styles.linkTitle}>{user.username}</Text>
@@ -861,13 +865,20 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       fontWeight: '700',
     },
     profileAvatar: {
+      alignItems: 'center',
       backgroundColor: colors.primarySoft,
       borderColor: colors.border,
       borderRadius: 24,
       borderWidth: 1,
       height: 56,
+      justifyContent: 'center',
       overflow: 'hidden',
       width: 56,
+    },
+    profileAvatarInitial: {
+      color: colors.primaryStrong,
+      fontSize: 22,
+      fontWeight: '800',
     },
     profileRow: {
       alignItems: 'center',

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -25,7 +25,7 @@ import { completeSocialLoginSession } from '@/lib/social-login';
 import { useSessionStore } from '@/store/use-session-store';
 
 type HarucutThemeColors = ReturnType<typeof useHarucutTheme>['colors'];
-type SocialProvider = 'kakao' | 'naver';
+type SocialProvider = 'google' | 'kakao' | 'naver';
 
 function usePublicScreenTheme() {
   const { colors, isDark } = useHarucutTheme();
@@ -117,14 +117,19 @@ function SocialButtons() {
         <View style={styles.socialLine} />
       </View>
       <SocialBrandButton
-        label={pending === 'kakao' ? '카카오 로그인 중...' : '카카오 로그인'}
+        label={pending === 'kakao' ? '카카오 로그인 중...' : '카카오로 계속하기'}
         onPress={() => void handleSocialLogin('kakao')}
         provider="kakao"
       />
       <SocialBrandButton
-        label={pending === 'naver' ? '네이버 로그인 중...' : '네이버 로그인'}
+        label={pending === 'naver' ? '네이버 로그인 중...' : '네이버로 계속하기'}
         onPress={() => void handleSocialLogin('naver')}
         provider="naver"
+      />
+      <SocialBrandButton
+        label={pending === 'google' ? '구글 로그인 중...' : '구글로 계속하기'}
+        onPress={() => void handleSocialLogin('google')}
+        provider="google"
       />
       <Text style={styles.socialConsentNotice}>
         소셜 계정으로 계속하면{' '}
@@ -148,10 +153,30 @@ function SocialBrandButton({
 }: {
   label: string;
   onPress: () => void;
-  provider: 'kakao' | 'naver';
+  provider: SocialProvider;
 }) {
   const { styles } = usePublicScreenTheme();
-  const isKakao = provider === 'kakao';
+
+  const buttonStyle =
+    provider === 'kakao'
+      ? styles.socialKakaoButton
+      : provider === 'naver'
+        ? styles.socialNaverButton
+        : styles.socialGoogleButton;
+
+  const iconBoxStyle =
+    provider === 'kakao'
+      ? styles.socialKakaoIconBox
+      : provider === 'naver'
+        ? styles.socialNaverIconBox
+        : styles.socialGoogleIconBox;
+
+  const labelStyle =
+    provider === 'kakao'
+      ? styles.socialKakaoLabel
+      : provider === 'naver'
+        ? styles.socialNaverLabel
+        : styles.socialGoogleLabel;
 
   return (
     <Pressable
@@ -160,32 +185,24 @@ function SocialBrandButton({
       onPress={onPress}
       style={({ pressed }) => [
         styles.socialButton,
-        isKakao ? styles.socialKakaoButton : styles.socialNaverButton,
+        buttonStyle,
         pressed ? styles.socialButtonPressed : null,
       ]}>
       <View style={styles.socialButtonInner}>
-        <View
-          style={[
-            styles.socialIconBox,
-            isKakao ? styles.socialKakaoIconBox : styles.socialNaverIconBox,
-          ]}>
-          {isKakao ? (
+        <View style={[styles.socialIconBox, iconBoxStyle]}>
+          {provider === 'kakao' ? (
             <View style={styles.kakaoMark}>
               <View style={styles.kakaoMarkBubble} />
               <View style={styles.kakaoMarkTail} />
             </View>
-          ) : (
+          ) : provider === 'naver' ? (
             <Text style={styles.naverMark}>N</Text>
+          ) : (
+            <Text style={styles.googleMark}>G</Text>
           )}
         </View>
         <View style={styles.socialLabelWrap}>
-          <Text
-            style={[
-              styles.socialButtonLabel,
-              isKakao ? styles.socialKakaoLabel : styles.socialNaverLabel,
-            ]}>
-            {label}
-          </Text>
+          <Text style={[styles.socialButtonLabel, labelStyle]}>{label}</Text>
         </View>
       </View>
     </Pressable>
@@ -312,7 +329,7 @@ export function LoginScreen() {
 
   return (
     <AuthShell
-      description="하루컷에 로그인하고 프레임과 기록을 이어서 관리해 보세요."
+      description="로그인하고 오늘의 네 컷을 이어가요."
       footer={
         <>
           <SocialButtons />
@@ -324,7 +341,7 @@ export function LoginScreen() {
           </Text>
         </>
       }
-      title="로그인">
+      title="다시 오셨네요">
       <SurfaceCard style={{ gap: 14 }}>
         {LOGIN_FIELDS.map((field) => (
           <FormField
@@ -478,7 +495,7 @@ export function SignupScreen() {
 
   return (
     <AuthShell
-      description="이메일 인증 후 계정을 만들어 보세요."
+      description="금방 끝나요. 이메일 인증 후 바로 첫 네 컷을 찍으러 가요."
       footer={
         <>
           <SocialButtons />
@@ -909,6 +926,12 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       fontWeight: '900',
       lineHeight: 20,
     },
+    googleMark: {
+      color: '#4285F4',
+      fontSize: 19,
+      fontWeight: '900',
+      lineHeight: 22,
+    },
     socialDivider: {
       alignItems: 'center',
       flexDirection: 'row',
@@ -975,6 +998,21 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
     },
     socialNaverLabel: {
       color: '#FFFFFF',
+    },
+    socialGoogleButton: {
+      backgroundColor: '#FFFFFF',
+      borderColor: isDark ? 'rgba(15, 23, 42, 0.16)' : 'rgba(60, 64, 67, 0.18)',
+      borderWidth: 1,
+      shadowColor: 'rgba(15, 23, 42, 0.08)',
+      shadowOffset: { height: 14, width: 0 },
+      shadowOpacity: 1,
+      shadowRadius: 24,
+    },
+    socialGoogleIconBox: {
+      backgroundColor: '#FFFFFF',
+    },
+    socialGoogleLabel: {
+      color: 'rgba(30, 30, 30, 0.88)',
     },
     legalFooterLink: {
       color: colors.muted,


### PR DESCRIPTION
## 작업 내용
모바일 앱(apps/mobile) 화면을 handoff/app 디자인 톤으로 다듬었습니다. 로직/store/expo-router 경로/API 계약은 변경하지 않았고, 색은 useHarucutTheme 토큰을 사용했습니다.

### 인증 (public-screens.tsx)
- 로그인 타이틀/설명을 handoff 카피로 정리 (다시 오셨네요 / 로그인하고 오늘의 네 컷을 이어가요)
- 회원가입 설명 카피 정리 (금방 끝나요. 이메일 인증 후 바로 첫 네 컷을 찍으러 가요)
- 소셜 로그인 3종 정비
  - 구글 버튼 추가: 흰 배경 + 테두리 + 컬러 G 마크 (handoff 스타일)
  - 카카오(FEE500) / 네이버(녹색 흰 글자) 라벨을 ...로 계속하기 톤으로 통일

### 소셜 로그인 연결 방식
- 기존 메커니즘 그대로 사용: openAuthSessionAsync로 baseUrl/oauth2/authorization/provider 진입 후 harucut://oauth2/callback 딥링크 복귀, completeSocialLoginSession으로 세션 확정
- SocialProvider 타입에 google만 확장하고 동일 OAuth 진입 경로로 연결 (백엔드 등록 후 동작)
- 카카오/네이버 기존 동작 그대로 유지

### 마이 (app-screens.tsx)
- 프로필 이미지가 없을 때 닉네임 이니셜을 표시하도록 보강

## 확인
- pnpm --dir apps/mobile typecheck 통과 (EXIT 0)
- 하단 탭바(홈/기록/촬영/MY)는 기존 구조 유지

## 주의
- 백엔드는 KAKAO/NAVER만 지원(swagger 기준)하므로 구글 버튼 동작은 백엔드 google provider 등록 후 활성화됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)