### PR TITLE
fix(web): stale 토큰으로 로그인이 막히는 인증 트랩 해소

### DIFF
--- a/apps/web/app/api/auth/session/route.ts
+++ b/apps/web/app/api/auth/session/route.ts
@@ -1,11 +1,34 @@
 import { NextResponse } from "next/server";
+import { forward } from "@/app/api/client/_proxy";
+import { adaptSetCookiesForRequest } from "@/lib/server/setCookies";
 
 export const runtime = "edge";
 
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
 export async function GET(req: Request) {
   const cookieHeader = req.headers.get("cookie") ?? "";
-  const authenticated =
-    cookieHeader.includes("accessToken=") || cookieHeader.includes("refreshToken=");
+  const hasAuthCookie =
+    cookieHeader.includes("accessToken=") ||
+    cookieHeader.includes("refreshToken=");
 
-  return NextResponse.json({ authenticated });
+  // 쿠키 자체가 없으면 바로 미인증
+  if (!hasAuthCookie) {
+    return NextResponse.json({ authenticated: false });
+  }
+
+  // 쿠키가 남아있어도 만료/무효일 수 있으므로 백엔드로 실제 유효성을 검증한다.
+  // (쿠키 존재만으로 인증으로 판단하면 만료된 세션이 /login에서 /home으로 튕긴다)
+  const upstream = await forward(req, {
+    method: "GET",
+    url: `${BASE_URL}/api/auth/status`,
+    forwardBody: false,
+  });
+
+  const res = NextResponse.json({ authenticated: upstream.ok });
+  // 백엔드가 토큰을 갱신했다면 set-cookie를 그대로 전달
+  for (const cookie of adaptSetCookiesForRequest(upstream.setCookies, req)) {
+    res.headers.append("set-cookie", cookie);
+  }
+  return res;
 }

--- a/apps/web/app/api/client/_proxy.test.ts
+++ b/apps/web/app/api/client/_proxy.test.ts
@@ -35,6 +35,60 @@ describe("client proxy forward", () => {
     });
   });
 
+  it("strips accessToken/refreshToken cookies when stripAuthCookies is set", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    global.fetch = fetchMock;
+
+    const req = new Request("http://localhost:3000/api/client/auth/login", {
+      method: "POST",
+      headers: {
+        cookie: "accessToken=stale; guestTrial=1; refreshToken=old",
+      },
+      body: JSON.stringify({ email: "test@example.com" }),
+    });
+
+    await forward(req, {
+      method: "POST",
+      url: "https://api.harucut.com/api/harucut/login",
+      stripAuthCookies: true,
+    });
+
+    const forwardedCookie = (fetchMock.mock.calls[0][1].headers as Record<string, string>)
+      .cookie;
+    // 인증 토큰만 제거되고 게스트 쿠키는 유지되어야 한다
+    expect(forwardedCookie).toBe("guestTrial=1");
+  });
+
+  it("forwards all cookies when stripAuthCookies is not set", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    global.fetch = fetchMock;
+
+    const req = new Request("http://localhost:3000/api/client/user-info", {
+      method: "GET",
+      headers: { cookie: "accessToken=valid; refreshToken=ok" },
+    });
+
+    await forward(req, {
+      method: "GET",
+      url: "https://api.harucut.com/api/auth/user/info",
+      forwardBody: false,
+    });
+
+    const forwardedCookie = (fetchMock.mock.calls[0][1].headers as Record<string, string>)
+      .cookie;
+    expect(forwardedCookie).toBe("accessToken=valid; refreshToken=ok");
+  });
+
   it("returns a JSON upstream error when fetch throws", async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error("connect ECONNREFUSED"));
 

--- a/apps/web/app/api/client/_proxy.ts
+++ b/apps/web/app/api/client/_proxy.ts
@@ -10,7 +10,26 @@ type ProxyOptions = {
   forwardBody?: boolean;
   contentType?: string;
   extraHeaders?: Record<string, string>;
+  /**
+   * 로그인/회원가입 등 비인증 엔드포인트로 프록시할 때 true.
+   * 브라우저에 남아있는 만료/무효 accessToken·refreshToken 쿠키를 함께 보내면
+   * 백엔드 인증 필터가 그 토큰을 검증해 INVALID_ACCESS_TOKEN(401)으로 막아버리므로,
+   * 인증 토큰 쿠키만 제거하고 나머지(게스트 쿠키 등)는 그대로 전달한다.
+   */
+  stripAuthCookies?: boolean;
 };
+
+const AUTH_COOKIE_NAMES = new Set(["accessToken", "refreshToken"]);
+
+function stripAuthCookies(cookie: string): string {
+  return cookie
+    .split(/;\s*/)
+    .filter((part) => {
+      const name = part.split("=")[0]?.trim();
+      return name ? !AUTH_COOKIE_NAMES.has(name) : false;
+    })
+    .join("; ");
+}
 
 type ForwardResult = {
   ok: boolean;
@@ -64,7 +83,10 @@ export async function forward(
     );
   }
 
-  const cookie = req.headers.get("cookie") ?? "";
+  const rawCookie = req.headers.get("cookie") ?? "";
+  const cookie = options.stripAuthCookies
+    ? stripAuthCookies(rawCookie)
+    : rawCookie;
   const shouldForwardBody =
     options.forwardBody ?? (options.method !== "GET" && options.method !== "DELETE");
   const body = shouldForwardBody ? await req.text() : undefined;

--- a/apps/web/app/api/client/auth/email/code/route.ts
+++ b/apps/web/app/api/client/auth/email/code/route.ts
@@ -9,5 +9,6 @@ export async function POST(req: Request) {
   return proxyJson(req, {
     method: "POST",
     url: `${BASE_URL}/api/email-auth/code`,
+    stripAuthCookies: true,
   });
 }

--- a/apps/web/app/api/client/auth/email/verification/route.ts
+++ b/apps/web/app/api/client/auth/email/verification/route.ts
@@ -9,5 +9,6 @@ export async function POST(req: Request) {
   return proxyJson(req, {
     method: "POST",
     url: `${BASE_URL}/api/email-auth/verification`,
+    stripAuthCookies: true,
   });
 }

--- a/apps/web/app/api/client/auth/login/route.ts
+++ b/apps/web/app/api/client/auth/login/route.ts
@@ -9,5 +9,6 @@ export async function POST(req: Request) {
   return proxyJson(req, {
     method: "POST",
     url: `${BASE_URL}/api/harucut/login`,
+    stripAuthCookies: true,
   });
 }

--- a/apps/web/app/api/client/auth/password/reset/route.ts
+++ b/apps/web/app/api/client/auth/password/reset/route.ts
@@ -9,5 +9,6 @@ export async function PATCH(req: Request) {
   return proxyJson(req, {
     method: "PATCH",
     url: `${BASE_URL}/api/harucut/reset/password`,
+    stripAuthCookies: true,
   });
 }

--- a/apps/web/app/api/client/auth/password/reset/verification/route.ts
+++ b/apps/web/app/api/client/auth/password/reset/verification/route.ts
@@ -9,5 +9,6 @@ export async function POST(req: Request) {
   return proxyJson(req, {
     method: "POST",
     url: `${BASE_URL}/api/harucut/reset/password/verification`,
+    stripAuthCookies: true,
   });
 }

--- a/apps/web/app/api/client/auth/register/route.ts
+++ b/apps/web/app/api/client/auth/register/route.ts
@@ -9,5 +9,6 @@ export async function POST(req: Request) {
   return proxyJson(req, {
     method: "POST",
     url: `${BASE_URL}/api/harucut/register`,
+    stripAuthCookies: true,
   });
 }

--- a/apps/web/app/mypage/page.tsx
+++ b/apps/web/app/mypage/page.tsx
@@ -7,7 +7,8 @@ import { AuthField } from "@/components/auth/AuthField";
 import { AppNav } from "@/components/layout/AppNav";
 import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { ColorThemePreferencePanel } from "@/components/theme/ColorThemePreferencePanel";
-import { clientApi } from "@/lib/clientApi";
+import { ApiRequestError, clientApi } from "@/lib/clientApi";
+import { buildPathWithRedirect } from "@/lib/redirect";
 import { uploadProfileImage } from "@/lib/profileImageApi";
 import { SUPPORTED_IMAGE_ACCEPT } from "@/lib/presignedUploadApi";
 import { getMyUserInfo, type UserInfo } from "@/lib/userApi";
@@ -44,6 +45,11 @@ export default function MyPage() {
       setUser(nextUser);
       setUsername(nextUser.username || "");
     } catch (error) {
+      // 세션 만료/무효(401)면 에러를 보여주지 말고 로그인 페이지로 보낸다
+      if (error instanceof ApiRequestError && error.status === 401) {
+        router.replace(buildPathWithRedirect("/login", "/mypage"));
+        return;
+      }
       console.error(error);
       setErrors({
         common: "내 정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.",


### PR DESCRIPTION
## 배경
브라우저에 만료/무효 accessToken 쿠키가 남아있으면 로그인 자체가 401 `INVALID_ACCESS_TOKEN` 으로 막히는 인증 트랩이 있었다. 백엔드 `JwtAuthenticationFilter` 가 공개(permitAll) 경로인 login/register 에서도 토큰을 검증하기 때문인데(FE 가 죽은 쿠키를 같이 보냄), FE 측에서 깔끔하게 우회/해결한다.

closes #372

## 변경 (작은 단위 3 커밋)
1. **비인증 요청에 stale 인증 토큰 쿠키 미전송** — `_proxy` 에 `stripAuthCookies` 옵션 추가, login/register/email-auth/reset 프록시에 적용. accessToken/refreshToken 만 제거하고 게스트 쿠키 등은 유지. 단위 테스트 추가.
2. **세션 판정 실유효성 검증** — `/api/auth/session` 이 쿠키 존재가 아니라 백엔드 `/api/auth/status` 로 실제 검증. 만료 세션이 `/login` 에서 `/home` 으로 튕기던 문제 해소.
3. **마이페이지 401 시 로그인 이동** — 에러 토스트 대신 `/login?redirectTo=/mypage` 로 리다이렉트.

## 검증
- `tsc --noEmit` 통과
- `jest _proxy redirect` 통과 (프록시 쿠키 스트립 케이스 2개 추가)

## 백엔드 후속 (별도, 이 PR 범위 아님)
`JwtAuthenticationFilter.shouldNotFilter()` 에 공개 경로(login/register/reset/email-auth) 추가 권장. 현재 `reissue`/`logout` 만 예외 처리된 비대칭이 근본 원인.
