### PR TITLE
fix: standalone 릴리즈에서 API 베이스 URL이 localhost로 잡혀 발생하는 Network request failed 수정

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -41,7 +41,7 @@
       "reactCompiler": true
     },
     "extra": {
-      "apiBaseUrl": "http://localhost:8080",
+      "apiBaseUrl": "https://api.harucut.com",
       "router": {},
       "eas": {
         "projectId": "1ccc6938-4a60-45f0-8a06-4db1a0101b0f"

--- a/apps/mobile/lib/api-client.ts
+++ b/apps/mobile/lib/api-client.ts
@@ -28,14 +28,30 @@ function trimTrailingSlash(value: string) {
   return value.replace(/\/+$/, '');
 }
 
+// localhost / 안드로이드 에뮬레이터 전용 호스트인지 판별한다.
+function isLocalDevHost(value: string) {
+  return /^https?:\/\/(localhost|127\.0\.0\.1|10\.0\.2\.2)(:|\/|$)/i.test(value.trim());
+}
+
 function configuredApiBaseUrl() {
-  const fromEnv = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+  // 릴리즈 빌드(__DEV__ === false)에서는 개발 전용 localhost 값을 신뢰하지 않고 운영 API로
+  // 폴백한다. env가 주입되지 않은 standalone 빌드가 app.json의 localhost 값을 채택해 모든
+  // 요청이 localhost로 향하고 "Network request failed"가 나던 문제를 코드 레벨에서도 막는다.
+  const acceptable = (value?: string | null) => {
+    const trimmed = value?.trim();
+    if (!trimmed) return undefined;
+    if (!__DEV__ && isLocalDevHost(trimmed)) return undefined;
+    return trimmed;
+  };
+
+  const fromEnv = acceptable(process.env.EXPO_PUBLIC_API_BASE_URL);
   if (fromEnv) return fromEnv;
 
-  const fromExtra = Constants.expoConfig?.extra?.apiBaseUrl;
-  if (typeof fromExtra === 'string' && fromExtra.trim()) {
-    return fromExtra;
-  }
+  const fromExtra =
+    typeof Constants.expoConfig?.extra?.apiBaseUrl === 'string'
+      ? acceptable(Constants.expoConfig?.extra?.apiBaseUrl)
+      : undefined;
+  if (fromExtra) return fromExtra;
 
   return DEFAULT_API_BASE_URL;
 }


### PR DESCRIPTION
## 문제
standalone 릴리즈 앱(폰 단독 실행, Metro/adb reverse 없음)에서 로그인 시도와 초기 화면 진입 시 `Network request failed`가 발생했습니다. 개발 모드에서는 정상 동작하고 release 빌드에서만 재현됩니다.

## 원인
`api-client.ts`의 `configuredApiBaseUrl()`은 `EXPO_PUBLIC_API_BASE_URL` 환경변수, `app.json`의 `extra.apiBaseUrl`, 그리고 `DEFAULT_API_BASE_URL`(`https://api.harucut.com`) 순으로 베이스 URL을 고릅니다. 개발 모드에서는 `.env.local`의 환경변수가 번들에 인라인되어 1순위로 잡히지만, env 주입 없이 `gradlew assembleRelease`로 만든 standalone 빌드에서는 이 값이 비어 2순위인 `app.json`의 `extra.apiBaseUrl`(`http://localhost:8080`)이 채택됩니다. 그 결과 모든 API 호출이 localhost로 향하는데, 폰에는 그 서버가 없고 릴리즈는 평문 HTTP를 차단하므로 fetch가 실패합니다.

## 변경
`app.json`의 `extra.apiBaseUrl` 기본값을 `https://api.harucut.com`으로 바꾸고, `configuredApiBaseUrl()`이 릴리즈 빌드(`__DEV__ === false`)에서는 localhost/127.0.0.1/10.0.2.2 같은 개발 전용 호스트를 신뢰하지 않고 운영 API로 폴백하도록 보강했습니다. 개발 모드 동작은 그대로 유지됩니다.

## 테스트
실기기에 env 주입 없이 빌드한 standalone APK를 설치해 Metro 없이 실행하고, 테스트 계정으로 로그인이 `https://api.harucut.com`에 정상 호출되어 홈 화면까지 진입하는 것을 확인했습니다.
