### PR TITLE
feat: 촬영 타이머 카운트다운 중 셔터 탭하면 즉시 촬영 (웹·앱 정합)

### DIFF
--- a/apps/mobile/screens/shoot-screens.tsx
+++ b/apps/mobile/screens/shoot-screens.tsx
@@ -16,10 +16,6 @@ import { useLibraryStore } from '@/store/use-library-store';
 import { useSessionStore } from '@/store/use-session-store';
 import { useShootStore } from '@/store/use-shoot-store';
 
-function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // 촬영 총 장수
 const SHOOT_TOTAL = 8;
 // 선택 가능한 타이머 간격(초)
@@ -129,6 +125,10 @@ export function ShootCaptureScreen() {
   // 언마운트된 컴포넌트에 setState/네비게이션이 발생할 수 있다. 마운트 여부를 추적해
   // 루프 중간에 안전하게 빠져나가기 위한 ref.
   const isMountedRef = useRef(true);
+  // 타이머 카운트다운을 셔터 탭으로 즉시 끝내기 위한 신호.
+  // captureNowRef: "지금 이 컷을 바로 찍어라" 플래그. tickResolveRef: 진행 중인 1초 틱을 깨우는 resolver.
+  const captureNowRef = useRef(false);
+  const tickResolveRef = useRef<(() => void) | null>(null);
   const { colors } = useHarucutTheme();
   const styles = useShootStyles();
   const shoot = useShootStore();
@@ -186,6 +186,8 @@ export function ShootCaptureScreen() {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
+      // 진행 중인 카운트다운 틱이 있으면 깨워, await가 영원히 매달리지 않게 한다.
+      tickResolveRef.current?.();
     };
   }, []);
 
@@ -230,26 +232,50 @@ export function ShootCaptureScreen() {
     return shotIndex + 1;
   };
 
+  // 타이머 카운트다운의 1초 틱. 셔터 탭(handleShootNow)이 들어오면 남은 대기를 깨고 즉시 반환한다.
+  const waitTickOrSkip = () =>
+    new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        tickResolveRef.current = null;
+        resolve();
+      };
+      const timeoutId = setTimeout(finish, 1000);
+      tickResolveRef.current = finish;
+    });
+
   // 타이머 모드: 선택한 간격으로 8장을 자동 연속 촬영.
+  // 카운트다운 중 셔터를 탭하면 남은 대기를 스킵하고 그 컷을 즉시 찍는다(captureNowRef + tickResolveRef로 틱 인터럽트).
   const handleTimerBurst = async () => {
     if (!(await ensureCameraPermission())) return;
     if (!cameraRef.current || isShooting) return;
 
     resetShootSession();
+    captureNowRef.current = false;
     setIsShooting(true);
 
     try {
       for (let shotIndex = 0; shotIndex < SHOOT_TOTAL; shotIndex += 1) {
+        // 컷마다 스킵 플래그를 초기화해, 직전 컷의 탭이 다음 컷으로 새지 않게 한다.
+        captureNowRef.current = false;
+
         for (let remaining = timerSeconds; remaining > 0; remaining -= 1) {
           // 카운트다운 도중 화면을 벗어났으면 즉시 중단(언마운트 후 setState 방지).
           if (!isMountedRef.current) return;
+          // 셔터를 탭했으면 남은 카운트다운을 건너뛴다.
+          if (captureNowRef.current) break;
           setCountdown(remaining);
-          // 1초 틱으로 맞춰 선택한 간격(3·5·8초)이 실제 촬영 간격과 일치하게 한다.
-          await delay(1000);
+          // 1초 틱으로 맞춰 선택한 간격(3·5·8초)이 실제 촬영 간격과 일치하게 한다(탭하면 조기 종료).
+          await waitTickOrSkip();
+          if (captureNowRef.current) break;
         }
 
         // 촬영 직전 이탈했으면 더 찍지 않는다.
         if (!isMountedRef.current) return;
+        captureNowRef.current = false;
         await captureOneShot(shotIndex);
       }
 
@@ -273,6 +299,14 @@ export function ShootCaptureScreen() {
         setIsShooting(false);
       }
     }
+  };
+
+  // 타이머 카운트다운 중 셔터 탭: 남은 대기를 스킵하고 즉시 그 컷을 찍는다.
+  // 대기 틱이 없는 순간(이미 캡처 진행 중)의 탭은 무시해 중복 촬영을 막는다.
+  const handleShootNow = () => {
+    if (!isShooting || !tickResolveRef.current) return;
+    captureNowRef.current = true;
+    tickResolveRef.current();
   };
 
   // 수동 모드: 셔터를 누를 때마다 즉시 1장. 8장째에서 자동으로 고르기 단계로 이동.
@@ -356,6 +390,7 @@ export function ShootCaptureScreen() {
                 <Text style={styles.countdownText}>{countdown}</Text>
               </View>
               <Text style={styles.overlayCaption}>{shoot.shots.length}/{SHOOT_TOTAL}</Text>
+              <Text style={styles.overlayHint}>셔터를 누르면 바로 이 컷을 찍어요</Text>
             </View>
           ) : null}
         </View>
@@ -437,12 +472,18 @@ export function ShootCaptureScreen() {
           </Pressable>
 
           <Pressable
-            accessibilityLabel={captureMode === 'manual' ? '한 장 촬영' : '촬영 시작'}
+            accessibilityLabel={
+              captureMode === 'manual' ? '한 장 촬영' : isShooting ? '지금 바로 촬영' : '촬영 시작'
+            }
             accessibilityRole="button"
-            accessibilityState={{ disabled: captureMode === 'timer' && isShooting }}
-            disabled={captureMode === 'timer' && isShooting}
-            onPress={() => void (captureMode === 'manual' ? handleManualShutter() : handleTimerBurst())}
-            style={[styles.shutterButton, captureMode === 'timer' && isShooting ? styles.controlLocked : null]}>
+            onPress={() =>
+              void (captureMode === 'manual'
+                ? handleManualShutter()
+                : isShooting
+                  ? handleShootNow()
+                  : handleTimerBurst())
+            }
+            style={styles.shutterButton}>
             <View style={styles.shutterInner} />
           </Pressable>
 
@@ -1021,6 +1062,10 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
       color: '#FFFFFF',
       fontSize: 12,
       fontWeight: '600',
+    },
+    overlayHint: {
+      color: 'rgba(255,255,255,0.82)',
+      fontSize: 11,
     },
     rowButtons: {
       flexDirection: 'row',

--- a/apps/web/app/shoot/capture/_hooks/useCaptureFlow.ts
+++ b/apps/web/app/shoot/capture/_hooks/useCaptureFlow.ts
@@ -53,6 +53,9 @@ export function useCaptureFlow() {
   // 타이머와 즉시 촬영 버튼이 같은 샷을 중복 처리하지 않도록 마지막으로 끝낸 샷 인덱스를 기록
   const lastFinishedShotRef = useRef(-1);
   const recordingNoticeShownRef = useRef(false);
+  // shooting.isShooting의 동기 미러. 상태는 비동기라, 첫 셔터 더블탭처럼 리렌더 이전의
+  // stale 클로저가 세션을 두 번 시작/리셋해 첫 장을 날리는 것을 막는 가드로 쓴다.
+  const isShootingRef = useRef(false);
 
   const remainingShots = Math.max(0, MAX_SHOTS - shotCount);
   const canFlipCamera =
@@ -311,6 +314,7 @@ export function useCaptureFlow() {
       return;
     }
 
+    isShootingRef.current = false;
     setShooting({ isShooting: false, countdown: null });
     router.push("/shoot/select");
   }, [
@@ -336,9 +340,13 @@ export function useCaptureFlow() {
       return;
     }
 
+    // 이미 촬영 중이면 재시작 무시(시작 버튼 더블탭으로 녹화가 중복 시작되는 것 방지).
+    if (isShootingRef.current) return;
+
     resetShots();
     setShotCount(0);
     lastFinishedShotRef.current = -1;
+    isShootingRef.current = true;
 
     // 타이머 모드: 선택한 간격으로 카운트다운을 돌려 8장을 자동 연속 촬영.
     // 수동 모드: 카운트다운 없이 첫 컷을 바로 찍고, 이후 셔터를 누를 때마다 1장씩.
@@ -400,8 +408,10 @@ export function useCaptureFlow() {
       return;
     }
 
-    if (!shooting.isShooting) {
-      // 첫 컷: 세션 초기화 후 녹화 시작 → 같은 클릭에서 바로 1장 촬영
+    if (!isShootingRef.current) {
+      // 첫 컷: 세션 초기화 후 녹화 시작 → 같은 클릭에서 바로 1장 촬영.
+      // 동기 ref로 가드해, 리렌더 전 더블탭이 세션을 두 번 리셋(첫 장 유실)하지 않게 한다.
+      isShootingRef.current = true;
       resetShots();
       setShotCount(0);
       lastFinishedShotRef.current = -1;
@@ -412,7 +422,6 @@ export function useCaptureFlow() {
     finishSingleShot();
   }, [
     isCameraReady,
-    shooting.isShooting,
     resetShots,
     setNotice,
     startRecordingForShot,

--- a/apps/web/app/shoot/capture/page.tsx
+++ b/apps/web/app/shoot/capture/page.tsx
@@ -261,16 +261,25 @@ export default function CapturePage() {
               </button>
             ) : null}
 
-            {/* 큰 원형 셔터: 타이머 모드는 '촬영 시작'(이후 자동 잠금), 수동 모드는 누를 때마다 한 장씩 */}
+            {/* 큰 원형 셔터: 수동은 누를 때마다 한 장씩. 타이머는 시작 전엔 '촬영 시작',
+                카운트다운 중엔 탭하면 남은 대기를 스킵하고 그 컷을 즉시 촬영한다. */}
             <button
               type="button"
               onClick={
-                captureMode === "manual" ? handleManualShutter : startShooting
+                captureMode === "manual"
+                  ? handleManualShutter
+                  : isShooting
+                    ? handleShootNow
+                    : startShooting
               }
-              disabled={
-                !isCameraReady || (captureMode === "timer" && isShooting)
+              disabled={!isCameraReady}
+              aria-label={
+                captureMode === "manual"
+                  ? "한 장 촬영"
+                  : isShooting
+                    ? "지금 바로 촬영"
+                    : "촬영 시작"
               }
-              aria-label={captureMode === "manual" ? "한 장 촬영" : "촬영 시작"}
               className="grid h-[72px] w-[72px] place-items-center rounded-full border-4 border-[color:var(--hc-text)] bg-transparent transition disabled:cursor-not-allowed disabled:opacity-40"
             >
               <span className="h-[54px] w-[54px] rounded-full bg-[color:var(--hc-primary)]" />
@@ -281,7 +290,9 @@ export default function CapturePage() {
 
           <p className="text-center text-[11px] text-[color:var(--hc-muted)]">
             {captureMode === "timer"
-              ? `촬영 시작을 누르면 ${timerSeconds}초 간격으로 8장을 자동으로 찍어요`
+              ? isShooting
+                ? "셔터를 누르면 기다리지 않고 바로 이 컷을 찍어요"
+                : `촬영 시작을 누르면 ${timerSeconds}초 간격으로 8장을 자동으로 찍어요`
               : "셔터를 누를 때마다 한 장씩 총 8장을 찍어요"}
           </p>
         </section>


### PR DESCRIPTION
## 무엇을

촬영방법 2가지(**타이머 / 수동**) 중 **타이머 모드**를 보강해 웹·앱 동작을 정합시킵니다.
카메라는 **고른 프레임의 현재 슬롯 크기/위치에 맞춘 표시를 그대로 유지**합니다(단일 풀 카메라로 바꾸지 않음).

## 왜

- 타이머 모드에서 카운트다운이 끝날 때까지 기다려야만 촬영되어, "지금 바로 찍고 싶다"는 요구를 못 받음.
- 모바일은 카운트다운 중 셔터가 비활성, 웹은 별도 "바로 촬영" 버튼만 존재해 동작이 불일치.

## 변경

- **타이머 모드: 카운트다운 중 셔터를 탭하면 남은 대기를 스킵하고 그 컷을 즉시 촬영.**
  - 모바일(`apps/mobile/screens/shoot-screens.tsx`): 1초 틱을 인터럽트 가능하게 변경
    (`waitTickOrSkip` + `captureNowRef`/`tickResolveRef`). 셔터를 타이머 진행 중에도 활성화해
    `handleShootNow`로 즉시 촬영. 미사용 `delay` 제거. 오버레이에 "셔터를 누르면 바로 이 컷" 힌트.
  - 웹(`apps/web/app/shoot/capture/page.tsx`): 메인 셔터가 타이머 진행 중 `handleShootNow`를
    호출하도록 `disabled` 조건 완화(기존 `isShooting` 잠금 해제).
- **수동 모드**: 셔터 1탭=1장(총 8장) 유지. 첫 셔터 더블탭이 세션을 두 번 리셋해 첫 장을 날리던
  잠재 버그를 동기 ref(`isShootingRef`) 가드로 차단(`useCaptureFlow.ts`).
- 자동 8장 · 타이머 3/5/8초 · 시작 후 모드/간격 잠금은 그대로.

## 검증

- 모바일 `tsc --noEmit` 통과
- 웹 `tsc --noEmit` 0건(생성물 `.next` 제외) · `jest` 23 suites / 74 tests 통과
- 웹·모바일 변경 파일 eslint 통과
- 다관점 적대 리뷰(경쟁상태/스펙/위생) 후 확정 결함 반영, 오탐 기각

## 스펙(확정)

1. 촬영 중 카메라 = 고른 프레임의 현재 슬롯 크기/위치에 맞춰 표시(슬롯 합성 뷰 유지)
2. 타이머: 시작 전 간격(3/5/8초) 선택 → 자동 8장 연속, 카운트다운 중 셔터 탭=즉시 촬영
3. 수동: 셔터 1탭=1장, 총 8장
