### PR TITLE
fix(web): 미디어 목록 페이지네이션 처리 (홈 크래시 수정)

### DIFF
--- a/apps/web/lib/userMediaApi.ts
+++ b/apps/web/lib/userMediaApi.ts
@@ -5,10 +5,14 @@ import type { ApiEnvelope, UserMedia, UserMediaType } from "@/lib/api-types";
 
 export async function listMyMedia(type?: UserMediaType) {
   const query = type ? `?type=${encodeURIComponent(type)}` : "";
-  const res = await clientApi.get<ApiEnvelope<UserMedia[]>>(
-    `/api/client/user/media${query}`,
-  );
-  return res.data.data ?? [];
+  // 백엔드 응답의 data는 페이지네이션 객체({ content: [...] })이거나(현행) 배열일 수 있어
+  // 양쪽을 모두 방어해 항상 배열을 반환한다. (이전엔 객체를 그대로 반환해 [...] 시 크래시)
+  const res = await clientApi.get<
+    ApiEnvelope<{ content?: UserMedia[] } | UserMedia[] | null>
+  >(`/api/client/user/media${query}`);
+  const data = res.data.data;
+  if (Array.isArray(data)) return data;
+  return data?.content ?? [];
 }
 
 export async function registerUserMedia(args: {


### PR DESCRIPTION
GET /user/media 응답 data가 페이지네이션 객체라 listMyMedia가 비배열을 반환해 홈/기록에서 nextMedia is not iterable 크래시. content 배열을 반환하도록 수정(배열/페이지네이션 양쪽 방어). tsc 통과.