### PR TITLE
fix(mobile): 홈 최근 기록 썸네일 전체 표시(resizeMode contain)

### DIFF
--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -244,7 +244,7 @@ export function HomeScreen() {
                 <View style={styles.thumbCard}>
                   {previewUri && previewKind === 'image' ? (
                     <>
-                      <Image source={{ uri: previewUri }} style={styles.thumbImage} />
+                      <Image resizeMode="contain" source={{ uri: previewUri }} style={styles.thumbImage} />
                       <View style={styles.thumbTypeBadge}>
                         <Ionicons
                           color="#FFFFFF"


### PR DESCRIPTION
모바일 홈 최근 기록 썸네일이 합성 4컷을 flat Image 기본 resizeMode(cover)로 그려 일부만 보이던 문제 수정.

- apps/mobile/screens/app-screens.tsx: thumbImage Image에 resizeMode=contain 추가
- 기록/상세는 FramePreview로 정상, 개별 컷/아바타 Image는 cover 유지(스코프 외)
- tsc 통과