### PR TITLE
feat(web): 데스크톱 AppNav 추가 및 홈/코치마크 handoff 정비

### DIFF
--- a/apps/web/app/history/page.tsx
+++ b/apps/web/app/history/page.tsx
@@ -11,6 +11,7 @@ import {
   Share2,
 } from "lucide-react";
 import { getUserFacingApiErrorMessage } from "@/lib/apiError";
+import { AppNav } from "@/components/layout/AppNav";
 import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { downloadFromUrl } from "@/lib/canvas/composeFrame";
 import { buildDownloadFilename } from "@/lib/fourcutOutput";
@@ -246,8 +247,10 @@ export default function HistoryPage() {
   ];
 
   return (
-    <main className="hc-page-app min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 lg:gap-6">
+    <main className="hc-page-app min-h-dvh pb-[90px] text-[color:var(--hc-text)] lg:pb-0">
+      <AppNav />
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 py-5 sm:py-6 lg:gap-6 lg:py-8">
         {/* 헤더 */}
         <header className="flex flex-col gap-2 pt-1 lg:flex-row lg:items-end lg:justify-between lg:pt-3">
           <div>

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -7,16 +7,14 @@ import {
   Camera,
   ChevronRight,
   Image as ImageIcon,
-  Palette,
   Play,
   Sparkles,
 } from "lucide-react";
 import { getMyUserInfo, type UserInfo } from "@/lib/userApi";
 import { listMyMedia } from "@/lib/userMediaApi";
-import { listMyFrames } from "@/lib/remoteFrameApi";
-import type { UserMedia, RemoteFrame } from "@/lib/api-types";
-import { frameIdFromFrameType } from "@/lib/frameApi";
+import type { UserMedia } from "@/lib/api-types";
 import { getUserMediaPreview, getUserMediaTitle } from "@/lib/userMediaPreview";
+import { AppNav } from "@/components/layout/AppNav";
 import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { CoachMarks, type CoachStep } from "@/components/onboarding/CoachMarks";
 
@@ -88,7 +86,6 @@ export default function HomePage() {
   const [user, setUser] = useState<UserInfo | null>(null);
   const [recentMedia, setRecentMedia] = useState<UserMedia[]>([]);
   const [previewMedia, setPreviewMedia] = useState<UserMedia[]>([]);
-  const [savedFrames, setSavedFrames] = useState<RemoteFrame[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -98,10 +95,9 @@ export default function HomePage() {
       setLoading(true);
 
       try {
-        const [nextUser, nextMedia, nextFrames] = await Promise.all([
+        const [nextUser, nextMedia] = await Promise.all([
           getMyUserInfo().catch(() => null),
           listMyMedia().catch(() => []),
-          listMyFrames().catch(() => []),
         ]);
 
         if (cancelled) return;
@@ -115,7 +111,6 @@ export default function HomePage() {
         setUser(nextUser);
         setRecentMedia(sortedMedia.slice(0, 4));
         setPreviewMedia(sortedMedia);
-        setSavedFrames(nextFrames.slice(0, 1));
       } finally {
         if (!cancelled) {
           setLoading(false);
@@ -131,14 +126,15 @@ export default function HomePage() {
   }, []);
 
   const currentDateLabel = useCurrentDateLabel();
-  const savedFrame = savedFrames[0] ?? null;
   const greetingName = user?.username ? `${user.username}님, ` : "";
 
   return (
-    <main className="hc-page-app min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 lg:gap-9">
+    <main className="hc-page-app min-h-dvh pb-[90px] text-[color:var(--hc-text)] lg:pb-0">
+      <AppNav userInitial={user?.username} />
+
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-5 sm:py-6 lg:gap-9 lg:py-8">
         {/* 인사 */}
-        <header className="pt-1 lg:pt-4">
+        <header className="pt-1 lg:pt-0">
           <span className="text-[12px] font-medium uppercase tracking-[0.22em] text-[color:var(--hc-primary)]">
             {currentDateLabel}
           </span>
@@ -265,12 +261,12 @@ export default function HomePage() {
                     href="/history"
                     className="group flex flex-col gap-2"
                   >
-                    <div className="hc-surface-well relative aspect-[3/4] overflow-hidden rounded-[18px] border transition group-hover:border-[color:var(--hc-border-strong)]">
+                    <div className="hc-surface-well relative grid aspect-[3/4] place-items-center overflow-hidden rounded-[18px] border bg-[color:var(--hc-surface-inset)] p-2.5 transition group-hover:border-[color:var(--hc-border-strong)]">
                       {preview.url ? (
                         preview.kind === "video" ? (
                           <video
                             src={preview.url}
-                            className="h-full w-full object-cover"
+                            className="h-full w-full object-contain"
                             muted
                             playsInline
                           />
@@ -279,7 +275,7 @@ export default function HomePage() {
                           <img
                             src={preview.url}
                             alt={getUserMediaTitle(item)}
-                            className="h-full w-full object-cover"
+                            className="h-full w-full object-contain"
                           />
                         )
                       ) : (
@@ -327,34 +323,6 @@ export default function HomePage() {
               </div>
             )}
           </div>
-        </section>
-
-        {/* 저장된 프레임 */}
-        <section className="hc-surface-card flex items-center justify-between rounded-[20px] border p-4 sm:p-5">
-          <div className="flex min-w-0 items-center gap-3">
-            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-[color:var(--hc-accent-soft-bg)]">
-              <Palette className="h-5 w-5 text-[color:var(--hc-primary)]" />
-            </span>
-            <div className="min-w-0">
-              <p className="text-[14px] font-bold">저장된 프레임</p>
-              <p className="mt-0.5 truncate text-[12px] text-[color:var(--hc-muted)]">
-                {savedFrame
-                  ? savedFrame.title
-                  : "만들어둔 프레임을 촬영할 때 골라 쓸 수 있어요."}
-              </p>
-            </div>
-          </div>
-          <Link
-            href={
-              savedFrame
-                ? `/theme?frame=${frameIdFromFrameType(savedFrame.frameType)}&remoteFrameId=${savedFrame.frameId}`
-                : "/theme"
-            }
-            className="hc-link-accent ml-3 flex shrink-0 items-center gap-1 text-[13px] font-semibold"
-          >
-            {savedFrame ? "이어서 수정" : "프레임 만들기"}
-            <ChevronRight className="h-4 w-4" />
-          </Link>
         </section>
       </div>
       <MobileTabBar />

--- a/apps/web/app/mypage/page.tsx
+++ b/apps/web/app/mypage/page.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CreditCard, LogOut, RefreshCw, ShieldCheck } from "lucide-react";
 import { AuthField } from "@/components/auth/AuthField";
+import { AppNav } from "@/components/layout/AppNav";
 import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { ColorThemePreferencePanel } from "@/components/theme/ColorThemePreferencePanel";
 import { clientApi } from "@/lib/clientApi";
@@ -194,8 +195,10 @@ export default function MyPage() {
   const profileInitial = user?.username?.trim()?.[0] ?? "U";
 
   return (
-    <main className="hc-page-app min-h-dvh px-4 py-5 pb-[90px] text-[color:var(--hc-text)] sm:py-6 lg:pb-6">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 lg:gap-6">
+    <main className="hc-page-app min-h-dvh pb-[90px] text-[color:var(--hc-text)] lg:pb-0">
+      <AppNav userInitial={user?.username} />
+
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-5 sm:py-6 lg:gap-6 lg:py-8">
         {/* 헤더 */}
         <header className="flex items-center justify-between pt-1 lg:pt-3">
           <h1 className="text-[28px] font-extrabold tracking-tight lg:text-[34px]">

--- a/apps/web/components/layout/AppNav.tsx
+++ b/apps/web/components/layout/AppNav.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Bell, Camera } from "lucide-react";
+import { BrandMark } from "@/components/layout/BrandMark";
+
+type AppNavProps = {
+  // 프로필 원형에 표시할 사용자 이니셜(없으면 아이콘 대체).
+  userInitial?: string | null;
+};
+
+const NAV_LINKS: { href: string; label: string }[] = [
+  { href: "/home", label: "홈" },
+  { href: "/history", label: "기록" },
+  { href: "/theme", label: "프레임" },
+  { href: "/pricing", label: "요금제" },
+];
+
+// 데스크톱(≥ lg) 전용 상단 네비게이션 (handoff app AppNav).
+// 모바일(< lg)에서는 숨기고 하단 MobileTabBar가 네비게이션을 담당한다.
+export function AppNav({ userInitial }: AppNavProps) {
+  const pathname = usePathname();
+  const isActive = (href: string) =>
+    pathname === href || pathname.startsWith(`${href}/`);
+
+  const initial = userInitial?.trim()?.[0]?.toUpperCase() ?? "";
+
+  return (
+    <header className="sticky top-0 z-40 hidden border-b border-[color:var(--hc-border)] bg-[color:var(--hc-surface-soft)] backdrop-blur-xl lg:block">
+      <div className="mx-auto flex h-[68px] w-full max-w-5xl items-center gap-9 px-7">
+        <BrandMark href="/home" />
+
+        <nav className="flex gap-2">
+          {NAV_LINKS.map(({ href, label }) => {
+            const active = isActive(href);
+            return (
+              <Link
+                key={href}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={`whitespace-nowrap rounded-full px-3.5 py-2 text-[14.5px] font-bold transition ${
+                  active
+                    ? "bg-[color:var(--hc-surface-highlight)] text-[color:var(--hc-text)] shadow-sm"
+                    : "text-[color:var(--hc-muted)] hover:text-[color:var(--hc-text)]"
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-3">
+          <Link
+            href="/shoot"
+            className="hc-button-primary flex items-center gap-1.5 rounded-full px-4 py-2 text-[13.5px] font-bold"
+          >
+            <Camera className="h-[17px] w-[17px]" />
+            촬영하기
+          </Link>
+
+          <button
+            type="button"
+            aria-label="알림"
+            className="hc-button-icon grid h-[42px] w-[42px] place-items-center rounded-full border text-[color:var(--hc-muted)] transition hover:text-[color:var(--hc-text)]"
+          >
+            <Bell className="h-[19px] w-[19px]" />
+          </button>
+
+          <Link
+            href="/mypage"
+            aria-label="마이페이지"
+            className="grid h-[42px] w-[42px] place-items-center rounded-full bg-[color:var(--hc-primary)] text-[15px] font-extrabold text-[color:var(--hc-primary-contrast)]"
+          >
+            {initial || "MY"}
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/components/onboarding/CoachMarks.tsx
+++ b/apps/web/components/onboarding/CoachMarks.tsx
@@ -26,8 +26,8 @@ export function CoachMarks({ id, steps }: { id: string; steps: CoachStep[] }) {
       done = true;
     }
     if (done) return;
-    // 버튼이 마운트될 시간을 준 뒤 시작
-    const timer = window.setTimeout(() => setActive(true), 700);
+    // 버튼이 마운트될 최소 시간만 기다린 뒤, 슬라이드/페이드 없이 즉시 표시
+    const timer = window.setTimeout(() => setActive(true), 350);
     return () => window.clearTimeout(timer);
   }, [storageKey]);
 
@@ -91,7 +91,7 @@ export function CoachMarks({ id, steps }: { id: string; steps: CoachStep[] }) {
       {rect ? (
         <div
           aria-hidden
-          className="pointer-events-none absolute rounded-2xl transition-all duration-200"
+          className="pointer-events-none absolute rounded-2xl"
           style={{
             top: rect.top - pad,
             left: rect.left - pad,
@@ -106,8 +106,12 @@ export function CoachMarks({ id, steps }: { id: string; steps: CoachStep[] }) {
       )}
 
       <div
-        className="absolute w-[300px] max-w-[calc(100vw-24px)] rounded-2xl border border-[color:var(--hc-border)] bg-[color:var(--hc-card)] p-4 shadow-2xl"
-        style={{ top: tooltipTop, left: tooltipLeft }}
+        className="absolute w-[300px] max-w-[calc(100vw-24px)] rounded-2xl border-2 border-[color:var(--hc-border-strong)] bg-[color:var(--hc-surface)] p-4 shadow-2xl"
+        style={{
+          top: tooltipTop,
+          left: tooltipLeft,
+          boxShadow: "0 18px 50px rgba(0,0,0,0.45), 0 0 0 1px rgba(0,0,0,0.08)",
+        }}
       >
         <p className="text-[11px] font-bold tracking-wide text-[color:var(--hc-primary)]">
           {index + 1} / {steps.length}


### PR DESCRIPTION
## 작업 내용
handoff 기준으로 웹 3가지를 정비했습니다.

### 1. 코치마크 (CoachMarks.tsx)
- 툴팁 배경을 정의되지 않던 var(--hc-card)에서 실제 불투명 surface(var(--hc-surface))로 교체해 글씨 가독성 확보
- 테두리를 border-strong 2px + 그림자 강화로 대비 보강
- 스포트라이트 박스의 transition-all duration-200 제거 → 첫 단계가 슬라이드/페이드 없이 즉시 제자리에 표시
- 등장 지연 700ms → 350ms (버튼 마운트 대기 최소치)

### 2. AppNav (신규 components/layout/AppNav.tsx)
- 데스크톱 전용(hidden lg:block) sticky 상단 네비
- 로고(BrandMark) + pill nav [홈/기록/프레임/요금제] + 우측 [촬영하기(그린)·알림 벨·프로필 원형]
- usePathname active 표시(활성 링크 highlight pill), 프로필은 /mypage 이동(닉네임 이니셜)
- 링크: 홈→/home, 기록→/history, 프레임→/theme, 요금제→/pricing (요금제 라우트는 추후 추가 예정이라 그대로 유지)
- home/history/mypage 상단에 적용. 모바일은 기존 MobileTabBar 유지

### 3. 홈 (app/home/page.tsx)
- 상단 AppNav 추가
- 최근 기록 썸네일: object-cover → object-contain + 어두운 카드 배경/여백으로 네 컷 전체가 잘리지 않게 표시
- 저장된 프레임(savedFrames) 섹션 제거 및 관련 state/import 정리(listMyFrames 호출 제거)

## 보존 확인
- CoachMarks 렌더 + data-coach="shoot|upload|theme" 앵커 유지
- MobileTabBar, 데이터 로딩/API 호출, 하단 탭바 가림 패딩 유지

## 검증
- pnpm exec tsc --noEmit 통과
- pnpm build 통과 (Compiled successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)