### PR TITLE
fix(mobile): 결과/저장 네컷에 선택 순서 보존

### DIFF
--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -497,8 +497,12 @@ export function ShootResultScreen() {
   ]);
 
   const currentHistory = historyItems.find((item) => item.id === shoot.persistedHistoryId) ?? null;
+  // 사용자가 탭한 순서(selectedShotIds)를 보존해 미리보기/저장 결과가 일치하도록 한다.
   const previewMedia =
-    currentHistory?.previewMedia ?? shoot.shots.filter((item) => shoot.selectedShotIds.includes(item.id));
+    currentHistory?.previewMedia ??
+    shoot.selectedShotIds
+      .map((id) => shoot.shots.find((shot) => shot.id === id))
+      .filter((shot): shot is (typeof shoot.shots)[number] => shot !== undefined);
 
   useEffect(() => {
     setDraftName(currentHistory?.title ?? '');

--- a/apps/mobile/screens/upload-screens.tsx
+++ b/apps/mobile/screens/upload-screens.tsx
@@ -284,8 +284,12 @@ export function UploadResultScreen() {
   ]);
 
   const currentHistory = historyItems.find((item) => item.id === upload.persistedHistoryId) ?? null;
+  // 사용자가 탭한 순서(selectedAssetIds)를 보존해 미리보기/저장 결과가 일치하도록 한다.
   const previewMedia =
-    currentHistory?.previewMedia ?? upload.assets.filter((item) => upload.selectedAssetIds.includes(item.id));
+    currentHistory?.previewMedia ??
+    upload.selectedAssetIds
+      .map((id) => upload.assets.find((asset) => asset.id === id))
+      .filter((asset): asset is (typeof upload.assets)[number] => asset !== undefined);
 
   useEffect(() => {
     setDraftName(currentHistory?.title ?? '');

--- a/apps/mobile/store/store-helpers.ts
+++ b/apps/mobile/store/store-helpers.ts
@@ -105,7 +105,11 @@ export function limitSelection(current: string[], id: string) {
 }
 
 export function selectedMedia(items: MediaAsset[], selectedIds: string[]) {
-  const selected = items.filter((item) => selectedIds.includes(item.id));
+  // 사용자가 탭한 순서(selectedIds)를 그대로 보존해야 미리보기와 저장 결과가 일치한다.
+  // 원본 items 순서로 filter하면 탭 순서가 사라지므로 selectedIds 기준으로 매핑한다.
+  const selected = selectedIds
+    .map((id) => items.find((item) => item.id === id))
+    .filter((item): item is MediaAsset => item !== undefined);
   return selected.slice(0, 4);
 }
 


### PR DESCRIPTION
## 개요
코덱스 P2 #351: 사용자가 탭한 순서가 결과 화면과 저장되는 네컷에 반영돼야 하는데, 결과/저장 경로가 원본 리스트 순서로 되돌리던 문제를 수정합니다.

## 변경
- store-helpers의 selectedMedia를 selectedIds 기준 매핑(map(find).filter)으로 변경. 저장 경로(use-shoot-store/use-upload-store의 persistResult)가 탭 순서를 보존합니다. 기존 items.filter(includes)는 원본 순서를 따라 순서가 사라졌습니다.
- ShootResultScreen/UploadResultScreen의 결과 미리보기 previewMedia도 selectedShotIds/selectedAssetIds 기준 매핑으로 변경해 미리보기와 실제 저장 결과 순서를 일치시킵니다. (select 화면은 이미 동일 패턴으로 순서를 보존하고 있었습니다.)
- find가 undefined일 수 있으므로 타입 술어(item is ...)로 안전하게 제거.

## 검증
- apps/mobile tsc --noEmit 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)