### PR TITLE
feat(web,mobile): 하단 탭바를 핸드오프 5탭 구성으로 정비

### DIFF
--- a/apps/mobile/components/harucut/bottom-nav.tsx
+++ b/apps/mobile/components/harucut/bottom-nav.tsx
@@ -11,7 +11,7 @@ import { useSessionStore } from '@/store/use-session-store';
 
 function activeKey(pathname: string) {
   if (pathname.startsWith('/shoot')) return 'shoot';
-  if (pathname.startsWith('/upload')) return 'upload';
+  if (pathname.startsWith('/theme')) return 'theme';
   if (pathname.startsWith('/history')) return 'history';
   if (pathname.startsWith('/mypage')) return 'mypage';
   return 'home';
@@ -29,94 +29,113 @@ export function BottomNavigation() {
   const push = (path: string) => router.push(path as never);
 
   return (
-    <View style={[styles.outer, { paddingBottom: Math.max(insets.bottom, 12) }]}>
-      <View style={styles.bar}>
-        {BOTTOM_NAV_ITEMS.map((item) => {
-          const active = item.key === currentKey;
-          const locked = accessMode === 'guest' && item.key !== 'shoot';
+    <View style={[styles.bar, { height: 74 + Math.max(insets.bottom, 0), paddingBottom: 10 + Math.max(insets.bottom, 0) }]}>
+      {BOTTOM_NAV_ITEMS.map((item) => {
+        const active = item.key === currentKey;
+        const locked = accessMode === 'guest' && item.key !== 'shoot';
+        const isCenter = 'center' in item && item.center;
 
+        const handlePress = () => {
+          if (locked) {
+            showGuestRestrictedNotice();
+            return;
+          }
+
+          push(item.href);
+        };
+
+        if (isCenter) {
           return (
             <Pressable
               key={item.key}
-              accessibilityLabel={`${item.label}${active ? ', 현재 탭' : ''}${locked ? ', 로그인 후 이용 가능' : ''}`}
+              accessibilityLabel={`촬영${active ? ', 현재 탭' : ''}`}
               accessibilityRole="tab"
               accessibilityState={{ selected: active }}
-              onPress={() => {
-                if (locked) {
-                  showGuestRestrictedNotice();
-                  return;
-                }
-
-                push(item.href);
-              }}
-              style={[styles.item, locked ? styles.itemLocked : null]}>
-              <Ionicons
-                color={
-                  locked
-                    ? isDark
-                      ? 'rgba(148, 163, 184, 0.58)'
-                      : 'rgba(89, 112, 143, 0.58)'
-                    : active
-                      ? colors.primaryStrong
-                      : colors.muted
-                }
-                name={active ? item.iconActive : item.icon}
-                size={22}
-              />
-              <Text style={[styles.label, active ? styles.labelActive : null, locked ? styles.labelLocked : null]}>
-                {item.label}
-              </Text>
+              onPress={handlePress}
+              style={styles.fab}>
+              <Ionicons color={colors.text} name={item.iconActive} size={26} />
             </Pressable>
           );
-        })}
-      </View>
+        }
+
+        return (
+          <Pressable
+            key={item.key}
+            accessibilityLabel={`${item.label}${active ? ', 현재 탭' : ''}${locked ? ', 로그인 후 이용 가능' : ''}`}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: active }}
+            onPress={handlePress}
+            style={[styles.item, locked ? styles.itemLocked : null]}>
+            <Ionicons
+              color={
+                locked
+                  ? isDark
+                    ? 'rgba(148, 163, 184, 0.58)'
+                    : 'rgba(89, 112, 143, 0.58)'
+                  : active
+                    ? colors.text
+                    : colors.muted
+              }
+              name={active ? item.iconActive : item.icon}
+              size={23}
+            />
+            <Text style={[styles.label, active ? styles.labelActive : null, locked ? styles.labelLocked : null]}>
+              {item.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
 
 function createStyles(colors: HarucutColors, isDark: boolean) {
   return StyleSheet.create({
+    // 핸드오프 TabBar: 높이 74(세이프에어리어 가산), --card 배경, 상단 1px 보더, 좌우 균등 분포.
     bar: {
-      backgroundColor: colors.cardStrong,
-      borderColor: colors.border,
-      borderRadius: 30,
-      borderWidth: 1,
+      alignItems: 'center',
+      backgroundColor: colors.card,
+      borderTopColor: colors.border,
+      borderTopWidth: 1,
       flexDirection: 'row',
-      justifyContent: 'space-between',
-      paddingHorizontal: 10,
-      paddingVertical: 8,
-      shadowColor: colors.shadow,
-      shadowOffset: { height: 14, width: 0 },
-      shadowOpacity: isDark ? 0.3 : 1,
-      shadowRadius: 30,
+      justifyContent: 'space-around',
+      paddingTop: 10,
+    },
+    // 중앙 촬영 FAB: 54x54 원형 그린, 위로 26 돌출, 그림자.
+    fab: {
+      alignItems: 'center',
+      backgroundColor: colors.primary,
+      borderRadius: 27,
+      elevation: 8,
+      height: 54,
+      justifyContent: 'center',
+      marginTop: -26,
+      shadowColor: colors.primary,
+      shadowOffset: { height: 8, width: 0 },
+      shadowOpacity: 0.45,
+      shadowRadius: 16,
+      width: 54,
     },
     item: {
       alignItems: 'center',
       borderRadius: HARUCUT_RADII.md,
-      flex: 1,
-      gap: 4,
-      paddingVertical: 7,
+      gap: 3,
+      width: 56,
     },
     itemLocked: {
       opacity: 0.72,
     },
     label: {
       color: colors.muted,
-      fontSize: 10,
-      fontWeight: '700',
+      fontSize: 10.5,
+      fontWeight: '500',
     },
     labelActive: {
-      color: colors.primaryStrong,
+      color: colors.text,
+      fontWeight: '700',
     },
     labelLocked: {
       color: isDark ? 'rgba(148, 163, 184, 0.76)' : 'rgba(89, 112, 143, 0.76)',
-    },
-    outer: {
-      backgroundColor: colors.background,
-      borderTopColor: colors.border,
-      borderTopWidth: 1,
-      paddingHorizontal: 16,
-      paddingTop: 10,
     },
   });
 }

--- a/apps/mobile/constants/harucut-data.ts
+++ b/apps/mobile/constants/harucut-data.ts
@@ -132,35 +132,38 @@ export const QUICK_LINKS = [
   { href: '/history', icon: 'time-outline', label: '기록' },
 ] as const;
 
+// 핸드오프 TabBar(홈·기록·촬영·프레임·MY) 정본 순서. 촬영은 중앙 FAB로 돌출 렌더.
+// 업로드는 독립 탭에서 제거(홈의 '사진 불러오기' / 촬영 진입으로 흡수, 라우트는 유지).
 export const BOTTOM_NAV_ITEMS = [
   { href: '/home', icon: 'home-outline', iconActive: 'home', key: 'home', label: '홈' },
   {
-    href: '/shoot',
-    icon: 'camera-outline',
-    iconActive: 'camera',
-    key: 'shoot',
-    label: '촬영',
+    href: '/history',
+    icon: 'grid-outline',
+    iconActive: 'grid',
+    key: 'history',
+    label: '기록',
   },
   {
-    href: '/upload',
-    icon: 'cloud-upload-outline',
-    iconActive: 'cloud-upload',
-    key: 'upload',
-    label: '업로드',
+    center: true,
+    href: '/shoot',
+    icon: 'camera',
+    iconActive: 'camera',
+    key: 'shoot',
+    label: '',
   },
   {
     href: '/theme',
-    icon: 'color-palette-outline',
-    iconActive: 'color-palette',
+    icon: 'film-outline',
+    iconActive: 'film',
     key: 'theme',
-    label: '꾸미기',
+    label: '프레임',
   },
   {
-    href: '/history',
-    icon: 'time-outline',
-    iconActive: 'time',
-    key: 'history',
-    label: '기록',
+    href: '/mypage',
+    icon: 'person-outline',
+    iconActive: 'person',
+    key: 'mypage',
+    label: 'MY',
   },
 ] as const;
 

--- a/apps/web/components/layout/MobileTabBar.tsx
+++ b/apps/web/components/layout/MobileTabBar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Camera, Clock3, Home, User } from "lucide-react";
+import { Camera, Film, Home, LayoutGrid, User } from "lucide-react";
 import { usePublicShootCta } from "@/lib/usePublicShootCta";
 
 type MobileTabBarProps = {
@@ -12,7 +12,8 @@ type MobileTabBarProps = {
   publicShoot?: boolean;
 };
 
-// 폰/태블릿(< lg)에서만 보이는 앱 스타일 하단 탭바 (handoff app TabBar: 홈·기록·촬영·MY).
+// 폰/태블릿(< lg)에서만 보이는 앱 스타일 하단 탭바
+// (handoff app TabBar: 홈·기록·촬영(FAB)·프레임·MY 5탭).
 // 데스크톱(≥ lg)에서는 숨기고 기존 웹 네비게이션을 사용한다.
 export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
   const pathname = usePathname();
@@ -50,7 +51,7 @@ export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
             : "text-[color:var(--hc-muted)]"
         }`}
       >
-        <Clock3 className="h-[23px] w-[23px]" />
+        <LayoutGrid className="h-[23px] w-[23px]" />
         <span className="text-[10.5px] font-medium">기록</span>
       </Link>
 
@@ -74,6 +75,19 @@ export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
           <Camera className="h-[26px] w-[26px]" />
         </Link>
       )}
+
+      <Link
+        href="/theme"
+        aria-label="프레임"
+        className={`flex w-14 flex-col items-center gap-0.5 ${
+          isActive("/theme")
+            ? "text-[color:var(--hc-text)]"
+            : "text-[color:var(--hc-muted)]"
+        }`}
+      >
+        <Film className="h-[23px] w-[23px]" />
+        <span className="text-[10.5px] font-medium">프레임</span>
+      </Link>
 
       <Link
         href="/mypage"


### PR DESCRIPTION
## 작업 내용
핸드오프 `handoff/app/ui.jsx`의 `TabBar`(홈·기록·촬영·프레임·MY 5탭)에 맞춰 웹/모바일 하단 탭바를 100% 일치하도록 정비했습니다.

### 모바일 (apps/mobile)
- `constants/harucut-data.ts`의 `BOTTOM_NAV_ITEMS`를 **홈·기록·촬영·프레임·MY** 5탭으로 재정의.
  - 업로드 독립 탭 제거(라우트는 유지). 기록=grid, 프레임=`/theme`(film), MY=`/mypage`(person).
- `components/harucut/bottom-nav.tsx`: 중앙 촬영을 평면 pill에서 **54x54 원형 그린 FAB**(marginTop -26 돌출·그림자, 라벨 없음)로 변경. 바를 높이 74·`--card` 배경·상단 1px 보더·좌우 균등 분포·paddingBottom 10(+세이프에어리어)로 핸드오프와 일치. 활성 탭=text(잉크)·라벨 10.5px. `activeKey`에 `theme` 추가, `upload` 제거.

### 웹 (apps/web/components/layout/MobileTabBar.tsx)
- 프레임(`/theme`, `Film` 아이콘) 탭을 추가해 4탭→5탭. 기록 아이콘을 `LayoutGrid`로 교체.
- `lg:hidden`, `--hc-*` 토큰, FAB 돌출(`-mt-7`)·그림자 유지. AppNav(데스크톱)는 변경 없음.

### 라우트 매핑
| 탭 | 라우트 |
|----|--------|
| 홈 | /home |
| 기록 | /history |
| 촬영(FAB) | /shoot |
| 프레임 | /theme |
| MY | /mypage |

### 업로드 진입
독립 탭에서 제거했지만 홈 화면의 '사진 불러오기' 버튼(`push('/upload')`)으로 진입 가능합니다. 라우트/화면은 그대로 유지.

## 검증
- 모바일 `pnpm exec tsc --noEmit`: 통과
- 웹 `pnpm exec tsc --noEmit`: 통과

## 참고
- 핸드오프 원본은 FAB에 `--coral`을 쓰지만, 지시에 따라 그린(`--hc-primary`/`--green` #1ED760)으로 통일했습니다.
