### PR TITLE
feat(web): 홈·기록·마이 페이지 handoff 디자인 재구성

### DIFF
--- a/apps/web/app/history/page.tsx
+++ b/apps/web/app/history/page.tsx
@@ -2,9 +2,15 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Download, PencilLine, Search, Share2 } from "lucide-react";
+import {
+  Download,
+  Image as ImageIcon,
+  PencilLine,
+  Play,
+  Search,
+  Share2,
+} from "lucide-react";
 import { getUserFacingApiErrorMessage } from "@/lib/apiError";
-import { PageHeader } from "@/components/layout/PageHeader";
 import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { downloadFromUrl } from "@/lib/canvas/composeFrame";
 import { buildDownloadFilename } from "@/lib/fourcutOutput";
@@ -233,229 +239,245 @@ export default function HistoryPage() {
     }
   };
 
+  const filterOptions: { value: FilterValue; label: string; count: number }[] = [
+    { value: "ALL", label: "전체", count: stats.total },
+    { value: "PHOTO", label: "사진", count: stats.photos },
+    { value: "VIDEO", label: "영상", count: stats.videos },
+  ];
+
   return (
-    <main className="hc-page-showcase min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5">
-        <PageHeader
-          title="사진 기록"
-          backHref="/home"
-          backLabel="홈으로"
-          description={
-            <>내가 만든 사진과 영상을 다시 보고, 이름을 정리하고, 공유할 수 있어요.</>
-          }
-        />
+    <main className="hc-page-app min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 lg:gap-6">
+        {/* 헤더 */}
+        <header className="flex flex-col gap-2 pt-1 lg:flex-row lg:items-end lg:justify-between lg:pt-3">
+          <div>
+            <h1 className="text-[28px] font-extrabold tracking-tight lg:text-[34px]">
+              기록
+            </h1>
+            <p className="mt-2 text-[13.5px] text-[color:var(--hc-muted)]">
+              남긴 하루컷 {loading ? "…" : stats.total}개 · 언제든 다시 내려받을 수
+              있어요
+            </p>
+          </div>
+          <div className="hidden gap-2 lg:flex">
+            <Link
+              href="/shoot"
+              className="hc-button-primary rounded-full px-4 py-2.5 text-[13px] font-semibold"
+            >
+              새 촬영
+            </Link>
+            <Link
+              href="/upload"
+              className="hc-button-secondary rounded-full border px-4 py-2.5 text-[13px] font-semibold"
+            >
+              업로드
+            </Link>
+          </div>
+        </header>
 
-        <section className="hc-surface-card-xl rounded-[28px] border p-4 sm:rounded-[32px] sm:p-5">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div>
-              <span className="hc-accent-chip rounded-full border px-3 py-1 text-[11px]">
-                MEMORY ARCHIVE
-              </span>
-              <h2 className="mt-4 text-[28px] font-semibold tracking-tight text-[color:var(--hc-text)] sm:text-3xl">
-                다시 꺼내 보는 내 기록함
-              </h2>
-              <p className="mt-3 max-w-2xl text-[14px] leading-6 text-zinc-400 sm:text-sm sm:leading-7">
-                저장한 결과를 다시 보고, 이름을 정리하고, 공유할 수 있어요.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              {[
-                { label: "전체", value: `${stats.total}개` },
-                { label: "사진", value: `${stats.photos}개` },
-                { label: "영상", value: `${stats.videos}개` },
-              ].map((stat) => (
-                <span
-                  key={stat.label}
-                    className="hc-surface-well rounded-full border px-3 py-2 text-[11px] text-zinc-300"
-                >
-                  {stat.label} {loading ? "..." : stat.value}
+        {/* 필터 + 검색 */}
+        <section className="flex flex-col gap-3 lg:flex-row lg:items-center">
+          <div className="flex flex-wrap gap-2">
+            {filterOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setFilter(option.value)}
+                className={`rounded-full px-3.5 py-1.5 text-[13px] font-semibold transition ${
+                  filter === option.value
+                    ? "bg-[color:var(--hc-primary)] text-[color:var(--hc-primary-contrast)]"
+                    : "hc-button-secondary border text-[color:var(--hc-muted)]"
+                }`}
+              >
+                {option.label}
+                <span className="ml-1 opacity-70">
+                  {loading ? "" : option.count}
                 </span>
-              ))}
-            </div>
+              </button>
+            ))}
           </div>
 
-          <div className="mt-5 flex flex-col gap-3 lg:flex-row lg:items-center">
-            <div className="flex flex-wrap gap-2">
-              {(["ALL", "PHOTO", "VIDEO"] as const).map((value) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setFilter(value)}
-                  className={`rounded-full px-3 py-1.5 text-[11px] font-medium ${
-                    filter === value
-                      ? "bg-[color:var(--hc-primary)] text-[color:var(--hc-primary-contrast)]"
-                      : "hc-button-secondary border text-zinc-300"
-                  }`}
-                >
-                  {value === "ALL" ? "전체" : value === "PHOTO" ? "사진" : "영상"}
-                </button>
-              ))}
-            </div>
-
-            <label className="hc-surface-well flex h-11 flex-1 items-center gap-2 rounded-2xl border px-3 text-sm text-zinc-300">
-              <Search className="h-4 w-4 text-zinc-500" />
-              <input
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="파일 이름으로 검색"
-                className="w-full bg-transparent text-sm outline-none placeholder:text-zinc-500"
-              />
-            </label>
-
-            <div className="grid grid-cols-2 gap-2 lg:w-[260px]">
-              <Link
-                href="/shoot"
-                className="hc-button-neutral rounded-full px-4 py-3 text-center text-sm font-semibold"
-              >
-                새 촬영
-              </Link>
-              <Link
-                href="/upload"
-                className="hc-button-secondary rounded-full border px-4 py-3 text-center text-sm font-semibold"
-              >
-                업로드
-              </Link>
-            </div>
-          </div>
+          <label className="hc-surface-well flex h-11 flex-1 items-center gap-2 rounded-2xl border px-3 text-sm">
+            <Search className="h-4 w-4 text-[color:var(--hc-muted-soft)]" />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="파일 이름으로 검색"
+              className="w-full bg-transparent text-sm outline-none placeholder:text-[color:var(--hc-muted-soft)]"
+            />
+          </label>
         </section>
 
         {feedback ? (
-          <div className="hc-feedback rounded-2xl border px-4 py-3 text-[11px]">
+          <div className="hc-feedback rounded-2xl border px-4 py-3 text-[12px]">
             {feedback}
           </div>
         ) : null}
 
-        {error ? <p className="text-[11px] text-red-300">{error}</p> : null}
+        {error ? (
+          <p className="text-[12px] text-[color:var(--hc-primary-strong)]">
+            {error}
+          </p>
+        ) : null}
 
+        {/* 그리드 */}
         {loading ? (
-          <div className="hc-surface-card rounded-[28px] border p-5">
-            <p className="text-[11px] text-zinc-400">기록을 불러오는 중이에요.</p>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {Array.from({ length: 4 }, (_, index) => (
+              <div
+                key={index}
+                className="hc-surface-card flex gap-3 rounded-[20px] border p-4"
+              >
+                <div className="h-32 w-24 shrink-0 animate-pulse rounded-2xl bg-[color:var(--hc-surface-muted)]" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-1/2 animate-pulse rounded bg-[color:var(--hc-surface-muted)]" />
+                  <div className="h-3 w-3/4 animate-pulse rounded bg-[color:var(--hc-surface-muted)]" />
+                </div>
+              </div>
+            ))}
           </div>
         ) : filteredItems.length === 0 ? (
-          <div className="hc-surface-card rounded-[28px] border p-5">
-            <p className="text-[11px] text-zinc-500">{emptyText}</p>
+          <div className="hc-surface-card flex flex-col items-center gap-3 rounded-[20px] border p-8 text-center">
+            <ImageIcon className="h-7 w-7 text-[color:var(--hc-muted-soft)]" />
+            <p className="text-[13px] text-[color:var(--hc-muted)]">
+              {search.trim() ? "검색 결과가 없어요." : emptyText}
+            </p>
+            {!search.trim() ? (
+              <Link
+                href="/shoot"
+                className="hc-button-primary rounded-full px-4 py-2 text-[12px] font-semibold"
+              >
+                새 네 컷 만들기
+              </Link>
+            ) : null}
           </div>
         ) : (
-          <section className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             {filteredItems.map((item) => {
               const preview = getUserMediaPreview(item, previewItems);
+              const isVideo = item.mediaType === "VIDEO";
 
               return (
                 <article
                   key={item.mediaId}
-                  className="hc-surface-card rounded-[28px] border p-4"
+                  className="hc-surface-card flex flex-col gap-3 rounded-[20px] border p-4 sm:flex-row"
                 >
-                  <div className="flex gap-3">
-                    <div className="h-32 w-24 shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950">
-                      {preview.url ? (
-                        preview.kind === "video" ? (
-                          <video
-                            src={preview.url}
-                            className="h-full w-full object-cover"
-                            muted
-                            playsInline
-                            controls={false}
-                          />
-                        ) : (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            src={preview.url}
-                            alt={getUserMediaTitle(item)}
-                            className="h-full w-full object-cover"
-                          />
-                        )
+                  <div className="relative h-40 w-full shrink-0 overflow-hidden rounded-2xl border border-[color:var(--hc-border)] bg-[color:var(--hc-surface-muted)] sm:h-32 sm:w-24">
+                    {preview.url ? (
+                      preview.kind === "video" ? (
+                        <video
+                          src={preview.url}
+                          className="h-full w-full object-cover"
+                          muted
+                          playsInline
+                          controls={false}
+                        />
                       ) : (
-                        <div className="grid h-full w-full place-items-center px-2 text-center text-[10px] text-zinc-500">
-                          미리보기를 준비하는 중이에요.
-                        </div>
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={preview.url}
+                          alt={getUserMediaTitle(item)}
+                          className="h-full w-full object-cover"
+                        />
+                      )
+                    ) : (
+                      <div className="grid h-full w-full place-items-center px-2 text-center text-[10px] text-[color:var(--hc-muted-soft)]">
+                        미리보기를 준비하는 중이에요.
+                      </div>
+                    )}
+                    <span className="absolute left-2 top-2 inline-flex items-center gap-1 rounded-full bg-black/55 px-2 py-0.5 text-[10px] font-bold text-white backdrop-blur">
+                      {isVideo ? (
+                        <>
+                          <Play
+                            aria-hidden="true"
+                            className="h-2.5 w-2.5"
+                            fill="currentColor"
+                          />
+                          영상
+                        </>
+                      ) : (
+                        <>
+                          <ImageIcon aria-hidden="true" className="h-2.5 w-2.5" />
+                          사진
+                        </>
                       )}
+                    </span>
+                  </div>
+
+                  <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
+                    <div className="flex flex-col gap-1">
+                      {editingId === item.mediaId ? (
+                        <div className="flex gap-2">
+                          <input
+                            value={draftName}
+                            onChange={(e) => setDraftName(e.target.value)}
+                            className="hc-input h-9 flex-1 rounded-xl border px-3 text-[12px]"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => void handleSaveName(item)}
+                            disabled={savingNameId === item.mediaId}
+                            className="hc-button-neutral rounded-full px-3 py-2 text-[11px] font-semibold disabled:opacity-50"
+                          >
+                            {savingNameId === item.mediaId ? "저장 중" : "저장"}
+                          </button>
+                        </div>
+                      ) : (
+                        <p className="truncate text-[15px] font-bold tracking-tight">
+                          {getUserMediaTitle(item)}
+                        </p>
+                      )}
+
+                      <p className="text-[11.5px] text-[color:var(--hc-muted-soft)]">
+                        {item.createdAt
+                          ? new Date(item.createdAt).toLocaleString("ko-KR")
+                          : "생성 시간을 확인할 수 없어요."}
+                      </p>
                     </div>
 
-                    <div className="flex min-w-0 flex-1 flex-col justify-between gap-3">
-                      <div className="flex flex-col gap-1">
-                        <div className="flex items-center gap-2">
-                          <span className="text-[10px] tracking-[0.2em] text-[color:var(--hc-primary)]">
-                            {getMediaTypeLabel(item.mediaType)}
-                          </span>
-                          {item.originalFileName ? (
-                            <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] text-zinc-400">
-                              original kept
-                            </span>
-                          ) : null}
-                        </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void handleDownload(item)}
+                        disabled={downloadingId === item.mediaId}
+                        className="hc-button-primary flex min-w-[104px] flex-1 items-center justify-center gap-1 rounded-full px-3 py-2 text-[11px] font-semibold disabled:opacity-50"
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                        <span>
+                          {downloadingId === item.mediaId
+                            ? "다운로드 중..."
+                            : "다운로드"}
+                        </span>
+                      </button>
 
-                        {editingId === item.mediaId ? (
-                          <div className="mt-2 flex gap-2">
-                            <input
-                              value={draftName}
-                              onChange={(e) => setDraftName(e.target.value)}
-                              className="hc-input h-9 flex-1 rounded-xl border px-3 text-[12px]"
-                            />
-                            <button
-                              type="button"
-                              onClick={() => void handleSaveName(item)}
-                              disabled={savingNameId === item.mediaId}
-                              className="hc-button-neutral rounded-full px-3 py-2 text-[11px] font-semibold disabled:opacity-50"
-                            >
-                              {savingNameId === item.mediaId ? "저장 중" : "저장"}
-                            </button>
-                          </div>
-                        ) : (
-                          <p className="truncate text-sm font-semibold text-zinc-100">
-                            {getUserMediaTitle(item)}
-                          </p>
-                        )}
+                      <button
+                        type="button"
+                        onClick={() => void handleShare(item)}
+                        disabled={sharingId === item.mediaId}
+                        className="hc-button-secondary flex min-w-[104px] flex-1 items-center justify-center gap-1 rounded-full border px-3 py-2 text-[11px] font-semibold disabled:opacity-50"
+                      >
+                        <Share2 className="h-3.5 w-3.5" />
+                        <span>
+                          {sharingId === item.mediaId
+                            ? "링크 준비 중..."
+                            : "공유하기"}
+                        </span>
+                      </button>
 
-                        <p className="text-[11px] text-zinc-500">
-                          {item.createdAt
-                            ? new Date(item.createdAt).toLocaleString("ko-KR")
-                            : "생성 시간을 확인할 수 없어요."}
-                        </p>
-                      </div>
-
-                      <div className="flex flex-wrap gap-2">
-                        <button
-                          type="button"
-                          onClick={() => void handleDownload(item)}
-                          disabled={downloadingId === item.mediaId}
-                          className="hc-button-primary flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full px-3 py-2 text-[11px] font-semibold disabled:opacity-50"
-                        >
-                          <Download className="h-3.5 w-3.5" />
-                          <span>
-                            {downloadingId === item.mediaId
-                              ? "다운로드 중..."
-                              : "다운로드"}
-                          </span>
-                        </button>
-
-                        <button
-                          type="button"
-                          onClick={() => void handleShare(item)}
-                          disabled={sharingId === item.mediaId}
-                          className="hc-button-secondary flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full border px-3 py-2 text-[11px] font-semibold disabled:opacity-50"
-                        >
-                          <Share2 className="h-3.5 w-3.5" />
-                          <span>
-                            {sharingId === item.mediaId
-                              ? "링크 준비 중..."
-                              : "공유하기"}
-                          </span>
-                        </button>
-
-                        <button
-                          type="button"
-                          onClick={() =>
-                            editingId === item.mediaId
-                              ? setEditingId(null)
-                              : handleStartRename(item)
-                          }
-                          className="hc-button-secondary flex min-w-[112px] flex-1 items-center justify-center gap-1 rounded-full border px-3 py-2 text-[11px] font-semibold"
-                        >
-                          <PencilLine className="h-3.5 w-3.5" />
-                          <span>{editingId === item.mediaId ? "취소" : "이름 수정"}</span>
-                        </button>
-                      </div>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          editingId === item.mediaId
+                            ? setEditingId(null)
+                            : handleStartRename(item)
+                        }
+                        className="hc-button-secondary flex min-w-[104px] flex-1 items-center justify-center gap-1 rounded-full border px-3 py-2 text-[11px] font-semibold"
+                      >
+                        <PencilLine className="h-3.5 w-3.5" />
+                        <span>
+                          {editingId === item.mediaId ? "취소" : "이름 수정"}
+                        </span>
+                      </button>
                     </div>
                   </div>
                 </article>

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -3,14 +3,14 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
+  ArrowRight,
   Camera,
   ChevronRight,
+  Image as ImageIcon,
   Palette,
   Play,
-  Upload,
-  User,
+  Sparkles,
 } from "lucide-react";
-import { PageHeader } from "@/components/layout/PageHeader";
 import { getMyUserInfo, type UserInfo } from "@/lib/userApi";
 import { listMyMedia } from "@/lib/userMediaApi";
 import { listMyFrames } from "@/lib/remoteFrameApi";
@@ -40,9 +40,10 @@ const HOME_COACH_STEPS: CoachStep[] = [
 
 function formatCurrentDate() {
   return new Date().toLocaleDateString("ko-KR", {
+    year: "numeric",
     month: "long",
     day: "numeric",
-    weekday: "short",
+    weekday: "long",
   });
 }
 
@@ -131,117 +132,145 @@ export default function HomePage() {
 
   const currentDateLabel = useCurrentDateLabel();
   const savedFrame = savedFrames[0] ?? null;
+  const greetingName = user?.username ? `${user.username}님, ` : "";
 
   return (
-    <main className="hc-page-showcase min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5">
-        <PageHeader
-          title={
-            <span className="flex flex-col gap-1">
-              <span className="text-[11px] uppercase tracking-[0.26em] text-[color:var(--hc-primary)]/80">
-                Record your day
+    <main className="hc-page-app min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 lg:gap-9">
+        {/* 인사 */}
+        <header className="pt-1 lg:pt-4">
+          <span className="text-[12px] font-medium uppercase tracking-[0.22em] text-[color:var(--hc-primary)]">
+            {currentDateLabel}
+          </span>
+          <h1 className="mt-3 text-[26px] font-extrabold leading-tight tracking-tight sm:text-[30px] lg:text-[34px]">
+            {greetingName}오늘은
+            <br className="lg:hidden" />
+            <span className="lg:ml-2">어떻게 남겨볼까요?</span>
+          </h1>
+        </header>
+
+        {/* 액션 인덱스 → 촬영 / 업로드 / 꾸미기 (data-coach 앵커 유지) */}
+        <section className="grid gap-3 sm:grid-cols-3">
+          <Link
+            href="/shoot"
+            data-coach="shoot"
+            className="group flex min-h-[120px] flex-col justify-between rounded-[20px] bg-[color:var(--hc-primary)] p-5 text-[color:var(--hc-primary-contrast)] shadow-[var(--hc-button-shadow)] transition hover:shadow-[var(--hc-button-shadow-hover)]"
+          >
+            <span className="text-[11px] font-semibold tracking-[0.18em] opacity-70">
+              01
+            </span>
+            <span>
+              <span className="flex items-center justify-between text-[18px] font-extrabold">
+                촬영하기
+                <ArrowRight className="h-[18px] w-[18px] transition group-hover:translate-x-0.5" />
               </span>
-              <span>
-                {user?.username ? `${user.username}님, ` : ""}오늘 하루를 네 컷으로
-                남겨보세요
+              <span className="mt-1 block text-[12.5px] font-medium opacity-75">
+                프레임 고르고 네 컷을 남겨요
               </span>
             </span>
-          }
-          rightHref="/mypage"
-          rightLabel="내 계정으로 이동"
-          rightSlot={<User size={16} />}
-          description=""
-        />
+          </Link>
 
-        <section className="hc-surface-card-xl rounded-[28px] border p-5 backdrop-blur sm:p-6">
-          <div className="hc-accent-chip inline-flex rounded-full border px-3 py-1 text-[11px]">
-            {currentDateLabel}
-          </div>
-
-          <div className="mt-4 space-y-3">
-            <h1 className="max-w-2xl text-[28px] font-semibold tracking-tight sm:text-[32px] md:text-5xl">
-              찍고 저장하고,
-              <span
-                className="block bg-clip-text text-transparent"
-                style={{
-                  backgroundImage:
-                    "linear-gradient(90deg, var(--hc-primary-strong), var(--hc-primary), var(--hc-hero-gradient-end))",
-                }}
-              >
-                다시 꺼내 보는 하루컷
+          <Link
+            href="/upload"
+            data-coach="upload"
+            className="hc-surface-card group flex min-h-[120px] flex-col justify-between rounded-[20px] border p-5 transition hover:border-[color:var(--hc-border-strong)]"
+          >
+            <span className="text-[11px] font-semibold tracking-[0.18em] text-[color:var(--hc-muted-soft)]">
+              02
+            </span>
+            <span>
+              <span className="flex items-center justify-between text-[18px] font-extrabold">
+                업로드하기
+                <ArrowRight className="h-[18px] w-[18px] text-[color:var(--hc-muted)] transition group-hover:translate-x-0.5" />
               </span>
-            </h1>
-            <p className="max-w-xl text-[14px] leading-6 text-zinc-300 sm:text-[15px] sm:leading-7">
-              촬영하거나 업로드해서 기록에 남겨두세요.
-            </p>
-          </div>
+              <span className="mt-1 block text-[12.5px] text-[color:var(--hc-muted)]">
+                찍어둔 사진·영상으로 만들어요
+              </span>
+            </span>
+          </Link>
 
-          <div className="mt-5 flex flex-col gap-3 sm:flex-row">
-            <Link
-              href="/shoot"
-              data-coach="shoot"
-              className="hc-button-hero inline-flex w-full items-center justify-center gap-2 rounded-full px-5 py-3 text-sm font-semibold transition sm:w-auto"
-            >
-              <Camera className="h-4 w-4" />
-              바로 촬영 시작
-            </Link>
-            <Link
-              href="/upload"
-              data-coach="upload"
-              className="hc-button-secondary inline-flex w-full items-center justify-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold transition sm:w-auto"
-            >
-              <Upload className="h-4 w-4" />
-              사진 업로드
-            </Link>
-            <Link
-              href="/theme"
-              data-coach="theme"
-              className="hc-button-secondary inline-flex w-full items-center justify-center gap-2 rounded-full border px-5 py-3 text-sm font-semibold transition sm:w-auto"
-            >
-              <Palette className="h-4 w-4" />
-              꾸미기
-            </Link>
-          </div>
-
+          <Link
+            href="/theme"
+            data-coach="theme"
+            className="hc-surface-card group flex min-h-[120px] flex-col justify-between rounded-[20px] border p-5 transition hover:border-[color:var(--hc-border-strong)]"
+          >
+            <span className="text-[11px] font-semibold tracking-[0.18em] text-[color:var(--hc-muted-soft)]">
+              03
+            </span>
+            <span>
+              <span className="flex items-center justify-between text-[18px] font-extrabold">
+                프레임 꾸미기
+                <ArrowRight className="h-[18px] w-[18px] text-[color:var(--hc-muted)] transition group-hover:translate-x-0.5" />
+              </span>
+              <span className="mt-1 block text-[12.5px] text-[color:var(--hc-muted)]">
+                만들어두면 촬영할 때 골라 써요
+              </span>
+            </span>
+          </Link>
         </section>
 
-        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
-          <section className="hc-surface-card rounded-[28px] border p-5">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-[10px] uppercase tracking-[0.24em] text-zinc-500">
-                  Recent
-                </p>
-                <h2 className="mt-2 text-lg font-semibold">최근 저장한 결과</h2>
-              </div>
-              <Link href="/history" className="hc-link-accent text-[11px]">
-                전체 보기
-              </Link>
-            </div>
+        {/* 모바일 보조 진입 (앱 느낌) */}
+        <section className="grid gap-3 sm:hidden">
+          <Link
+            href="/shoot"
+            className="hc-surface-card flex items-center gap-3 rounded-2xl border p-4"
+          >
+            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-[color:var(--hc-accent-soft-bg)]">
+              <Camera className="h-5 w-5 text-[color:var(--hc-primary)]" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-[14px] font-bold">바로 촬영 시작</span>
+              <span className="block text-[11.5px] text-[color:var(--hc-muted)]">
+                셔터를 누르면 네 컷이 자동으로 찍혀요
+              </span>
+            </span>
+            <ChevronRight className="ml-auto h-5 w-5 shrink-0 text-[color:var(--hc-muted-soft)]" />
+          </Link>
+        </section>
 
-            <div className="mt-4 grid grid-cols-2 gap-3">
-              {loading ? (
-                Array.from({ length: 4 }, (_, index) => (
-                  <div
-                    key={index}
-                    className="aspect-[3/4] animate-pulse rounded-3xl bg-white/5"
-                  />
-                ))
-              ) : recentMedia.length > 0 ? (
-                recentMedia.map((item) => {
-                  const preview = getUserMediaPreview(item, previewMedia);
-                  const isVideo = item.mediaType === "VIDEO";
+        {/* 최근 기록 */}
+        <section className="flex flex-col gap-4">
+          <div className="flex items-end justify-between">
+            <h2 className="flex items-baseline gap-2 text-[20px] font-extrabold tracking-tight lg:text-[22px]">
+              최근 기록
+              <span className="text-[12px] font-normal uppercase tracking-[0.2em] text-[color:var(--hc-muted-soft)]">
+                Recent
+              </span>
+            </h2>
+            <Link
+              href="/history"
+              className="hc-link-accent flex items-center gap-1 text-[13px] font-semibold"
+            >
+              전체보기
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
 
-                  return (
-                    <div
-                      key={item.mediaId}
-                      className="hc-surface-well relative overflow-hidden rounded-3xl border"
-                    >
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-4">
+            {loading ? (
+              Array.from({ length: 4 }, (_, index) => (
+                <div
+                  key={index}
+                  className="aspect-[3/4] animate-pulse rounded-[18px] bg-[color:var(--hc-surface-muted)]"
+                />
+              ))
+            ) : recentMedia.length > 0 ? (
+              recentMedia.map((item) => {
+                const preview = getUserMediaPreview(item, previewMedia);
+                const isVideo = item.mediaType === "VIDEO";
+
+                return (
+                  <Link
+                    key={item.mediaId}
+                    href="/history"
+                    className="group flex flex-col gap-2"
+                  >
+                    <div className="hc-surface-well relative aspect-[3/4] overflow-hidden rounded-[18px] border transition group-hover:border-[color:var(--hc-border-strong)]">
                       {preview.url ? (
                         preview.kind === "video" ? (
                           <video
                             src={preview.url}
-                            className="aspect-[3/4] w-full object-cover"
+                            className="h-full w-full object-cover"
                             muted
                             playsInline
                           />
@@ -250,69 +279,82 @@ export default function HomePage() {
                           <img
                             src={preview.url}
                             alt={getUserMediaTitle(item)}
-                            className="aspect-[3/4] w-full object-cover"
+                            className="h-full w-full object-cover"
                           />
                         )
                       ) : (
-                        <div className="aspect-[3/4] bg-white/5" />
+                        <div className="h-full w-full bg-[color:var(--hc-surface-muted)]" />
                       )}
-                      {isVideo ? (
-                        <div className="pointer-events-none absolute inset-0 grid place-items-center bg-black/10">
-                          <span className="grid h-10 w-10 place-items-center rounded-full border border-white/40 bg-black/45 text-white shadow-lg backdrop-blur">
+                      <span className="absolute left-2.5 top-2.5 inline-flex items-center gap-1 rounded-full bg-black/55 px-2 py-0.5 text-[10.5px] font-bold text-white backdrop-blur">
+                        {isVideo ? (
+                          <>
                             <Play
                               aria-hidden="true"
-                              className="ml-0.5 h-4 w-4"
+                              className="h-2.5 w-2.5"
                               fill="currentColor"
                             />
-                          </span>
-                        </div>
-                      ) : null}
+                            영상
+                          </>
+                        ) : (
+                          <>
+                            <ImageIcon
+                              aria-hidden="true"
+                              className="h-2.5 w-2.5"
+                            />
+                            사진
+                          </>
+                        )}
+                      </span>
                     </div>
-                  );
-                })
-              ) : (
-                <div className="hc-surface-well col-span-2 rounded-3xl border border-dashed p-5 text-center text-[11px] text-zinc-400">
-                  아직 저장한 결과가 없어요.
-                </div>
-              )}
-            </div>
-          </section>
-
-          <div className="flex flex-col gap-4">
-            <section className="hc-surface-card rounded-[28px] border p-5">
-              <div className="flex items-center justify-between">
-                <p className="text-sm font-semibold text-zinc-100">
-                  저장된 프레임
+                    <p className="truncate text-[13.5px] font-bold tracking-tight">
+                      {getUserMediaTitle(item)}
+                    </p>
+                  </Link>
+                );
+              })
+            ) : (
+              <div className="hc-surface-well col-span-2 flex flex-col items-center gap-3 rounded-[18px] border border-dashed p-6 text-center md:col-span-4">
+                <Sparkles className="h-6 w-6 text-[color:var(--hc-primary)]" />
+                <p className="text-[13px] text-[color:var(--hc-muted)]">
+                  아직 저장한 기록이 없어요. 첫 네 컷을 남겨보세요.
                 </p>
-                <Link href="/theme" className="hc-link-accent text-[11px]">
-                  전체 보기
+                <Link
+                  href="/shoot"
+                  className="hc-button-primary rounded-full px-4 py-2 text-[12px] font-semibold"
+                >
+                  촬영 시작
                 </Link>
               </div>
-
-              <div className="mt-3">
-                {savedFrame ? (
-                  <Link
-                    href={`/theme?frame=${frameIdFromFrameType(savedFrame.frameType)}&remoteFrameId=${savedFrame.frameId}`}
-                    className="hc-surface-well hc-surface-well-hover flex items-center justify-between rounded-2xl border px-3 py-3 transition"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-semibold text-zinc-100">
-                        {savedFrame.title}
-                      </p>
-                      <p className="mt-1 text-[11px] text-zinc-500">
-                        저장한 프레임을 이어서 수정할 수 있어요.
-                      </p>
-                    </div>
-                    <ChevronRight className="h-4 w-4 shrink-0 text-zinc-500" />
-                  </Link>
-                ) : (
-                  <p className="hc-surface-well rounded-2xl border border-dashed px-4 py-4 text-[11px] text-zinc-400">
-                    아직 저장한 프레임이 없어요.
-                  </p>
-                )}
-              </div>
-            </section>
+            )}
           </div>
+        </section>
+
+        {/* 저장된 프레임 */}
+        <section className="hc-surface-card flex items-center justify-between rounded-[20px] border p-4 sm:p-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-[color:var(--hc-accent-soft-bg)]">
+              <Palette className="h-5 w-5 text-[color:var(--hc-primary)]" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-[14px] font-bold">저장된 프레임</p>
+              <p className="mt-0.5 truncate text-[12px] text-[color:var(--hc-muted)]">
+                {savedFrame
+                  ? savedFrame.title
+                  : "만들어둔 프레임을 촬영할 때 골라 쓸 수 있어요."}
+              </p>
+            </div>
+          </div>
+          <Link
+            href={
+              savedFrame
+                ? `/theme?frame=${frameIdFromFrameType(savedFrame.frameType)}&remoteFrameId=${savedFrame.frameId}`
+                : "/theme"
+            }
+            className="hc-link-accent ml-3 flex shrink-0 items-center gap-1 text-[13px] font-semibold"
+          >
+            {savedFrame ? "이어서 수정" : "프레임 만들기"}
+            <ChevronRight className="h-4 w-4" />
+          </Link>
         </section>
       </div>
       <MobileTabBar />

--- a/apps/web/app/mypage/page.tsx
+++ b/apps/web/app/mypage/page.tsx
@@ -2,9 +2,8 @@
 
 import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { CreditCard, RefreshCw, ShieldCheck } from "lucide-react";
+import { CreditCard, LogOut, RefreshCw, ShieldCheck } from "lucide-react";
 import { AuthField } from "@/components/auth/AuthField";
-import { PageHeader } from "@/components/layout/PageHeader";
 import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { ColorThemePreferencePanel } from "@/components/theme/ColorThemePreferencePanel";
 import { clientApi } from "@/lib/clientApi";
@@ -192,41 +191,46 @@ export default function MyPage() {
     }
   };
 
+  const profileInitial = user?.username?.trim()?.[0] ?? "U";
+
   return (
-    <main className="hc-page-app min-h-dvh px-4 py-6 pb-[90px] text-[color:var(--hc-text)] lg:pb-6">
-      <div className="mx-auto flex w-full max-w-md flex-col gap-6">
-        <PageHeader
-          title="내 계정"
-          rightSlot={
-            <button
-              type="button"
-              onClick={fetchUser}
-              disabled={isSubmitting || loading}
-              className="hc-button-icon grid h-9 w-9 place-items-center rounded-full border text-zinc-300 disabled:opacity-50"
-              aria-label="새로고침"
-              title="새로고침"
-            >
-              <RefreshCw
-                className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
-              />
-            </button>
-          }
-          description={
-            errors.common ? (
-              <span className="text-[11px] text-red-400">{errors.common}</span>
-            ) : undefined
-          }
-        />
+    <main className="hc-page-app min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 lg:gap-6">
+        {/* 헤더 */}
+        <header className="flex items-center justify-between pt-1 lg:pt-3">
+          <h1 className="text-[28px] font-extrabold tracking-tight lg:text-[34px]">
+            마이페이지
+          </h1>
+          <button
+            type="button"
+            onClick={fetchUser}
+            disabled={isSubmitting || loading}
+            className="hc-button-icon grid h-10 w-10 place-items-center rounded-full border disabled:opacity-50"
+            aria-label="새로고침"
+            title="새로고침"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          </button>
+        </header>
+
+        {errors.common ? (
+          <p className="text-[12px] text-[color:var(--hc-primary-strong)]">
+            {errors.common}
+          </p>
+        ) : null}
 
         {loading ? (
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-            <p className="text-[11px] text-zinc-400">정보를 불러오는 중...</p>
+          <div className="hc-surface-card rounded-[20px] border p-5">
+            <p className="text-[12px] text-[color:var(--hc-muted)]">
+              정보를 불러오는 중...
+            </p>
           </div>
         ) : user ? (
           <>
-            <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border border-zinc-700 bg-zinc-800">
+            {/* 프로필 */}
+            <section className="hc-surface-card rounded-[24px] border p-5 sm:p-6">
+              <div className="flex items-center gap-4">
+                <div className="grid h-16 w-16 shrink-0 place-items-center overflow-hidden rounded-full bg-[color:var(--hc-primary)] text-[24px] font-extrabold text-[color:var(--hc-primary-contrast)]">
                   {user.profileUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
@@ -235,53 +239,59 @@ export default function MyPage() {
                       className="h-full w-full object-cover"
                     />
                   ) : (
-                    <span className="text-[11px] text-zinc-400">USER</span>
+                    <span>{profileInitial}</span>
                   )}
                 </div>
 
-                <div className="flex flex-col">
-                  <span className="text-sm font-semibold">{user.username}</span>
-                  <span className="text-[11px] text-zinc-400">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[18px] font-extrabold">
+                    {user.username}
+                  </p>
+                  <p className="truncate text-[13px] text-[color:var(--hc-muted)]">
                     {user.email}
-                  </span>
+                  </p>
                 </div>
               </div>
 
-              <div className="mt-3 grid gap-2 md:grid-cols-2">
-                <div className="rounded-2xl border border-zinc-800 bg-zinc-950/60 p-3">
-                  <div className="flex items-center gap-2 text-zinc-300">
-                    <ShieldCheck className="h-4 w-4 text-[color:var(--hc-primary-strong)]" />
-                    <span className="text-[11px]">로그인 플랫폼</span>
+              {/* 플랜·플랫폼 */}
+              <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                <div className="hc-surface-well rounded-2xl border p-3.5">
+                  <div className="flex items-center gap-2 text-[color:var(--hc-muted)]">
+                    <ShieldCheck className="h-4 w-4 text-[color:var(--hc-primary)]" />
+                    <span className="text-[11.5px]">로그인 플랫폼</span>
                   </div>
-                  <p className="mt-2 text-sm font-semibold text-zinc-100">
+                  <p className="mt-1.5 text-[14px] font-bold">
                     {user.loginPlatform ?? "HARUCUT"}
                   </p>
                 </div>
-                <div className="rounded-2xl border border-zinc-800 bg-zinc-950/60 p-3">
-                  <div className="flex items-center gap-2 text-zinc-300">
-                    <CreditCard className="h-4 w-4 text-[color:var(--hc-primary-strong)]" />
-                    <span className="text-[11px]">플랜</span>
+                <div className="hc-surface-well rounded-2xl border p-3.5">
+                  <div className="flex items-center gap-2 text-[color:var(--hc-muted)]">
+                    <CreditCard className="h-4 w-4 text-[color:var(--hc-primary)]" />
+                    <span className="text-[11.5px]">플랜</span>
                   </div>
-                  <p className="mt-2 text-sm font-semibold text-zinc-100">
+                  <p className="mt-1.5 text-[14px] font-bold">
                     {user.planTier ?? "BASIC"}
-                    {user.monthlyPrice ? ` · 월 ${user.monthlyPrice.toLocaleString("ko-KR")}원` : ""}
+                    {user.monthlyPrice
+                      ? ` · 월 ${user.monthlyPrice.toLocaleString("ko-KR")}원`
+                      : ""}
                   </p>
                 </div>
               </div>
 
-              <div className="mt-3 flex items-center gap-2">
+              {/* 프로필 이미지 업로드 */}
+              <div className="mt-4 flex items-center gap-2">
                 <input
                   type="file"
                   accept={SUPPORTED_IMAGE_ACCEPT}
                   onChange={handleProfileFileChange}
                   disabled={isUploadingProfile}
-                  className="block w-full text-[11px] text-zinc-300 file:mr-3 file:rounded-full file:border-0 file:bg-zinc-800 file:px-3 file:py-2 file:text-[11px] file:font-semibold file:text-zinc-100 hover:file:bg-zinc-700"
+                  className="block w-full text-[11.5px] text-[color:var(--hc-muted)] file:mr-3 file:rounded-full file:border-0 file:bg-[color:var(--hc-surface-muted)] file:px-3 file:py-2 file:text-[11.5px] file:font-semibold file:text-[color:var(--hc-text)] hover:file:bg-[color:var(--hc-surface-muted-hover)]"
                 />
                 <button
                   type="button"
                   onClick={handleUploadProfileImage}
                   disabled={isUploadingProfile || !profileFile}
-                  className="hc-button-primary h-9 shrink-0 whitespace-nowrap rounded-full px-4 text-[11px] font-semibold disabled:opacity-50"
+                  className="hc-button-primary h-9 shrink-0 whitespace-nowrap rounded-full px-4 text-[11.5px] font-semibold disabled:opacity-50"
                 >
                   {isUploadingProfile ? "업로드 중" : "업로드"}
                 </button>
@@ -290,9 +300,10 @@ export default function MyPage() {
 
             <ColorThemePreferencePanel />
 
-            <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-              <h2 className="text-sm font-semibold">닉네임 변경</h2>
-              <p className="mt-1 text-[11px] text-zinc-400">
+            {/* 닉네임 변경 */}
+            <section className="hc-surface-card rounded-[20px] border p-5">
+              <h2 className="text-[15px] font-bold">닉네임 변경</h2>
+              <p className="mt-1 text-[12px] text-[color:var(--hc-muted)]">
                 서비스에서 표시될 이름을 수정할 수 있어요.
               </p>
 
@@ -300,27 +311,28 @@ export default function MyPage() {
                 <input
                   value={username}
                   onChange={(e) => setUsername(e.target.value)}
-                  className="hc-input h-9 flex-1 rounded-xl border px-3 text-[12px] outline-none"
+                  className="hc-input h-10 flex-1 rounded-xl border px-3 text-[13px] outline-none"
                   placeholder="닉네임을 입력해 주세요"
                 />
                 <button
                   type="submit"
                   disabled={isSubmitting}
-                  className="hc-button-primary h-9 rounded-full px-4 text-[11px] font-semibold disabled:opacity-50"
+                  className="hc-button-primary h-10 rounded-full px-4 text-[12px] font-semibold disabled:opacity-50"
                 >
                   저장
                 </button>
               </form>
 
               {errors.username ? (
-                <p className="mt-2 text-[11px] text-red-400">
+                <p className="mt-2 text-[11.5px] text-[color:var(--hc-primary-strong)]">
                   {errors.username}
                 </p>
               ) : null}
             </section>
 
-            <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-              <h2 className="text-sm font-semibold">비밀번호 변경</h2>
+            {/* 비밀번호 변경 */}
+            <section className="hc-surface-card rounded-[20px] border p-5">
+              <h2 className="text-[15px] font-bold">비밀번호 변경</h2>
 
               <form
                 onSubmit={handleChangePassword}
@@ -365,46 +377,48 @@ export default function MyPage() {
                 <button
                   type="submit"
                   disabled={isSubmitting}
-                  className="hc-button-primary mt-1 h-9 rounded-full text-[11px] font-semibold disabled:opacity-50"
+                  className="hc-button-primary mt-1 h-10 rounded-full text-[12px] font-semibold disabled:opacity-50"
                 >
                   {isSubmitting ? "변경 중..." : "비밀번호 변경"}
                 </button>
               </form>
             </section>
 
-            <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-              <h2 className="text-sm font-semibold">로그아웃</h2>
+            {/* 로그아웃 / 탈퇴 */}
+            <section className="hc-surface-card rounded-[20px] border p-5">
               <button
                 type="button"
                 onClick={handleLogout}
                 disabled={isSubmitting}
-                className="mt-3 h-9 w-full rounded-full bg-zinc-800 text-[11px] font-semibold text-zinc-100 hover:bg-zinc-700 disabled:opacity-50"
+                className="hc-button-secondary flex h-10 w-full items-center justify-center gap-2 rounded-full border text-[12px] font-semibold disabled:opacity-50"
               >
+                <LogOut className="h-4 w-4" />
                 로그아웃
               </button>
+
+              <div className="mt-4 border-t border-[color:var(--hc-border-subtle)] pt-4">
+                <p className="text-[11.5px] text-[color:var(--hc-muted)]">
+                  탈퇴를 요청하면 계정이 비활성화돼요. 1주일 내로 다시 로그인하면
+                  탈퇴를 취소하고 계정을 다시 사용할 수 있어요.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleExit}
+                  disabled={isSubmitting}
+                  className="mt-3 text-[12px] font-semibold text-[color:var(--hc-muted-soft)] underline underline-offset-4 transition hover:text-[color:var(--hc-text)] disabled:opacity-50"
+                >
+                  회원 탈퇴 요청
+                </button>
+              </div>
             </section>
 
-            <section className="rounded-2xl border border-red-900/40 bg-red-950/10 p-4">
-              <h2 className="text-sm font-semibold text-red-700 dark:text-red-200">
-                회원 탈퇴 요청
-              </h2>
-              <p className="mt-1 text-[11px] text-red-900/80 dark:text-red-200/80">
-                탈퇴를 요청하면 계정이 비활성화돼요. 다시 로그인하면 탈퇴를
-                취소하고 계정을 다시 사용할 수 있어요.
-              </p>
-              <button
-                type="button"
-                onClick={handleExit}
-                disabled={isSubmitting}
-                className="mt-3 h-9 w-full rounded-full bg-red-500 text-[11px] font-semibold text-zinc-950 hover:bg-red-400 disabled:opacity-50"
-              >
-                회원 탈퇴 요청
-              </button>
-            </section>
+            <p className="pb-2 text-center text-[11px] text-[color:var(--hc-muted-soft)]">
+              하루컷 v1.0.0
+            </p>
           </>
         ) : (
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-            <p className="text-[11px] text-zinc-400">
+          <div className="hc-surface-card rounded-[20px] border p-5">
+            <p className="text-[12px] text-[color:var(--hc-muted)]">
               내 정보를 불러오지 못했어요.
             </p>
           </div>


### PR DESCRIPTION
## 작업 내용
웹 인증 메인 페이지(home/history/mypage)의 콘텐츠/레이아웃을 handoff 디자인 기준으로 재구성했습니다. 색·탭바는 기존대로 두고 섹션/카드/타이포/간격만 다시 짰습니다.

### home
- 인사 헤더(날짜 오버라인 + 규원님, 오늘은 어떻게 남겨볼까요) + 번호형 액션 카드 3개(촬영/업로드/꾸미기)
- 최근 기록 그리드(모바일 2열, 데스크톱 4열) + 저장된 프레임 카드
- data-coach=shoot|upload|theme 앵커, CoachMarks, MobileTabBar 그대로 유지

### history
- 헤더(기록 + 총 개수) + 필터 칩(개수 표시) + 검색
- 반응형 카드 그리드, 다운로드·공유·이름수정 로직 전부 유지

### mypage
- 프로필 헤더 + 플랜/플랫폼 카드 + 닉네임/비밀번호/프로필이미지/로그아웃/탈퇴 섹션
- 모든 API 호출(getMyUserInfo, username/password change, profile upload, logout, exit) 유지

## 보존 확인
- 데이터 로딩/상태/훅/API 호출 변경 없음
- MobileTabBar, CoachMarks, data-coach 속성, pb-[90px] lg:pb-6 유지
- 색은 --hc-* 토큰 사용

## 검증
- tsc --noEmit 통과
- jest 23 suites / 71 tests 통과
- next build 통과(home/history/mypage 정적 생성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)