### PR TITLE
fix: 상단 브랜드 마크의 반짝이 placeholder를 실제 하루컷 로고로 교체

### DIFF
--- a/apps/mobile/components/harucut/ui.tsx
+++ b/apps/mobile/components/harucut/ui.tsx
@@ -3,7 +3,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import * as React from 'react';
 import type { PropsWithChildren, ReactNode } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, TextInput, View, type StyleProp, type TextInputProps, type ViewStyle } from 'react-native';
+import { Image, Pressable, ScrollView, StyleSheet, Text, TextInput, View, type StyleProp, type TextInputProps, type ViewStyle } from 'react-native';
 
 import { HARUCUT_RADII, HARUCUT_SPACING, type ButtonVariant, type HarucutColors } from '@/constants/harucut-design';
 import { useHarucutTheme } from '@/hooks/use-harucut-theme';
@@ -52,7 +52,6 @@ export function AppScrollView({
 
 export function BrandMark({ compact = false, href = '/home' }: { compact?: boolean; href?: string }) {
   const router = useRouter();
-  const { colors, isDark } = useHarucutTheme();
   const styles = useUiStyles();
 
   return (
@@ -62,17 +61,8 @@ export function BrandMark({ compact = false, href = '/home' }: { compact?: boole
       onPress={() => router.push(href as never)}
       style={styles.brandRow}>
       <View style={styles.brandIcon}>
-        <LinearGradient
-          colors={
-            isDark
-              ? ['rgba(59, 130, 246, 0.18)', 'rgba(255, 255, 255, 0.02)']
-              : ['rgba(255, 255, 255, 0.98)', 'rgba(239, 246, 255, 0.95)']
-          }
-          end={{ x: 0.9, y: 1 }}
-          start={{ x: 0, y: 0 }}
-          style={styles.brandIconGradient}>
-          <Ionicons color={colors.primary} name="sparkles-outline" size={18} />
-        </LinearGradient>
+        {/* 반짝이 placeholder 대신 실제 하루컷 로고(앱 아이콘)를 브랜드 마크로 사용 */}
+        <Image source={require('../../assets/images/icon.png')} style={styles.brandIconImage} />
       </View>
       <View style={{ flexShrink: 1 }}>
         {!compact ? (
@@ -354,6 +344,10 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       shadowOpacity: 1,
       shadowRadius: 30,
       width: 40,
+    },
+    brandIconImage: {
+      height: '100%',
+      width: '100%',
     },
     brandIconGradient: {
       alignItems: 'center',


### PR DESCRIPTION
## 문제
온보딩/로그인 화면 좌상단의 브랜드 마크(`BrandMark`)가 실제 하루컷 로고 대신 `sparkles-outline` 아이콘 placeholder를 그라데이션 박스 안에 표시하고 있었습니다.

## 변경
`BrandMark`의 그라데이션 + 반짝이 아이콘을 실제 앱 아이콘 이미지(`assets/images/icon.png` — 딥다크 배경에 그린 4컷 스트립 로고)로 교체했습니다. 기존 40×40 둥근 박스(`overflow: hidden`)에 이미지를 채워 모서리가 자연스럽게 클립되도록 했고, 더 이상 쓰지 않는 `useHarucutTheme` 호출과 그라데이션 마크업을 제거했습니다. `LinearGradient`는 같은 파일의 다른 컴포넌트에서 계속 사용하므로 import는 유지했습니다.

## 테스트
타입 검사(`tsc --noEmit`) 통과를 확인했고, 실기기에서 좌상단에 반짝이 대신 실제 로고가 표시되는지 확인합니다.
