### PR TITLE
refactor: 저장 프레임 패널을 handoff처럼 2열 세로카드 그리드로 정렬

### DIFF
--- a/apps/mobile/components/harucut/frame.tsx
+++ b/apps/mobile/components/harucut/frame.tsx
@@ -1091,9 +1091,11 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     savedGrid: {
       flexDirection: 'row',
       flexWrap: 'wrap',
-      gap: 12,
       justifyContent: 'space-between',
       marginTop: 8,
+      // 가로 간격은 justifyContent: space-between으로 처리(48%+48%=96%이 한 줄에 들어감).
+      // columnGap을 추가하면 96%+gap이 좁은 기기에서 100%를 넘겨 1열로 줄바꿈되므로 rowGap만 둔다.
+      rowGap: 12,
     },
     savedCard: {
       backgroundColor: colors.cardStrong,

--- a/apps/mobile/components/harucut/frame.tsx
+++ b/apps/mobile/components/harucut/frame.tsx
@@ -884,7 +884,7 @@ export function SavedFramesPanel({
       {matchingFrames.length === 0 ? (
         <Text style={styles.emptyText}>{emptyText}</Text>
       ) : (
-        <View style={{ gap: 12, marginTop: 8 }}>
+        <View style={styles.savedGrid}>
           {matchingFrames.map((frame) => {
             const selected = frame.id === selectedSavedFrameId;
             const locked = lockedIds.has(frame.id);
@@ -1088,13 +1088,21 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       overflow: 'hidden',
       width: '100%',
     },
+    savedGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 12,
+      justifyContent: 'space-between',
+      marginTop: 8,
+    },
     savedCard: {
       backgroundColor: colors.cardStrong,
       borderColor: colors.border,
       borderRadius: HARUCUT_RADII.lg,
       borderWidth: 1,
-      gap: 12,
+      gap: 10,
       padding: 12,
+      width: '48%',
     },
     savedCardLocked: {
       opacity: 0.6,
@@ -1225,12 +1233,13 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       fontWeight: '700',
     },
     savedPressable: {
-      flexDirection: 'row',
-      gap: 12,
+      flexDirection: 'column',
+      gap: 10,
     },
     savedPreview: {
+      alignItems: 'center',
       position: 'relative',
-      width: 96,
+      width: '100%',
     },
     savedRefresh: {
       fontSize: 11,


### PR DESCRIPTION
## 배경
handoff `app/studio.jsx`(프레임 보관함)의 저장 프레임은 **2열 세로카드 그리드**입니다(미리보기 상단, 제목·레이아웃·버튼 하단). 반면 앱의 `SavedFramesPanel`은 1열 가로카드(미리보기 좌측 + 텍스트 우측) 리스트였습니다.

## 변경
- 저장 프레임 컨테이너를 1열 세로 리스트에서 **2열 그리드**(`flexDirection: row`, `flexWrap: wrap`, 카드 폭 `48%`)로 바꿨습니다.
- 카드 내부 레이아웃을 가로(`row`)에서 **세로(`column`)**로 바꿔, 미리보기가 카드 상단 중앙에 오고 그 아래 제목·설명·상태·액션 버튼이 쌓이도록 했습니다.
- 용량 게이지(`FrameCapacityMeter`)는 이미 존재하므로 그대로 두었고, 이 변경은 보관함(`theme`)과 촬영 프레임 선택(`shoot`) 양쪽에 동일하게 적용됩니다.

## 테스트
모바일 타입 검사(`tsc --noEmit`) 통과. 카드 폭/미리보기 크기 등 세부 시각 정렬은 실기기 최종 점검에서 확인합니다.
