### PR TITLE
fix(mobile): 하단 여백 이중 적용 제거

### DIFF
--- a/apps/mobile/app/(public)/_layout.tsx
+++ b/apps/mobile/app/(public)/_layout.tsx
@@ -7,7 +7,7 @@ export default function PublicLayout() {
   const { colors } = useHarucutTheme();
 
   return (
-    <SafeAreaView edges={['top']} style={{ backgroundColor: colors.background, flex: 1 }}>
+    <SafeAreaView edges={['top', 'bottom']} style={{ backgroundColor: colors.background, flex: 1 }}>
       <Slot />
     </SafeAreaView>
   );

--- a/apps/mobile/components/harucut/ui.tsx
+++ b/apps/mobile/components/harucut/ui.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'expo-router';
 import * as React from 'react';
 import type { PropsWithChildren, ReactNode } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, TextInput, View, type StyleProp, type TextInputProps, type ViewStyle } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { HARUCUT_RADII, HARUCUT_SPACING, type ButtonVariant, type HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
@@ -21,10 +20,11 @@ export function AppScrollView({
   children,
   contentContainerStyle,
 }: PropsWithChildren<{ contentContainerStyle?: StyleProp<ViewStyle> }>) {
-  const insets = useSafeAreaInsets();
   const styles = useUiStyles();
   const { colors } = useHarucutTheme();
-  const bottomPadding = Math.max(insets.bottom, HARUCUT_SPACING.screen);
+  // 하단 안전영역은 (app)의 BottomNavigation, (public)/(legal) 레이아웃의 bottom safe-area가
+  // 처리한다. 스크롤 콘텐츠는 콘텐츠 간격만 둬서 안전영역 이중 적용(하단 여백 과다)을 막는다.
+  const bottomPadding = HARUCUT_SPACING.screen;
 
   return (
     <View style={styles.screen}>

--- a/apps/mobile/screens/legal-screens.tsx
+++ b/apps/mobile/screens/legal-screens.tsx
@@ -2,7 +2,6 @@ import { PRIVACY_POLICY, TERMS_OF_SERVICE, type LegalDocument } from '@harucut/s
 import { useRouter } from 'expo-router';
 import { useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AppScrollView, PageHeader, SurfaceCard } from '@/components/harucut/ui';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
@@ -10,12 +9,10 @@ import { useHarucutTheme } from '@/hooks/use-harucut-theme';
 function LegalDocumentScreen({ document }: { document: LegalDocument }) {
   const { colors } = useHarucutTheme();
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const bottomPadding = Math.max(insets.bottom, 16);
 
   return (
-    <AppScrollView contentContainerStyle={{ paddingBottom: bottomPadding }}>
+    <AppScrollView>
       <PageHeader description={`시행일 ${document.effectiveDate}`} title={document.title} />
       <SurfaceCard style={{ gap: 18 }}>
         <Text style={styles.intro}>{document.intro}</Text>

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useEffect, useMemo, useState } from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { HERO_IMAGE_SOURCE, LOGIN_FIELDS, SIGNUP_FIELDS } from '@/constants/harucut-data';
 import { ActionButton, AppScrollView, BrandMark, FormField, PageHeader, SurfaceCard } from '@/components/harucut/ui';
@@ -47,12 +46,10 @@ function AuthShell({
 }) {
   const { styles } = usePublicScreenTheme();
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const push = (path: string) => router.push(path as never);
-  const bottomPadding = Math.max(insets.bottom, 16);
 
   return (
-    <AppScrollView contentContainerStyle={{ paddingBottom: bottomPadding }}>
+    <AppScrollView>
       <PageHeader
         description={description}
         title={title}
@@ -212,17 +209,11 @@ function SocialBrandButton({
 export function LandingScreen() {
   const { styles } = usePublicScreenTheme();
   const router = useRouter();
-  const insets = useSafeAreaInsets();
   const push = (path: string) => router.push(path as never);
   const showGuestTrialNotice = useSessionStore((state) => state.showGuestTrialNotice);
-  const landingBottomPadding = Math.max(insets.bottom, 16);
 
   return (
-    <AppScrollView
-      contentContainerStyle={[
-        styles.landingScrollContent,
-        { paddingBottom: landingBottomPadding },
-      ]}>
+    <AppScrollView contentContainerStyle={styles.landingScrollContent}>
       <View style={styles.landingHeader}>
         <BrandMark href="/" />
       </View>


### PR DESCRIPTION
앱 하단에 안전영역만큼 여백이 이중으로 생기던 문제 수정. AppScrollView는 콘텐츠 간격만, 하단 안전영역은 BottomNavigation(app)/레이아웃(public) bottom edge가 처리. mobile typecheck 통과.