### PR TITLE
fix(web): 공개 페이지 촬영 CTA 게스트 진입 및 복구기간 30일 통일

### DIFF
--- a/apps/web/app/mypage/page.tsx
+++ b/apps/web/app/mypage/page.tsx
@@ -173,7 +173,7 @@ export default function MyPage() {
 
   const handleExit = async () => {
     const ok = confirm(
-      "정말 탈퇴하시겠어요?\n1주일 내로 다시 로그인하면 계정을 복구할 수 있어요.",
+      "정말 탈퇴하시겠어요?\n탈퇴 신청일부터 30일 내로 다시 로그인하면 계정을 복구할 수 있어요.",
     );
     if (!ok) return;
 
@@ -401,8 +401,8 @@ export default function MyPage() {
 
               <div className="mt-4 border-t border-[color:var(--hc-border-subtle)] pt-4">
                 <p className="text-[11.5px] text-[color:var(--hc-muted)]">
-                  탈퇴를 요청하면 계정이 비활성화돼요. 1주일 내로 다시 로그인하면
-                  탈퇴를 취소하고 계정을 다시 사용할 수 있어요.
+                  탈퇴를 요청하면 계정이 비활성화돼요. 탈퇴 신청일부터 30일 내로
+                  다시 로그인하면 탈퇴를 취소하고 계정을 다시 사용할 수 있어요.
                 </p>
                 <button
                   type="button"

--- a/apps/web/components/layout/AppNav.tsx
+++ b/apps/web/components/layout/AppNav.tsx
@@ -4,14 +4,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Bell, Camera } from "lucide-react";
 import { BrandMark } from "@/components/layout/BrandMark";
-import { useGuestTrialStore } from "@/lib/guestTrialStore";
+import { usePublicShootCta } from "@/lib/usePublicShootCta";
 
 type AppNavProps = {
   // 프로필 원형에 표시할 사용자 이니셜(없으면 아이콘 대체).
   userInitial?: string | null;
-  // 공개 페이지(/pricing 등)에서 렌더될 때 true. 촬영 CTA가 /shoot로 직행하면
-  // proxy가 비회원을 /login으로 막으므로, 게스트 체험 안내를 띄워
-  // enterGuestMode 후 /shoot로 이어지도록 한다. authed 페이지에서는 미지정.
+  // 공개 페이지(/pricing 등)에서 렌더될 때 true. 촬영 CTA는 인증 여부를 확인해
+  // 로그인 사용자는 /shoot로 직행, 비회원은 게스트 체험 안내를 띄운다.
+  // (proxy가 비회원을 /login으로 막으므로) authed 페이지에서는 미지정.
   publicShoot?: boolean;
 };
 
@@ -26,9 +26,7 @@ const NAV_LINKS: { href: string; label: string }[] = [
 // 모바일(< lg)에서는 숨기고 하단 MobileTabBar가 네비게이션을 담당한다.
 export function AppNav({ userInitial, publicShoot = false }: AppNavProps) {
   const pathname = usePathname();
-  const showGuestTrialNotice = useGuestTrialStore(
-    (state) => state.showGuestTrialNotice,
-  );
+  const { onShootCta } = usePublicShootCta();
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`);
 
@@ -66,7 +64,7 @@ export function AppNav({ userInitial, publicShoot = false }: AppNavProps) {
           {publicShoot ? (
             <button
               type="button"
-              onClick={showGuestTrialNotice}
+              onClick={onShootCta}
               className={shootButtonClass}
             >
               <Camera className="h-[17px] w-[17px]" />

--- a/apps/web/components/layout/AppNav.tsx
+++ b/apps/web/components/layout/AppNav.tsx
@@ -4,10 +4,15 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Bell, Camera } from "lucide-react";
 import { BrandMark } from "@/components/layout/BrandMark";
+import { useGuestTrialStore } from "@/lib/guestTrialStore";
 
 type AppNavProps = {
   // 프로필 원형에 표시할 사용자 이니셜(없으면 아이콘 대체).
   userInitial?: string | null;
+  // 공개 페이지(/pricing 등)에서 렌더될 때 true. 촬영 CTA가 /shoot로 직행하면
+  // proxy가 비회원을 /login으로 막으므로, 게스트 체험 안내를 띄워
+  // enterGuestMode 후 /shoot로 이어지도록 한다. authed 페이지에서는 미지정.
+  publicShoot?: boolean;
 };
 
 const NAV_LINKS: { href: string; label: string }[] = [
@@ -19,12 +24,18 @@ const NAV_LINKS: { href: string; label: string }[] = [
 
 // 데스크톱(≥ lg) 전용 상단 네비게이션 (handoff app AppNav).
 // 모바일(< lg)에서는 숨기고 하단 MobileTabBar가 네비게이션을 담당한다.
-export function AppNav({ userInitial }: AppNavProps) {
+export function AppNav({ userInitial, publicShoot = false }: AppNavProps) {
   const pathname = usePathname();
+  const showGuestTrialNotice = useGuestTrialStore(
+    (state) => state.showGuestTrialNotice,
+  );
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`);
 
   const initial = userInitial?.trim()?.[0]?.toUpperCase() ?? "";
+
+  const shootButtonClass =
+    "hc-button-primary flex items-center gap-1.5 rounded-full px-4 py-2 text-[13.5px] font-bold";
 
   return (
     <header className="sticky top-0 z-40 hidden border-b border-[color:var(--hc-border)] bg-[color:var(--hc-surface-soft)] backdrop-blur-xl lg:block">
@@ -52,13 +63,21 @@ export function AppNav({ userInitial }: AppNavProps) {
         </nav>
 
         <div className="ml-auto flex items-center gap-3">
-          <Link
-            href="/shoot"
-            className="hc-button-primary flex items-center gap-1.5 rounded-full px-4 py-2 text-[13.5px] font-bold"
-          >
-            <Camera className="h-[17px] w-[17px]" />
-            촬영하기
-          </Link>
+          {publicShoot ? (
+            <button
+              type="button"
+              onClick={showGuestTrialNotice}
+              className={shootButtonClass}
+            >
+              <Camera className="h-[17px] w-[17px]" />
+              촬영하기
+            </button>
+          ) : (
+            <Link href="/shoot" className={shootButtonClass}>
+              <Camera className="h-[17px] w-[17px]" />
+              촬영하기
+            </Link>
+          )}
 
           <button
             type="button"

--- a/apps/web/components/layout/MobileTabBar.tsx
+++ b/apps/web/components/layout/MobileTabBar.tsx
@@ -3,12 +3,12 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Camera, Clock3, Home, User } from "lucide-react";
-import { useGuestTrialStore } from "@/lib/guestTrialStore";
+import { usePublicShootCta } from "@/lib/usePublicShootCta";
 
 type MobileTabBarProps = {
-  // 공개 페이지(/pricing 등)에서 렌더될 때 true. 촬영 탭이 /shoot로 직행하면
-  // proxy가 비회원을 /login으로 막으므로, 게스트 체험 안내를 띄워
-  // enterGuestMode 후 /shoot로 이어지도록 한다. authed 페이지에서는 미지정.
+  // 공개 페이지(/pricing 등)에서 렌더될 때 true. 촬영 탭은 인증 여부를 확인해
+  // 로그인 사용자는 /shoot로 직행, 비회원은 게스트 체험 안내를 띄운다.
+  // (proxy가 비회원을 /login으로 막으므로) authed 페이지에서는 미지정.
   publicShoot?: boolean;
 };
 
@@ -16,9 +16,7 @@ type MobileTabBarProps = {
 // 데스크톱(≥ lg)에서는 숨기고 기존 웹 네비게이션을 사용한다.
 export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
   const pathname = usePathname();
-  const showGuestTrialNotice = useGuestTrialStore(
-    (state) => state.showGuestTrialNotice,
-  );
+  const { onShootCta } = usePublicShootCta();
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`);
 
@@ -60,7 +58,7 @@ export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
         <button
           type="button"
           aria-label="촬영"
-          onClick={showGuestTrialNotice}
+          onClick={onShootCta}
           className={shootButtonClass}
           style={{ background: "var(--hc-primary)" }}
         >

--- a/apps/web/components/layout/MobileTabBar.tsx
+++ b/apps/web/components/layout/MobileTabBar.tsx
@@ -3,13 +3,27 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Camera, Clock3, Home, User } from "lucide-react";
+import { useGuestTrialStore } from "@/lib/guestTrialStore";
+
+type MobileTabBarProps = {
+  // 공개 페이지(/pricing 등)에서 렌더될 때 true. 촬영 탭이 /shoot로 직행하면
+  // proxy가 비회원을 /login으로 막으므로, 게스트 체험 안내를 띄워
+  // enterGuestMode 후 /shoot로 이어지도록 한다. authed 페이지에서는 미지정.
+  publicShoot?: boolean;
+};
 
 // 폰/태블릿(< lg)에서만 보이는 앱 스타일 하단 탭바 (handoff app TabBar: 홈·기록·촬영·MY).
 // 데스크톱(≥ lg)에서는 숨기고 기존 웹 네비게이션을 사용한다.
-export function MobileTabBar() {
+export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
   const pathname = usePathname();
+  const showGuestTrialNotice = useGuestTrialStore(
+    (state) => state.showGuestTrialNotice,
+  );
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(`${href}/`);
+
+  const shootButtonClass =
+    "-mt-7 grid h-[54px] w-[54px] place-items-center rounded-full text-[color:var(--hc-primary-contrast)] shadow-[var(--hc-button-shadow)]";
 
   return (
     <nav
@@ -42,14 +56,26 @@ export function MobileTabBar() {
         <span className="text-[10.5px] font-medium">기록</span>
       </Link>
 
-      <Link
-        href="/shoot"
-        aria-label="촬영"
-        className="-mt-7 grid h-[54px] w-[54px] place-items-center rounded-full text-[color:var(--hc-primary-contrast)] shadow-[var(--hc-button-shadow)]"
-        style={{ background: "var(--hc-primary)" }}
-      >
-        <Camera className="h-[26px] w-[26px]" />
-      </Link>
+      {publicShoot ? (
+        <button
+          type="button"
+          aria-label="촬영"
+          onClick={showGuestTrialNotice}
+          className={shootButtonClass}
+          style={{ background: "var(--hc-primary)" }}
+        >
+          <Camera className="h-[26px] w-[26px]" />
+        </button>
+      ) : (
+        <Link
+          href="/shoot"
+          aria-label="촬영"
+          className={shootButtonClass}
+          style={{ background: "var(--hc-primary)" }}
+        >
+          <Camera className="h-[26px] w-[26px]" />
+        </Link>
+      )}
 
       <Link
         href="/mypage"

--- a/apps/web/components/pricing/PricingView.tsx
+++ b/apps/web/components/pricing/PricingView.tsx
@@ -135,7 +135,7 @@ export function PricingView() {
 
   return (
     <main className="hc-page-app min-h-dvh pb-[90px] text-[color:var(--hc-text)] lg:pb-0">
-      <AppNav />
+      <AppNav publicShoot />
 
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 py-6 sm:py-8 lg:gap-14 lg:py-10">
         {/* 헤더 */}
@@ -197,7 +197,7 @@ export function PricingView() {
         </section>
       </div>
 
-      <MobileTabBar />
+      <MobileTabBar publicShoot />
     </main>
   );
 }

--- a/apps/web/lib/usePublicShootCta.ts
+++ b/apps/web/lib/usePublicShootCta.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { clientApi } from "@/lib/clientApi";
+import { useGuestTrialStore } from "@/lib/guestTrialStore";
+
+// 공개 페이지(/pricing 등)의 촬영 CTA 클릭 핸들러.
+// 인증 쿠키(accessToken/refreshToken)는 httpOnly라 클라이언트에서 직접 읽을 수 없으므로,
+// 앱이 이미 사용하는 /api/auth/status(소셜 로그인 콜백과 동일)로 로그인 여부를 판단한다.
+// - 로그인 사용자: 게스트 오버레이/enterGuestMode 없이 /shoot로 직행해
+//   회원 스토어를 게스트로 덮어쓰지 않는다(저장 프레임·영상 옵션 유지).
+// - 비회원: 기존 게스트 체험 안내(showGuestTrialNotice)를 띄운다.
+export function usePublicShootCta() {
+  const router = useRouter();
+  const showGuestTrialNotice = useGuestTrialStore(
+    (state) => state.showGuestTrialNotice,
+  );
+  const pendingRef = useRef(false);
+
+  const onShootCta = useCallback(async () => {
+    if (pendingRef.current) {
+      return;
+    }
+    pendingRef.current = true;
+
+    try {
+      await clientApi.get("/api/auth/status", { cache: "no-store" });
+      // 200이면 인증 쿠키가 백엔드에서 유효 → 회원으로 바로 촬영 진입.
+      router.push("/shoot");
+    } catch {
+      // 401 등 비인증/오류 → 게스트 체험 안내.
+      showGuestTrialNotice();
+    } finally {
+      pendingRef.current = false;
+    }
+  }, [router, showGuestTrialNotice]);
+
+  return { onShootCta };
+}


### PR DESCRIPTION
## 개요
코덱스 P2 지적 2건을 수정합니다.

### #353 게스트 촬영 CTA
- /pricing 등 공개 페이지에서 AppNav/MobileTabBar의 촬영 CTA가 /shoot로 직행 -> proxy가 게스트 쿠키 없는 비회원을 /login?redirectTo=/shoot 로 막던 문제.
- AppNav, MobileTabBar에 옵셔널 prop publicShoot 추가.
  - publicShoot=true(공개 페이지): 촬영 CTA가 showGuestTrialNotice를 띄움 -> 체험 시작 시 enterGuestMode 후 /shoot (랜딩의 GuestTrialStartButton과 동일 흐름).
  - prop 미지정(authed 페이지 /home, /history, /mypage): 기존 /shoot 직링크 동작 불변.
- enterGuestMode를 로그인 사용자에 무조건 호출하지 않음(오버레이의 사용자 액션에서만 호출).

### #350 복구기간 문구
- mypage 탈퇴 안내 문구와 handleExit 확인창의 복구 가능 기간을 약관(packages/shared/src/legal.ts)의 30일과 일치하도록 1주일 -> 30일로 통일.

## 검증
- apps/web tsc --noEmit 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)