### PR TITLE
perf: 로그인/회원가입 입력 리렌더 최적화로 비밀번호 입력 버벅임 해소

### DIFF
--- a/apps/mobile/components/harucut/ui.tsx
+++ b/apps/mobile/components/harucut/ui.tsx
@@ -260,7 +260,9 @@ type FormFieldProps = TextInputProps & {
   secure?: boolean;
 };
 
-export function FormField({ error, label, secure = false, style, ...props }: FormFieldProps) {
+// React.memo로 감싸 부모(로그인/회원가입 화면)의 키 입력당 전체 리렌더가 입력 필드까지
+// 전파되지 않게 한다. 부모는 필드별 onChangeText 핸들러를 안정 참조로 넘겨야 효과가 난다.
+function FormFieldImpl({ error, label, secure = false, style, ...props }: FormFieldProps) {
   const [visible, setVisible] = React.useState(false);
   const { colors } = useHarucutTheme();
   const styles = useUiStyles();
@@ -295,6 +297,8 @@ export function FormField({ error, label, secure = false, style, ...props }: For
     </View>
   );
 }
+
+export const FormField = React.memo(FormFieldImpl);
 
 export function SectionEyebrow({ children }: PropsWithChildren) {
   const styles = useUiStyles();

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -273,6 +273,20 @@ export function LoginScreen() {
   const [submitting, setSubmitting] = useState(false);
   const [remember, setRemember] = useState(true);
 
+  // 키 입력마다 새 인라인 핸들러를 만들면 memo된 FormField가 매번 리렌더되어, 가려진
+  // 비밀번호 입력의 노출→마스킹 왕복이 끊겨 보인다. 필드별 핸들러를 한 번만 만들어
+  // 안정 참조로 넘겨 바뀐 필드만 리렌더되게 한다.
+  const handleFieldChange = useMemo(
+    () =>
+      Object.fromEntries(
+        LOGIN_FIELDS.map((field) => [
+          field.key,
+          (value: string) => setForm((current) => ({ ...current, [field.key]: value })),
+        ]),
+      ) as Record<string, (value: string) => void>,
+    [],
+  );
+
   const handleLogin = async () => {
     const emailError = validateEmail(form.email);
     if (emailError) {
@@ -324,7 +338,7 @@ export function LoginScreen() {
           <FormField
             key={field.key}
             label={field.label}
-            onChangeText={(value) => setForm((current) => ({ ...current, [field.key]: value }))}
+            onChangeText={handleFieldChange[field.key]}
             placeholder={field.placeholder}
             secure={field.secure}
             value={form[field.key]}
@@ -363,6 +377,18 @@ export function SignupScreen() {
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [form, setForm] = useState({ confirmPassword: '', password: '', username: '' });
+  // 키 입력당 화면 전체 리렌더가 memo된 FormField까지 번지지 않도록 필드별 핸들러를
+  // 안정 참조로 한 번만 만든다(가려진 비밀번호 입력 버벅임 방지).
+  const handleFieldChange = useMemo(
+    () =>
+      Object.fromEntries(
+        SIGNUP_FIELDS.map((field) => [
+          field.key,
+          (value: string) => setForm((current) => ({ ...current, [field.key]: value })),
+        ]),
+      ) as Record<string, (value: string) => void>,
+    [],
+  );
   const [codeExpiresAt, setCodeExpiresAt] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -543,7 +569,7 @@ export function SignupScreen() {
           <FormField
             key={field.key}
             label={field.label}
-            onChangeText={(value) => setForm((current) => ({ ...current, [field.key]: value }))}
+            onChangeText={handleFieldChange[field.key]}
             placeholder={field.placeholder}
             secure={field.secure}
             value={form[field.key]}


### PR DESCRIPTION
## 문제
로그인/회원가입 화면에서 가려진(secureTextEntry) 비밀번호 입력칸에 타이핑하면, 입력한 글자가 잠깐 원래 글자로 보였다가 마스킹되면서 버벅거리는 것처럼 보였습니다.

## 원인
`LoginScreen`/`SignupScreen`은 입력값을 화면 최상위 `useState`(`form`)로 들고 `FormField`에 제어값으로 내려줍니다. 따라서 키를 한 글자 누를 때마다 `setForm`이 호출되어 화면 전체(그라데이션 배경, 소셜 로그인 버튼, 회원가입의 인증 타이머 등을 포함한 서브트리)가 통째로 리렌더됩니다. `FormField`가 `React.memo`로 감싸여 있지 않고 부모가 매 렌더마다 새 인라인 `onChangeText`를 넘기므로, 키 입력마다 제어된 `TextInput`이 재조정되며 Android의 "마지막 글자 노출 후 마스킹" 동작이 눈에 띄게 끊겨 보입니다.

## 변경
`FormField`를 `React.memo`로 감싸 부모 리렌더가 입력 필드까지 전파되지 않게 하고, `LoginScreen`/`SignupScreen`에서 필드별 `onChangeText` 핸들러를 `useMemo`로 한 번만 생성해 안정 참조로 넘기도록 바꿨습니다. 이로써 값이 바뀐 필드만 리렌더되고 배경·소셜 버튼·타이머 등 나머지 트리는 리렌더가 차단됩니다.

## 테스트
실기기에서 비밀번호 입력칸에 빠르게 타이핑하며 노출→마스킹 전환이 매끄러운지, 기존 로그인/회원가입 제출과 값 바인딩이 그대로인지 확인합니다.
