### PR TITLE
feat: 온보딩 로그인 우선 + 브랜드 카피 '오늘'→'하루'

### DIFF
--- a/apps/mobile/screens/app-screens.tsx
+++ b/apps/mobile/screens/app-screens.tsx
@@ -375,7 +375,7 @@ export function HomeScreen() {
 
       <View style={styles.greetingBlock}>
         <Text style={styles.dateEyebrow}>{todayMoment}</Text>
-        <Text style={styles.greetingTitle}>{user.username}님, 오늘은</Text>
+        <Text style={styles.greetingTitle}>{user.username}님, 하루는</Text>
         <Text style={styles.greetingAccent}>어떤 네 컷일까요?</Text>
       </View>
 

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -260,24 +260,18 @@ export function LandingScreen() {
       <View style={styles.onboardingFooter}>
         <View style={styles.onboardingTitleStack}>
           <Text style={styles.onboardingTitle}>어디서든,</Text>
-          <Text style={styles.onboardingTitleAccent}>오늘의 네 컷</Text>
+          <Text style={styles.onboardingTitleAccent}>하루를 촬영해요</Text>
         </View>
-        <Text style={styles.onboardingBody}>특별한 하루를{'\n'}사진으로 남겨보세요.</Text>
+        <Text style={styles.onboardingBody}>특별한 하루를 사진으로 남겨보세요.</Text>
 
-        <ActionButton label="시작하기" onPress={() => push('/signup')} />
+        {/* 로그인 우선. 회원가입은 로그인 화면에서 유도하고, 비회원은 체험하기로 바로 촬영. */}
+        <ActionButton label="로그인" onPress={() => push('/login')} />
         <ActionButton
-          label="이미 계정이 있어요"
-          onPress={() => push('/login')}
+          label="체험하기"
+          onPress={showGuestTrialNotice}
           style={{ marginTop: 10 }}
           variant="ghost"
         />
-        <Pressable
-          accessibilityLabel="로그인 없이 바로 촬영해보기"
-          accessibilityRole="button"
-          onPress={showGuestTrialNotice}
-          style={{ marginTop: 16 }}>
-          <Text style={styles.onboardingGuestLink}>로그인 없이 바로 촬영해보기 →</Text>
-        </Pressable>
       </View>
     </View>
   );
@@ -341,7 +335,7 @@ export function LoginScreen() {
 
   return (
     <AuthShell
-      description="로그인하고 오늘의 네 컷을 이어가요."
+      description="로그인하고 하루의 네 컷을 이어가요."
       footer={
         <>
           <SocialButtons />
@@ -1020,12 +1014,6 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       lineHeight: 23,
       marginBottom: 26,
       marginTop: 12,
-    },
-    onboardingGuestLink: {
-      color: colors.muted,
-      fontSize: 13.5,
-      fontWeight: '600',
-      textAlign: 'center',
     },
     rememberRow: {
       alignItems: 'center',

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -224,13 +224,13 @@ export default function HomePage() {
           </span>
           {/* 데스크톱(lg+): handoff web 카피 */}
           <h1 className="mt-3 hidden text-[34px] font-extrabold leading-[1.15] tracking-tight lg:block">
-            {greetingName}오늘은
+            {greetingName}하루는
             <br />
             어떻게 남겨볼까요?
           </h1>
           {/* 모바일(&lt;lg): handoff app 카피 ("어떤 네 컷"만 그린) */}
           <h1 className="mt-2 text-[25px] font-extrabold leading-[1.25] tracking-tight lg:hidden">
-            {greetingName}오늘은
+            {greetingName}하루는
             <br />
             <span className="text-[color:var(--hc-primary)]">어떤 네 컷</span>
             일까요?

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -9,7 +9,7 @@ import { ExternalBrowserGate } from "./ExternalBrowserGate";
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.harucut.com"),
   title: "하루컷",
-  description: "오늘의 인생 네컷을 기록하는 사진 서비스",
+  description: "하루의 인생 네컷을 기록하는 사진 서비스",
   manifest: "/site.webmanifest",
   icons: {
     icon: [
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     apple: "/apple-touch-icon.png",
   },
   openGraph: {
-    title: "하루컷 — 오늘 하루를 네 컷으로",
+    title: "하루컷 — 하루를 네 컷으로",
     description: "찍고, 꾸미고, 기록하는 나만의 인생네컷. 하루컷.",
     images: ["/og-image.png"],
     type: "website",

--- a/apps/web/components/auth/AuthPageShell.tsx
+++ b/apps/web/components/auth/AuthPageShell.tsx
@@ -61,7 +61,7 @@ export function AuthPageShell({ title, description, children, footer, icon }: Pr
         </div>
         <div className="relative z-10 mt-auto">
           <p className="text-[34px] font-extrabold leading-[1.2] tracking-[-1px] text-white">
-            오늘 하루를
+            하루를
             <br />네 컷으로.
           </p>
           <p className="mt-3.5 max-w-[300px] text-[15px] leading-[1.6] text-white/60">

--- a/apps/web/components/landing/LandingView.tsx
+++ b/apps/web/components/landing/LandingView.tsx
@@ -185,7 +185,7 @@ export function LandingView() {
           <h1 className="mt-2 text-[40px] font-extrabold leading-[1.12] tracking-[-2px] sm:text-[58px]">
             어디서든,
             <br />
-            <span style={{ color: GREEN }}>오늘의 네&nbsp;컷</span>
+            <span style={{ color: GREEN }}>하루를 촬영해요</span>
           </h1>
           <p className="mb-7 mt-5 max-w-[430px] text-[17px] leading-[1.65] text-[#B3B3B3]">
             특별한 하루를 사진으로 남겨보세요.
@@ -300,7 +300,7 @@ export function LandingView() {
             FRAMES · 프레임
           </span>
           <h2 className="mt-3 text-[38px] font-extrabold tracking-[-1.2px]">
-            오늘의 기분대로, <span style={{ color: GREEN }}>네 가지 프레임</span>
+            하루의 기분대로, <span style={{ color: GREEN }}>네 가지 프레임</span>
           </h2>
         </div>
         <div className="flex flex-wrap items-end justify-center gap-9">
@@ -465,7 +465,7 @@ export function LandingView() {
           style={{ background: GREEN }}
         >
           <h2 className="text-[30px] font-extrabold tracking-[-1px]" style={{ color: "#06140A" }}>
-            오늘 하루, 네 컷으로 남겨볼까요?
+            하루를 네 컷으로 남겨볼까요?
           </h2>
           <Link
             href="/signup"
@@ -484,7 +484,7 @@ export function LandingView() {
             <p className="mt-3.5 text-[13px] leading-[1.6] text-[#6F6F73]">
               온라인 인생네컷 서비스.
               <br />
-              오늘 하루를 네 컷으로 남기세요.
+              하루를 네 컷으로 남기세요.
             </p>
           </div>
           <div className="flex flex-wrap gap-14">


### PR DESCRIPTION
## 무엇을
앱 온보딩을 로그인 우선 흐름으로 바꾸고, 하루컷 브랜드 보이스에 맞춰 '오늘' 표현을 '하루'로 통일.

## 변경
### 온보딩(모바일)
- CTA: '시작하기'(→회원가입) + '이미 계정이 있어요'(→로그인) → **'로그인'**(→로그인) + **'체험하기'**(게스트 체험).
- 회원가입은 로그인 화면의 기존 '회원가입' 링크로 유도(로그인 우선 + signup nested).
- 타이틀 '오늘의 네 컷' → **'하루를 촬영해요'**, 본문 한 줄로. 미사용 스타일 제거.

### 브랜드 카피 '오늘'→'하루' (웹·앱)
- 모바일: 홈 그리팅('님, 하루는'), 로그인 설명('하루의 네 컷을 이어가요').
- 웹: 랜딩 히어로('하루를 촬영해요')·프레임 섹션·하단 CTA/푸터, AuthPageShell, layout 메타데이터(description/OG).
- **유지**: 기능성 일일 쿼터 메시지 '오늘 영상 변환 가능 횟수'(매일 리셋 의미라 '오늘'이 정확).

## 참고
온보딩 흐름/일부 카피는 handoff와 의도적으로 달라짐(사용자 지시: 로그인 우선 + '하루' 보이스).

## 검증
- 웹 `tsc` 0건 · 모바일 `tsc` 통과 · 웹 `jest` 74 통과 · eslint 0 errors
