### PR TITLE
fix(web): 홈 최근 기록 4컷 전체 표시(여백 포함)

### DIFF
--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -266,7 +266,7 @@ export default function HomePage() {
                         preview.kind === "video" ? (
                           <video
                             src={preview.url}
-                            className="h-full w-full object-contain"
+                            className="absolute inset-0 h-full w-full object-contain p-3"
                             muted
                             playsInline
                           />
@@ -275,7 +275,7 @@ export default function HomePage() {
                           <img
                             src={preview.url}
                             alt={getUserMediaTitle(item)}
-                            className="h-full w-full object-contain"
+                            className="absolute inset-0 h-full w-full object-contain p-3"
                           />
                         )
                       ) : (


### PR DESCRIPTION
홈 최근 기록 썸네일이 세로 긴 4컷(2000x6000)을 일부만 보여주던 문제 수정.

원인: 카드 aspect-[3/4] + 이미지 h-full w-full 조합에서 aspect-ratio 높이가 깨져 이미지가 645px로 오버플로되고 overflow-hidden에 잘림.
수정: 이미지를 absolute inset-0로 카드에 가두고 object-contain으로 전체 표시, p-3로 위아래 여백 추가.

- apps/web/app/home/page.tsx: 최근 기록 img/video 클래스 변경
- Playwright 실측: cardBox 236x315(0.75), 이미지 contain으로 스트립 전체 표시 확인
- tsc 통과