### PR TITLE
refactor: 꾸미기 스티커를 handoff 16종 이모지 타일 그리드로 정렬

### DIFF
--- a/apps/mobile/constants/harucut-data.ts
+++ b/apps/mobile/constants/harucut-data.ts
@@ -256,12 +256,24 @@ export const THEME_TEXT_COLOR_SWATCHES = [
   '#5AA9FF',
 ] as const;
 
+// 핸드오프 decorate ED_STICKERS 정본(이모지 16종)
 export const THEME_STICKERS = [
-  { id: 'spark', label: '반짝', symbol: '✦' },
-  { id: 'heart', label: '하트', symbol: '♡' },
-  { id: 'star', label: '별', symbol: '★' },
-  { id: 'ribbon', label: '리본', symbol: '⌁' },
-  { id: 'note', label: '메모', symbol: '✎' },
+  { id: 'star', label: '별', symbol: '⭐️' },
+  { id: 'heart-pink', label: '핑크하트', symbol: '💖' },
+  { id: 'sparkles', label: '반짝', symbol: '✨' },
+  { id: 'blossom', label: '벚꽃', symbol: '🌸' },
+  { id: 'ribbon', label: '리본', symbol: '🎀' },
+  { id: 'cloud', label: '구름', symbol: '☁️' },
+  { id: 'fire', label: '불꽃', symbol: '🔥' },
+  { id: 'cool', label: '선글라스', symbol: '😎' },
+  { id: 'dog', label: '강아지', symbol: '🐶' },
+  { id: 'strawberry', label: '딸기', symbol: '🍓' },
+  { id: 'rainbow', label: '무지개', symbol: '🌈' },
+  { id: 'heart-red', label: '하트', symbol: '❤️' },
+  { id: 'crown', label: '왕관', symbol: '👑' },
+  { id: 'butterfly', label: '나비', symbol: '🦋' },
+  { id: 'clover', label: '클로버', symbol: '🍀' },
+  { id: 'camera', label: '카메라', symbol: '📷' },
 ] as const;
 
 export const LOGIN_FIELDS = [

--- a/apps/mobile/screens/theme-screens.tsx
+++ b/apps/mobile/screens/theme-screens.tsx
@@ -6,7 +6,7 @@ import { Image, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'rea
 import { captureRef } from 'react-native-view-shot';
 
 import { FrameCapacityMeter, FramePickerSection, FramePreview, SavedFramesPanel } from '@/components/harucut/frame';
-import { ActionButton, AppScrollView, FormField, PageHeader, Pill, StepProgress, SurfaceCard } from '@/components/harucut/ui';
+import { ActionButton, AppScrollView, FormField, PageHeader, StepProgress, SurfaceCard } from '@/components/harucut/ui';
 import { BACKGROUND_SWATCHES, FRAME_COLOR_SWATCHES, THEME_STICKERS, THEME_TEXT_COLOR_SWATCHES, type ThemeAsset, type ThemeEditorComponent } from '@/constants/harucut-data';
 import { resolvePlanInfo } from '@/constants/plan-limits';
 import type { HarucutColors } from '@/constants/harucut-design';
@@ -490,11 +490,14 @@ export function ThemeStickerScreen() {
         {decorateTab === 'sticker' ? (
           <View style={styles.stickerGrid}>
             {THEME_STICKERS.map((sticker) => (
-              <Pill
+              <Pressable
                 key={sticker.id}
-                onPress={() => addThemeComponentFromAsset('STICKER', sticker.symbol)}>
-                {sticker.symbol} {sticker.label}
-              </Pill>
+                accessibilityLabel={`${sticker.label} 스티커 추가`}
+                accessibilityRole="button"
+                onPress={() => addThemeComponentFromAsset('STICKER', sticker.symbol)}
+                style={styles.stickerTile}>
+                <Text style={styles.stickerTileSymbol}>{sticker.symbol}</Text>
+              </Pressable>
             ))}
           </View>
         ) : null}
@@ -1152,6 +1155,20 @@ function createStyles(colors: HarucutColors) {
       flexDirection: 'row',
       flexWrap: 'wrap',
       gap: 8,
+    },
+    stickerTile: {
+      alignItems: 'center',
+      aspectRatio: 1,
+      backgroundColor: colors.cardMuted,
+      borderColor: colors.border,
+      borderRadius: 12,
+      borderWidth: 1,
+      justifyContent: 'center',
+      width: 48,
+    },
+    stickerTileSymbol: {
+      fontSize: 24,
+      lineHeight: 30,
     },
     stickerRow: {
       flexDirection: 'row',

--- a/apps/mobile/store/use-theme-editor-store.ts
+++ b/apps/mobile/store/use-theme-editor-store.ts
@@ -114,7 +114,8 @@ function defaultThemeEditor(): ThemeEditorSessionState {
     description: '하루컷에서 직접 꾸민 나만의 프레임',
     frameId: 'polaroid-4',
     selectedSavedFrameId: null,
-    stickers: ['✦', '♡'],
+    // 기본 스티커는 THEME_STICKERS(이모지 16종) 카탈로그의 앞 두 개(별·핑크하트)와 맞춘다.
+    stickers: ['⭐️', '💖'],
     tab: 'PHOTO',
     title: '새 테마 프레임',
     cellCutouts: [false, false, false, false],


### PR DESCRIPTION
## 배경
handoff `app/decorate.jsx`의 스티커 세트는 이모지 16종(`⭐️💖✨🌸🎀☁️🔥😎🐶🍓🌈❤️👑🦋🍀📷`)을 정사각 타일 그리드로 보여줍니다. 반면 앱은 5개 글리프(`✦♡★⌁✎`)를 라벨이 붙은 Pill로 보여주고 있었습니다.

## 변경
- `THEME_STICKERS`를 handoff와 동일한 이모지 16종으로 교체했습니다(접근성 라벨용 한글 이름 유지).
- 스티커 탭을 Pill(심볼+라벨)에서 **라벨 없는 정사각 타일 그리드**(`stickerTile`: `aspectRatio: 1`, 48px, `fontSize: 24`)로 바꿔 handoff의 이모지 그리드와 맞췄습니다.
- 더 이상 쓰지 않는 `Pill` import를 정리했습니다.

## 남은 항목 (별도)
회전/크기 조절의 **연속 슬라이더**(handoff `Slider`, `-180~180°` / `12~64px`)는 `@react-native-community/slider` 네이티브 의존성 추가 + 빌드가 필요하므로, 디바이스 빌드 단계에서 별도 PR로 진행합니다.

## 테스트
모바일 타입 검사(`tsc --noEmit`) 통과. 타일 크기/그리드 열 수 등 시각 정렬은 실기기 최종 점검에서 확인합니다.
