### PR TITLE
fix(web): 모바일 하단 탭바를 핸드오프 5탭(프레임 추가)으로 정비

### DIFF
--- a/apps/web/components/layout/MobileTabBar.tsx
+++ b/apps/web/components/layout/MobileTabBar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Camera, Clock3, Home, User } from "lucide-react";
+import { Camera, Film, Home, LayoutGrid, User } from "lucide-react";
 import { usePublicShootCta } from "@/lib/usePublicShootCta";
 
 type MobileTabBarProps = {
@@ -12,7 +12,7 @@ type MobileTabBarProps = {
   publicShoot?: boolean;
 };
 
-// 폰/태블릿(< lg)에서만 보이는 앱 스타일 하단 탭바 (handoff app TabBar: 홈·기록·촬영·MY).
+// 폰/태블릿(< lg)에서만 보이는 앱 스타일 하단 탭바 (handoff app TabBar: 홈·기록·촬영·프레임·MY).
 // 데스크톱(≥ lg)에서는 숨기고 기존 웹 네비게이션을 사용한다.
 export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
   const pathname = usePathname();
@@ -50,7 +50,7 @@ export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
             : "text-[color:var(--hc-muted)]"
         }`}
       >
-        <Clock3 className="h-[23px] w-[23px]" />
+        <LayoutGrid className="h-[23px] w-[23px]" />
         <span className="text-[10.5px] font-medium">기록</span>
       </Link>
 
@@ -74,6 +74,19 @@ export function MobileTabBar({ publicShoot = false }: MobileTabBarProps) {
           <Camera className="h-[26px] w-[26px]" />
         </Link>
       )}
+
+      <Link
+        href="/theme"
+        aria-label="프레임"
+        className={`flex w-14 flex-col items-center gap-0.5 ${
+          isActive("/theme")
+            ? "text-[color:var(--hc-text)]"
+            : "text-[color:var(--hc-muted)]"
+        }`}
+      >
+        <Film className="h-[23px] w-[23px]" />
+        <span className="text-[10.5px] font-medium">프레임</span>
+      </Link>
 
       <Link
         href="/mypage"


### PR DESCRIPTION
## 배경
핸드오프 앱 `TabBar`(handoff/app/ui.jsx)는 하단 5탭 [홈 · 기록 · 촬영(중앙) · 프레임 · MY] 인데, 웹 모바일/태블릿(<lg) `MobileTabBar` 는 4탭으로 프레임 탭이 빠져 있었다.

closes #374

## 변경
- `MobileTabBar` 에 프레임 탭 추가 (film 아이콘, /theme)
- 기록 아이콘 clock -> grid (핸드오프 일치)
- 순서: 홈 · 기록 · 촬영(중앙 돌출) · 프레임 · MY

## 검증
- tsc --noEmit 통과

## 참고 (이 PR 범위 밖)
모바일 앱 코드 BOTTOM_NAV_ITEMS 는 [홈·촬영·업로드·꾸미기·기록]으로 핸드오프와 다름 -> 별도 정합성 검토 필요.
