### PR TITLE
feat: 게스트 체험 CTA '무료로 체험하기' 통일 + 안내 바텀시트·온보딩 정렬 정리

### DIFF
--- a/apps/mobile/components/harucut/global-notice.tsx
+++ b/apps/mobile/components/harucut/global-notice.tsx
@@ -52,29 +52,35 @@ export function GlobalNotice() {
   };
 
   return (
-    <Modal animationType="fade" transparent visible>
+    <Modal
+      animationType="slide"
+      transparent
+      visible
+      statusBarTranslucent
+      onRequestClose={clearNotice}>
       <View style={styles.backdrop}>
         <Pressable onPress={clearNotice} style={StyleSheet.absoluteFill} />
-        <View style={[styles.sheetWrap, { paddingBottom: Math.max(insets.bottom, 24) }]}>
-          <View style={styles.sheet}>
+        <View style={[styles.sheet, { paddingBottom: Math.max(insets.bottom, 16) + 12 }]}>
+          <View style={styles.grabber} />
+          {notice.icon ? (
             <View style={styles.iconWrap}>
               <Ionicons color={colors.primaryStrong} name={notice.icon as any} size={24} />
             </View>
-            {notice.eyebrow ? <Pill>{notice.eyebrow}</Pill> : null}
-            <View style={{ gap: 8 }}>
-              <Text style={styles.title}>{notice.title}</Text>
-              <Text style={styles.message}>{notice.message}</Text>
-            </View>
-            <View style={styles.buttonColumn}>
-              {notice.actions.map((action) => (
-                <ActionButton
-                  key={action.id}
-                  label={action.label}
-                  onPress={() => handleAction(action.id)}
-                  variant={action.variant ?? 'primary'}
-                />
-              ))}
-            </View>
+          ) : null}
+          {notice.eyebrow ? <Pill>{notice.eyebrow}</Pill> : null}
+          <View style={{ gap: 8 }}>
+            <Text style={styles.title}>{notice.title}</Text>
+            <Text style={styles.message}>{notice.message}</Text>
+          </View>
+          <View style={styles.buttonColumn}>
+            {notice.actions.map((action) => (
+              <ActionButton
+                key={action.id}
+                label={action.label}
+                onPress={() => handleAction(action.id)}
+                variant={action.variant ?? 'primary'}
+              />
+            ))}
           </View>
         </View>
       </View>
@@ -92,6 +98,14 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     buttonColumn: {
       gap: 10,
       marginTop: 4,
+    },
+    grabber: {
+      alignSelf: 'center',
+      backgroundColor: colors.border,
+      borderRadius: 999,
+      height: 5,
+      marginBottom: 4,
+      width: 44,
     },
     iconWrap: {
       alignItems: 'center',
@@ -111,18 +125,16 @@ function createStyles(colors: HarucutColors, isDark: boolean) {
     sheet: {
       backgroundColor: colors.cardStrong,
       borderColor: colors.border,
-      borderRadius: 30,
-      borderWidth: 1,
+      borderTopLeftRadius: 28,
+      borderTopRightRadius: 28,
+      borderTopWidth: 1,
       gap: 14,
-      padding: 20,
+      paddingHorizontal: 20,
+      paddingTop: 12,
       shadowColor: colors.shadow,
-      shadowOffset: { height: 20, width: 0 },
+      shadowOffset: { height: -6, width: 0 },
       shadowOpacity: isDark ? 0.34 : 1,
-      shadowRadius: 32,
-    },
-    sheetWrap: {
-      paddingHorizontal: 16,
-      paddingTop: 24,
+      shadowRadius: 30,
     },
     title: {
       color: colors.text,

--- a/apps/mobile/components/harucut/global-theme-toggle.tsx
+++ b/apps/mobile/components/harucut/global-theme-toggle.tsx
@@ -1,7 +1,7 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { usePathname } from 'expo-router';
 import * as React from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { BackHandler, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type {
@@ -76,6 +76,18 @@ export function GlobalThemeToggle() {
   React.useEffect(() => {
     setOpen(false);
   }, [pathname]);
+
+  // 메뉴가 열려 있으면 안드로이드 뒤로가기로 화면을 떠나지 말고 메뉴만 닫는다.
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      setOpen(false);
+      return true;
+    });
+    return () => subscription.remove();
+  }, [open]);
 
   return (
     <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>

--- a/apps/mobile/screens/public-screens.tsx
+++ b/apps/mobile/screens/public-screens.tsx
@@ -274,7 +274,7 @@ export function LandingScreen() {
         {/* 로그인 우선. 회원가입은 로그인 화면에서 유도하고, 비회원은 체험하기로 바로 촬영. */}
         <ActionButton label="로그인" onPress={() => push('/login')} />
         <ActionButton
-          label="체험하기"
+          label="무료로 체험하기"
           onPress={showGuestTrialNotice}
           style={{ marginTop: 10 }}
           variant="ghost"
@@ -949,13 +949,11 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       zIndex: 2,
     },
     onboardingFrames: {
-      alignItems: 'flex-start',
+      // 헤더와 푸터 사이 남는 공간을 채우고 그 중앙에 프레임을 띄운다(absolute top 고정 → flex 중앙정렬).
+      alignItems: 'center',
+      flex: 1,
       flexDirection: 'row',
       justifyContent: 'center',
-      left: 0,
-      position: 'absolute',
-      right: 0,
-      top: 74,
       zIndex: 1,
     },
     onboardingFrameImage: {
@@ -1013,7 +1011,6 @@ function createStyles(colors: HarucutThemeColors, isDark: boolean) {
       zIndex: 2,
     },
     onboardingFooter: {
-      marginTop: 'auto',
       paddingBottom: 30,
       paddingHorizontal: 26,
       paddingTop: 60,

--- a/apps/mobile/store/use-session-store.ts
+++ b/apps/mobile/store/use-session-store.ts
@@ -114,14 +114,12 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     set({
       notice: {
         actions: [
-          { id: 'start-guest-trial', label: '촬영 체험 시작' },
+          { id: 'start-guest-trial', label: '무료로 체험 시작' },
           { id: 'go-login', label: '로그인하기', variant: 'secondary' },
         ],
-        eyebrow: 'TRY HARUCUT',
-        icon: 'camera-outline',
         message:
-          '비회원 체험에서는 촬영과 이미지 다운로드만 가능합니다. 링크 공유나, 추가 기능들은 로그인 후에 사용할 수 있어요!',
-        title: '비회원 체험을 시작할까요?',
+          '가입 없이 촬영·꾸미기를 바로 체험할 수 있어요. 저장·영상·기록 보관은 무료 가입 후 이용할 수 있어요.',
+        title: '무료로 체험해볼까요?',
       },
     }),
   showNotice: (notice) => set({ notice }),

--- a/apps/web/components/guest/GuestTrialOverlay.tsx
+++ b/apps/web/components/guest/GuestTrialOverlay.tsx
@@ -77,7 +77,7 @@ export function GuestTrialOverlay() {
         </button>
 
         <div className="flex flex-col gap-4">
-          <NoticeIcon icon={notice.icon} />
+          {notice.icon ? <NoticeIcon icon={notice.icon} /> : null}
           {notice.eyebrow ? (
             <span className="hc-accent-chip inline-flex w-fit rounded-full border px-3 py-1 text-[11px] font-medium">
               {notice.eyebrow}

--- a/apps/web/components/guest/GuestTrialStartButton.tsx
+++ b/apps/web/components/guest/GuestTrialStartButton.tsx
@@ -21,7 +21,7 @@ export function GuestTrialStartButton({
       onClick={showGuestTrialNotice}
       className={className ?? DEFAULT_CLASS}
     >
-      {children ?? "체험하기"}
+      {children ?? "무료로 체험하기"}
     </button>
   );
 }

--- a/apps/web/components/landing/LandingView.tsx
+++ b/apps/web/components/landing/LandingView.tsx
@@ -205,7 +205,7 @@ export function LandingView() {
               무료로 시작하기
             </Link>
             <GuestTrialStartButton className="flex w-full items-center justify-center rounded-full border border-white/20 px-6 py-3.5 text-[16px] font-bold text-white transition-colors hover:border-white">
-              체험하기
+              무료로 체험하기
             </GuestTrialStartButton>
           </div>
           {/* 데스크톱: 기존 마케팅 CTA(무료로 시작하기 우선) */}
@@ -218,7 +218,7 @@ export function LandingView() {
               무료로 시작하기 <ArrowRight className="h-[19px] w-[19px]" />
             </Link>
             <GuestTrialStartButton className="inline-flex items-center rounded-full border border-white/20 px-6 py-3.5 text-[16px] font-bold text-white transition-colors hover:border-white">
-              체험하기
+              무료로 체험하기
             </GuestTrialStartButton>
           </div>
         </div>

--- a/apps/web/lib/guestTrialStore.ts
+++ b/apps/web/lib/guestTrialStore.ts
@@ -130,14 +130,12 @@ export const useGuestTrialStore = create<GuestTrialStore>((set) => ({
     set({
       notice: {
         actions: [
-          { id: "start-guest-trial", label: "촬영 체험 시작" },
+          { id: "start-guest-trial", label: "무료로 체험 시작" },
           { id: "go-login", label: "로그인하기", variant: "secondary" },
         ],
-        eyebrow: "TRY HARUCUT",
-        icon: "camera",
         message:
-          "비회원 체험에서는 촬영과 이미지 다운로드만 가능합니다. 링크 공유나, 추가 기능들은 로그인 후에 사용할 수 있어요!",
-        title: "비회원 체험을 시작할까요?",
+          "가입 없이 촬영·꾸미기를 바로 체험할 수 있어요. 저장·영상·기록 보관은 무료 가입 후 이용할 수 있어요.",
+        title: "무료로 체험해볼까요?",
       },
     }),
 }));

--- a/apps/web/tests/e2e/home.spec.ts
+++ b/apps/web/tests/e2e/home.spec.ts
@@ -7,5 +7,5 @@ test("landing page renders the public entry links", async ({ page }) => {
   await expect(page.locator("main")).toBeVisible();
   await expect(page.getByRole("link", { name: "로그인" })).toBeVisible();
   await expect(page.getByRole("link", { name: "회원가입" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "체험하기" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "무료로 체험하기" })).toBeVisible();
 });


### PR DESCRIPTION
## 요약

랜딩과 온보딩의 비회원 체험 동선을 정리하고, 모바일 안내 모달을 바텀시트로 다듬은 변경입니다. 웹과 앱 양쪽에서 체험 진입 버튼 문구를 "무료로 체험하기"로 통일했습니다.

## 변경 내용

### 웹
- 랜딩 히어로의 비회원 체험 CTA 문구를 "체험하기"에서 "무료로 체험하기"로 바꿨습니다. 모바일과 데스크톱 레이아웃 모두에 적용되도록 GuestTrialStartButton의 기본 라벨과 LandingView의 두 버튼에 반영했습니다.
- 게스트 체험 안내(guestTrialStore)의 문구를 다듬었습니다. 제목을 "무료로 체험해볼까요?"로 바꾸고, 가입 없이 촬영과 꾸미기를 바로 체험할 수 있으며 저장, 영상, 기록 보관은 무료 가입 후 이용할 수 있다는 내용으로 메시지를 교체했습니다. 시작 버튼 라벨은 "무료로 체험 시작"으로 바꿨습니다.
- 안내에서 eyebrow와 icon을 더 이상 사용하지 않으므로, GuestTrialOverlay가 icon이 없을 때는 NoticeIcon을 렌더링하지 않도록 조건 가드를 추가했습니다.
- 버튼 문구 변경에 맞춰 home.spec.ts e2e 테스트의 기대 텍스트를 "무료로 체험하기"로 업데이트했습니다.

### 앱(모바일)
- 비회원 안내 모달(global-notice)을 화면 가운데 카드에서 하단 바텀시트로 바꿨습니다. 슬라이드 애니메이션, 상단 그래버 핸들, 상단만 둥근 모서리, onRequestClose를 적용했고 icon이 없을 때는 아이콘 영역을 렌더링하지 않습니다.
- 글로벌 테마/메뉴 토글이 열려 있을 때 안드로이드 하드웨어 뒤로가기를 누르면 화면을 떠나지 않고 메뉴만 닫히도록 BackHandler를 연결했습니다.
- 온보딩 히어로 프레임을 absolute top 고정 방식에서 flex 중앙 정렬로 바꿔, 헤더와 푸터 사이 남는 공간의 한가운데에 프레임이 놓이도록 했습니다. 이에 맞춰 푸터의 marginTop auto도 정리했습니다.
- 랜딩 체험 CTA 문구와 세션 스토어의 게스트 안내 문구를 웹과 동일하게 "무료로 체험하기", "무료로 체험해볼까요?"로 맞췄습니다.

## 테스트
- 변경된 e2e 기대값은 CI(verify)의 웹 jest와 build 단계에서 검증됩니다.
- 모바일은 lint와 typecheck로 검증됩니다. icon과 eyebrow는 기존에도 선택값으로 쓰이고 있어 타입 검증에 영향이 없습니다.
